### PR TITLE
claude/fix-docker-networking-Lnvbl

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ DD_REPORT_THRESHOLD_MAJOR=500
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Docker
+# Host port to publish the container on. Change this if 3000 is already
+# in use on the host (e.g. APP_PORT=3100 to expose at http://localhost:3100).
+APP_PORT=3000

--- a/README.md
+++ b/README.md
@@ -101,6 +101,28 @@ The SQLite database is persisted in the named volume `outage-map-data`
 creating a `.env` file next to `docker-compose.yml` (the compose file reads
 the same variables as `.env.example`).
 
+### Changing the host port
+
+The container listens on port `3000` internally and is published on the
+host via `${APP_PORT:-3000}:3000`. If you see an error like:
+
+```
+Bind for 0.0.0.0:3000 failed: port is already allocated
+```
+
+another process (or another container) is already bound to host port
+`3000`. Pick a free port and set `APP_PORT` before redeploying:
+
+```bash
+# .env (next to docker-compose.yml)
+APP_PORT=3100
+```
+
+Then `docker compose up -d` again, or in Portainer set `APP_PORT=3100`
+under the stack's environment variables and redeploy. The dashboard will
+be reachable at `http://<host>:3100`. To find what's holding port 3000,
+run `docker ps --filter "publish=3000"` or `sudo lsof -i :3000`.
+
 ## Deploying with Portainer
 
 The stack can be deployed as a Portainer Stack in one of two ways:


### PR DESCRIPTION
Surface APP_PORT in .env.example and document the host-port remap in the
Docker section of the README so users hitting "Bind for 0.0.0.0:3000
failed: port is already allocated" know how to resolve it without
editing docker-compose.yml.