### PR TITLE
Add incident tracking and brand font support to status dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "outage-map-temp",
-  "version": "0.1.0",
+  "name": "outage-map",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "outage-map-temp",
-      "version": "0.1.0",
+      "name": "outage-map",
+      "version": "1.0.0",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "cheerio": "^1.2.0",

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -16,9 +16,9 @@ function statusToMinutes(status: ServiceStatus): number {
 }
 
 function aggregateByDay(
-  rows: Array<{ service_slug: string; status: string; report_count: number; recorded_at: string }>
+  rows: Array<{ service_slug: string; status: string; report_count: number; incident_count: number; recorded_at: string }>
 ): Record<string, HistoryPoint[]> {
-  const byService: Record<string, Map<string, { statuses: string[]; reports: number[]; outageMinutes: number }>> = {};
+  const byService: Record<string, Map<string, { statuses: string[]; reports: number[]; incidents: number[]; outageMinutes: number }>> = {};
 
   for (const row of rows) {
     if (!byService[row.service_slug]) {
@@ -29,11 +29,13 @@ function aggregateByDay(
     const dayData = byService[row.service_slug].get(date) || {
       statuses: [],
       reports: [],
+      incidents: [],
       outageMinutes: 0,
     };
 
     dayData.statuses.push(row.status);
     dayData.reports.push(row.report_count || 0);
+    dayData.incidents.push(row.incident_count || 0);
     dayData.outageMinutes += statusToMinutes(row.status as ServiceStatus);
 
     byService[row.service_slug].set(date, dayData);
@@ -60,6 +62,7 @@ function aggregateByDay(
           date,
           status: worstStatus,
           reports: Math.max(...data.reports),
+          incidents: Math.max(...data.incidents, 0),
           outageMinutes: data.outageMinutes,
         };
       });

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -44,6 +44,9 @@ export async function GET() {
         overallStatus: deriveOverallStatus(officialStatus, ddStatus),
         details: official?.details || null,
         lastChecked: official?.checked_at || dd?.checked_at || null,
+        statusUrl: service.statusUrl,
+        downdetectorUrl: `https://downdetector.com/status/${service.downdetectorSlug}/`,
+        brandFont: service.brandFont,
       };
     });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import { Inter, Roboto, Source_Sans_3, Lato } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import AppShell from "@/components/AppShell";
@@ -13,6 +14,30 @@ const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
   variable: "--font-geist-mono",
   weight: "100 900",
+});
+
+// Brand-approximation fonts applied per service (see src/lib/services.ts)
+const brandInter = Inter({
+  subsets: ["latin"],
+  variable: "--font-brand-inter",
+  display: "swap",
+});
+const brandRoboto = Roboto({
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  variable: "--font-brand-roboto",
+  display: "swap",
+});
+const brandSourceSans = Source_Sans_3({
+  subsets: ["latin"],
+  variable: "--font-brand-source-sans",
+  display: "swap",
+});
+const brandLato = Lato({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  variable: "--font-brand-lato",
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -40,7 +65,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${brandInter.variable} ${brandRoboto.variable} ${brandSourceSans.variable} ${brandLato.variable} antialiased`}
       >
         <ThemeProvider>
           <AppShell>{children}</AppShell>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -79,7 +79,7 @@ export default function Dashboard() {
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
             </svg>
           </div>
-          <h2 className="text-lg font-bold text-foreground mb-1">Unable to load dashboard</h2>
+          <h2 className="text-lg font-semibold tracking-tight text-foreground mb-1">Unable to load dashboard</h2>
           <p className="text-gray-400 text-sm mb-4">
             Could not fetch service statuses. The polling service may not have run yet.
           </p>
@@ -159,7 +159,7 @@ export default function Dashboard() {
 
       <section>
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
-          <h2 className="text-base font-semibold text-foreground flex items-center gap-2">
+          <h2 className="text-base font-semibold tracking-tight text-foreground flex items-center gap-2">
             <span className="w-1 h-5 rounded-full bg-accent-cyan" />
             Service Status
           </h2>
@@ -209,7 +209,7 @@ export default function Dashboard() {
 
       <section className="grid grid-cols-1 xl:grid-cols-3 gap-6">
         <div className="xl:col-span-2 space-y-4">
-          <h2 className="text-base font-semibold text-foreground flex items-center gap-2">
+          <h2 className="text-base font-semibold tracking-tight text-foreground flex items-center gap-2">
             <span className="w-1 h-5 rounded-full bg-purple-400" />
             30-Day Outage History
           </h2>

--- a/src/components/OutageChart.tsx
+++ b/src/components/OutageChart.tsx
@@ -35,6 +35,7 @@ function statusToColor(status: string): string {
 interface TooltipPayload {
   date: string;
   reports: number;
+  incidents: number;
   outageMinutes: number;
   status: string;
 }
@@ -49,7 +50,7 @@ function CustomTooltip({ active, payload, label }: {
 
   return (
     <div className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 shadow-xl">
-      <p className="text-xs text-gray-400 mb-1">{label}</p>
+      <p className="text-xs text-gray-300 mb-1">{label}</p>
       <div className="space-y-1">
         <div className="flex items-center gap-2">
           <span
@@ -60,11 +61,16 @@ function CustomTooltip({ active, payload, label }: {
             {data.status.replace('_', ' ')}
           </span>
         </div>
-        <p className="text-xs text-gray-300">
+        <p className="text-xs text-gray-200">
           Reports: <span className="text-white font-medium">{data.reports}</span>
         </p>
+        {data.incidents > 0 && (
+          <p className="text-xs text-gray-200">
+            Incidents: <span className="text-white font-medium">{data.incidents}</span>
+          </p>
+        )}
         {data.outageMinutes > 0 && (
-          <p className="text-xs text-gray-300">
+          <p className="text-xs text-gray-200">
             Outage: <span className="text-orange-400 font-medium">{data.outageMinutes}min</span>
           </p>
         )}
@@ -78,7 +84,7 @@ export default function OutageChart({ serviceName, serviceColor, data }: OutageC
     return (
       <div className="bg-gray-800/30 rounded-xl border border-gray-700/50 p-4">
         <h3 className="text-sm font-semibold text-white mb-3">{serviceName}</h3>
-        <div className="h-32 flex items-center justify-center text-gray-500 text-xs">
+        <div className="h-32 flex items-center justify-center text-gray-400 text-xs">
           No history data yet. Data will populate as the dashboard polls services.
         </div>
       </div>
@@ -91,49 +97,70 @@ export default function OutageChart({ serviceName, serviceColor, data }: OutageC
     fillColor: statusToColor(point.status),
   }));
 
+  const hasReports = chartData.some((p) => p.reports > 0);
+  const hasIncidents = chartData.some((p) => (p.incidents || 0) > 0);
+  const gradId = `grad-${serviceName.replace(/\s/g, '')}`;
+  const incidentGradId = `grad-incidents-${serviceName.replace(/\s/g, '')}`;
+
   return (
     <div className="bg-gray-800/30 rounded-xl border border-gray-700/50 p-4">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-semibold text-white flex items-center gap-2">
+        <h3 className="text-sm font-semibold text-white flex items-center gap-2 tracking-tight">
           <span
             className="w-3 h-3 rounded"
             style={{ backgroundColor: serviceColor }}
           />
           {serviceName}
         </h3>
-        <span className="text-xs text-gray-500">
+        <span className="text-xs text-gray-400">
           {data.length} days
         </span>
       </div>
       <ResponsiveContainer width="100%" height={140}>
         <AreaChart data={chartData} margin={{ top: 5, right: 5, bottom: 0, left: -20 }}>
           <defs>
-            <linearGradient id={`grad-${serviceName.replace(/\s/g, '')}`} x1="0" y1="0" x2="0" y2="1">
+            <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
               <stop offset="5%" stopColor={serviceColor} stopOpacity={0.3} />
               <stop offset="95%" stopColor={serviceColor} stopOpacity={0} />
+            </linearGradient>
+            <linearGradient id={incidentGradId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#f97316" stopOpacity={0.35} />
+              <stop offset="95%" stopColor="#f97316" stopOpacity={0} />
             </linearGradient>
           </defs>
           <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
           <XAxis
             dataKey="date"
-            tick={{ fill: '#6b7280', fontSize: 10 }}
-            axisLine={{ stroke: '#374151' }}
+            tick={{ fill: '#9ca3af', fontSize: 10 }}
+            axisLine={{ stroke: '#4b5563' }}
             tickLine={false}
             interval="preserveStartEnd"
           />
           <YAxis
-            tick={{ fill: '#6b7280', fontSize: 10 }}
-            axisLine={{ stroke: '#374151' }}
+            tick={{ fill: '#9ca3af', fontSize: 10 }}
+            axisLine={{ stroke: '#4b5563' }}
             tickLine={false}
           />
           <Tooltip content={<CustomTooltip />} />
+          {/* Always render the reports area, but draw the incidents area on top
+              so Zoom-style services (flat DD reports but real Statuspage incidents)
+              still show activity. */}
           <Area
             type="monotone"
             dataKey="reports"
-            stroke={serviceColor}
+            stroke={hasReports ? serviceColor : 'transparent'}
             strokeWidth={2}
-            fill={`url(#grad-${serviceName.replace(/\s/g, '')})`}
+            fill={`url(#${gradId})`}
           />
+          {hasIncidents && (
+            <Area
+              type="monotone"
+              dataKey="incidents"
+              stroke="#f97316"
+              strokeWidth={1.5}
+              fill={`url(#${incidentGradId})`}
+            />
+          )}
         </AreaChart>
       </ResponsiveContainer>
     </div>

--- a/src/components/OutageMapView.tsx
+++ b/src/components/OutageMapView.tsx
@@ -128,10 +128,10 @@ export default function OutageMapView() {
             <h2 className="text-sm font-semibold text-foreground">Report density by region</h2>
             <p className="text-xs text-gray-500 mt-0.5">Larger dots · redder tint = more reports</p>
           </div>
-          <div className="flex items-center gap-1 bg-white/5 rounded-md p-0.5 overflow-x-auto">
+          <div className="inline-flex items-center gap-1 bg-white/5 rounded-full p-1 overflow-x-auto">
             <button
               onClick={() => setSelectedService('all')}
-              className={`px-3 py-1 text-xs rounded whitespace-nowrap ${
+              className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-full whitespace-nowrap transition-colors ${
                 selectedService === 'all'
                   ? 'bg-accent-soft text-foreground'
                   : 'text-gray-400 hover:text-foreground'
@@ -143,7 +143,7 @@ export default function OutageMapView() {
               <button
                 key={s.slug}
                 onClick={() => setSelectedService(s.slug)}
-                className={`inline-flex items-center gap-1.5 px-3 py-1 text-xs rounded whitespace-nowrap ${
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-full whitespace-nowrap transition-colors ${
                   selectedService === s.slug
                     ? 'bg-accent-soft text-foreground'
                     : 'text-gray-400 hover:text-foreground'
@@ -165,6 +165,10 @@ export default function OutageMapView() {
               </radialGradient>
             </defs>
 
+            {/* TODO(outage-map#7 follow-up): Replace these amorphous continent
+                outlines with TopoJSON-backed country shapes (react-simple-maps or
+                similar), and add a separate "North America" tab with US regional
+                granularity (East/West/Central/South). Tracked as a follow-up. */}
             <g opacity="0.35" fill="none" stroke="rgba(148,163,184,0.35)" strokeWidth="1">
               {/* Simplified continent paths */}
               <path d="M80 130 Q120 90 180 100 Q240 90 280 130 L300 180 Q260 220 200 230 Q150 230 100 200 Z" />

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -62,7 +62,12 @@ export default function ServiceCard({ service, onClick, href }: ServiceCardProps
             {icon}
           </div>
           <div>
-            <h3 className="text-foreground font-semibold text-sm leading-tight">{service.name}</h3>
+            <h3
+              className="text-foreground font-semibold text-sm leading-tight tracking-tight"
+              style={{ fontFamily: service.brandFont }}
+            >
+              {service.name}
+            </h3>
             <p className="text-gray-500 text-[11px] mt-0.5">
               {formatTimestamp(service.lastChecked)}
             </p>
@@ -97,9 +102,14 @@ export default function ServiceCard({ service, onClick, href }: ServiceCardProps
           <span className={
             service.downdetectorReports >= 500 ? 'text-red-400 font-semibold' :
             service.downdetectorReports >= 100 ? 'text-yellow-400' :
+            service.downdetectorStatus === 'unknown' ? 'text-gray-500 italic' :
             'text-gray-300'
           }>
-            {service.downdetectorReports > 0 ? service.downdetectorReports.toLocaleString() : '--'}
+            {service.downdetectorStatus === 'unknown'
+              ? 'no data'
+              : service.downdetectorReports > 0
+                ? service.downdetectorReports.toLocaleString()
+                : '--'}
           </span>
         </div>
       </div>
@@ -109,6 +119,29 @@ export default function ServiceCard({ service, onClick, href }: ServiceCardProps
           {service.details}
         </p>
       )}
+
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="mt-3 pt-2 border-t border-subtle flex items-center gap-3 text-[10px]"
+      >
+        <a
+          href={service.statusUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent-cyan hover:underline"
+        >
+          Official ↗
+        </a>
+        <span className="text-gray-700">·</span>
+        <a
+          href={service.downdetectorUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent-cyan hover:underline"
+        >
+          {service.downdetectorStatus === 'unknown' ? 'Open Downdetector ↗' : 'Downdetector ↗'}
+        </a>
+      </div>
     </div>
   );
 

--- a/src/components/ServiceDetailModal.tsx
+++ b/src/components/ServiceDetailModal.tsx
@@ -43,7 +43,12 @@ export default function ServiceDetailModal({
               {service.name.charAt(0)}
             </div>
             <div>
-              <h2 className="text-lg font-bold text-white">{service.name}</h2>
+              <h2
+                className="text-lg font-semibold text-white tracking-tight"
+                style={{ fontFamily: service.brandFont }}
+              >
+                {service.name}
+              </h2>
               <StatusBadge status={service.overallStatus} size="sm" />
             </div>
           </div>
@@ -66,15 +71,33 @@ export default function ServiceDetailModal({
               {service.details && (
                 <p className="text-xs text-gray-400 mt-2">{service.details}</p>
               )}
+              <a
+                href={service.statusUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-accent-cyan hover:underline mt-2 inline-block"
+              >
+                View official source ↗
+              </a>
             </div>
             <div className="bg-gray-800/50 rounded-lg p-4">
               <p className="text-xs text-gray-500 mb-1">Downdetector</p>
               <StatusBadge status={service.downdetectorStatus} size="sm" />
               <p className="text-xs text-gray-400 mt-2">
-                {service.downdetectorReports > 0
-                  ? `${service.downdetectorReports.toLocaleString()} reports`
-                  : 'No data available'}
+                {service.downdetectorStatus === 'unknown'
+                  ? 'No data — open Downdetector directly'
+                  : service.downdetectorReports > 0
+                    ? `${service.downdetectorReports.toLocaleString()} reports`
+                    : 'No reports'}
               </p>
+              <a
+                href={service.downdetectorUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-accent-cyan hover:underline mt-2 inline-block"
+              >
+                {service.downdetectorStatus === 'unknown' ? 'Open Downdetector' : 'View on Downdetector'} ↗
+              </a>
             </div>
           </div>
 

--- a/src/components/ServiceDetailView.tsx
+++ b/src/components/ServiceDetailView.tsx
@@ -100,7 +100,12 @@ export default function ServiceDetailView({ slug }: Props) {
               <p className="text-[11px] uppercase tracking-widest text-gray-500 mb-1">
                 {config.fetcher} · {config.slug}
               </p>
-              <h1 className="text-3xl font-bold text-foreground tracking-tight">{config.name}</h1>
+              <h1
+                className="text-3xl font-semibold text-foreground tracking-tight"
+                style={{ fontFamily: config.brandFont }}
+              >
+                {config.name}
+              </h1>
               <div className="mt-3 flex items-center gap-3">
                 <StatusBadge status={heroStatus} size="md" />
                 {service?.details && (
@@ -109,17 +114,30 @@ export default function ServiceDetailView({ slug }: Props) {
               </div>
             </div>
           </div>
-          <a
-            href={config.statusUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-subtle text-xs text-foreground transition-colors"
-          >
-            Official status
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-            </svg>
-          </a>
+          <div className="flex items-center gap-2">
+            <a
+              href={config.statusUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-subtle text-xs text-foreground transition-colors"
+            >
+              Official status
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+              </svg>
+            </a>
+            <a
+              href={`https://downdetector.com/status/${config.downdetectorSlug}/`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-subtle text-xs text-foreground transition-colors"
+            >
+              Downdetector
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+              </svg>
+            </a>
+          </div>
         </div>
       </div>
 

--- a/src/components/ui/StatTile.tsx
+++ b/src/components/ui/StatTile.tsx
@@ -38,7 +38,7 @@ export default function StatTile({
         <div className="flex items-start justify-between gap-3">
           <div>
             <p className="text-xs font-medium text-gray-400 uppercase tracking-wider">{label}</p>
-            <p className="text-3xl font-bold mt-2 text-foreground tabular-nums">{value}</p>
+            <p className="text-3xl font-semibold tracking-tight mt-2 text-foreground tabular-nums">{value}</p>
           </div>
           {icon && (
             <div className="w-10 h-10 rounded-xl bg-white/5 flex items-center justify-center">

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -56,6 +56,7 @@ function initTables(db: Database.Database) {
       service_slug TEXT NOT NULL,
       status TEXT NOT NULL,
       report_count INTEGER DEFAULT 0,
+      incident_count INTEGER DEFAULT 0,
       recorded_at DATETIME NOT NULL DEFAULT (datetime('now'))
     );
 
@@ -70,6 +71,12 @@ function initTables(db: Database.Database) {
       sent_at DATETIME NOT NULL DEFAULT (datetime('now'))
     );
   `);
+
+  // Safe migration for pre-existing databases — add incident_count if missing.
+  const cols = db.prepare(`PRAGMA table_info(status_history)`).all() as Array<{ name: string }>;
+  if (!cols.some((c) => c.name === 'incident_count')) {
+    db.exec(`ALTER TABLE status_history ADD COLUMN incident_count INTEGER DEFAULT 0`);
+  }
 }
 
 export function upsertServiceStatus(
@@ -94,13 +101,14 @@ export function upsertServiceStatus(
 export function insertStatusHistory(
   serviceSlug: string,
   status: string,
-  reportCount: number
+  reportCount: number,
+  incidentCount: number = 0
 ) {
   const db = getDb();
   db.prepare(`
-    INSERT INTO status_history (service_slug, status, report_count, recorded_at)
-    VALUES (?, ?, ?, datetime('now'))
-  `).run(serviceSlug, status, reportCount);
+    INSERT INTO status_history (service_slug, status, report_count, incident_count, recorded_at)
+    VALUES (?, ?, ?, ?, datetime('now'))
+  `).run(serviceSlug, status, reportCount, incidentCount);
 }
 
 export function upsertIncident(
@@ -176,7 +184,7 @@ export function getStatusHistory(serviceSlug: string | null, days: number = 30) 
   const db = getDb();
   if (serviceSlug) {
     return db.prepare(`
-      SELECT service_slug, status, report_count, recorded_at
+      SELECT service_slug, status, report_count, incident_count, recorded_at
       FROM status_history
       WHERE service_slug = ? AND recorded_at >= datetime('now', '-' || ? || ' days')
       ORDER BY recorded_at ASC
@@ -184,11 +192,12 @@ export function getStatusHistory(serviceSlug: string | null, days: number = 30) 
       service_slug: string;
       status: string;
       report_count: number;
+      incident_count: number;
       recorded_at: string;
     }>;
   }
   return db.prepare(`
-    SELECT service_slug, status, report_count, recorded_at
+    SELECT service_slug, status, report_count, incident_count, recorded_at
     FROM status_history
     WHERE recorded_at >= datetime('now', '-' || ? || ' days')
     ORDER BY recorded_at ASC
@@ -196,6 +205,7 @@ export function getStatusHistory(serviceSlug: string | null, days: number = 30) 
     service_slug: string;
     status: string;
     report_count: number;
+    incident_count: number;
     recorded_at: string;
   }>;
 }

--- a/src/lib/fetchers/google.ts
+++ b/src/lib/fetchers/google.ts
@@ -44,6 +44,7 @@ export async function fetchGoogleStatus(serviceSlug: string): Promise<FetchResul
     // Google embeds status data in script tags as JSON
     let worstStatus: ServiceStatus = 'operational';
     const affectedServices: string[] = [];
+    let jsonBranchMatched = false;
 
     // Try to find embedded JSON data
     $('script').each((_, el) => {
@@ -54,6 +55,7 @@ export async function fetchGoogleStatus(serviceSlug: string): Promise<FetchResul
         try {
           const data = JSON.parse(jsonMatch[1]);
           if (Array.isArray(data?.services)) {
+            jsonBranchMatched = true;
             for (const service of data.services) {
               const name = service.name || '';
               const status = service.status || 1;
@@ -74,16 +76,24 @@ export async function fetchGoogleStatus(serviceSlug: string): Promise<FetchResul
       }
     });
 
-    // Fallback: parse HTML status indicators
-    if (worstStatus === 'operational') {
-      $('[class*="status"], .psi, [data-status]').each((_, el) => {
-        const text = $(el).text().trim().toLowerCase();
-        if (text.includes('disruption') || text.includes('outage')) {
+    // Fallback: parse HTML status indicators.
+    // Only run when the JSON branch didn't match — otherwise generic "disruption"
+    // text elsewhere on the page (e.g. "Report a disruption") can flip a green
+    // dashboard to major_outage. Scope the selector to actual service rows only,
+    // and require whole-word matches.
+    if (!jsonBranchMatched) {
+      const majorRe = /\b(service disruption|outage in progress|disrupted)\b/i;
+      const degradedRe = /\b(service information|minor issue|degraded performance)\b/i;
+
+      $('table.ps-table tr, .ps-service-row, [data-service-name]').each((_, el) => {
+        const text = $(el).text().trim();
+        const rowName = $(el).find('.name, td:first, [data-service-name]').first().text().trim();
+        if (majorRe.test(text)) {
           worstStatus = 'major_outage';
-          affectedServices.push($(el).closest('tr, .row').find('.name, td:first').text().trim());
-        } else if (text.includes('issue') || text.includes('degraded')) {
+          if (rowName) affectedServices.push(rowName);
+        } else if (degradedRe.test(text)) {
           if (worstStatus === 'operational') worstStatus = 'degraded';
-          affectedServices.push($(el).closest('tr, .row').find('.name, td:first').text().trim());
+          if (rowName) affectedServices.push(rowName);
         }
       });
     }

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -66,6 +66,7 @@ async function pollService(service: ServiceConfig): Promise<void> {
 
   // Process official status
   let officialStatus: StatusResult | null = null;
+  let activeIncidentCount = 0;
   if (officialResult.status === 'fulfilled') {
     officialStatus = officialResult.value.status;
     upsertServiceStatus(
@@ -78,6 +79,7 @@ async function pollService(service: ServiceConfig): Promise<void> {
 
     // Process incidents
     for (const incident of officialResult.value.incidents) {
+      if (!incident.resolvedAt) activeIncidentCount++;
       const { isNew } = upsertIncident(
         incident.serviceSlug,
         incident.incidentId,
@@ -100,6 +102,8 @@ async function pollService(service: ServiceConfig): Promise<void> {
     if (previousStatus && previousStatus !== officialStatus.status) {
       await sendStatusChangeAlert(service.slug, previousStatus, officialStatus.status);
     }
+  } else {
+    console.debug(`[poller] ${service.name} official fetch rejected:`, officialResult.reason);
   }
 
   // Process Downdetector
@@ -113,14 +117,20 @@ async function pollService(service: ServiceConfig): Promise<void> {
       ddStatus.details,
       ddStatus.reportCount
     );
+  } else {
+    console.debug(`[poller] ${service.name} downdetector fetch rejected:`, ddResult.reason);
   }
 
-  // Record history point
+  // Record history point — include active incident count so services whose
+  // Statuspage reports issues still show a non-empty history even when DD
+  // is disabled or returns zero reports.
   const effectiveStatus = officialStatus?.status || ddStatus?.status || 'unknown';
   const reportCount = ddStatus?.reportCount || 0;
-  insertStatusHistory(service.slug, effectiveStatus, reportCount);
+  insertStatusHistory(service.slug, effectiveStatus, reportCount, activeIncidentCount);
 
-  console.log(`[poller] ${service.name}: ${effectiveStatus} (DD: ${reportCount} reports)`);
+  console.log(
+    `[poller] ${service.name}: ${effectiveStatus} (DD: ${reportCount} reports, active incidents: ${activeIncidentCount})`
+  );
 }
 
 let isPolling = false;

--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -8,6 +8,7 @@ export const SERVICES: ServiceConfig[] = [
     statusUrl: 'https://status.office365.com',
     downdetectorSlug: 'office-365',
     fetcher: 'microsoft',
+    brandFont: 'var(--font-brand-inter), Inter, system-ui, sans-serif',
   },
   {
     name: 'Adobe Creative Cloud',
@@ -16,6 +17,7 @@ export const SERVICES: ServiceConfig[] = [
     statusUrl: 'https://status.adobe.com',
     downdetectorSlug: 'creative-cloud',
     fetcher: 'statuspage',
+    brandFont: 'var(--font-brand-source-sans), "Source Sans 3", system-ui, sans-serif',
   },
   {
     name: 'ServiceNow',
@@ -24,6 +26,7 @@ export const SERVICES: ServiceConfig[] = [
     statusUrl: 'https://status.servicenow.com',
     downdetectorSlug: 'servicenow',
     fetcher: 'statuspage',
+    brandFont: 'var(--font-brand-inter), Inter, system-ui, sans-serif',
   },
   {
     name: 'Salesforce',
@@ -32,6 +35,7 @@ export const SERVICES: ServiceConfig[] = [
     statusUrl: 'https://api.status.salesforce.com',
     downdetectorSlug: 'salesforce',
     fetcher: 'salesforce',
+    brandFont: 'var(--font-brand-inter), Inter, system-ui, sans-serif',
   },
   {
     name: 'Workday',
@@ -40,6 +44,7 @@ export const SERVICES: ServiceConfig[] = [
     statusUrl: 'https://status.workday.com',
     downdetectorSlug: 'workday',
     fetcher: 'workday',
+    brandFont: 'var(--font-brand-lato), Lato, system-ui, sans-serif',
   },
   {
     name: 'Zoom',
@@ -48,6 +53,7 @@ export const SERVICES: ServiceConfig[] = [
     statusUrl: 'https://status.zoom.us',
     downdetectorSlug: 'zoom',
     fetcher: 'statuspage',
+    brandFont: 'var(--font-brand-inter), Inter, system-ui, sans-serif',
   },
   {
     name: 'Google Workspace',
@@ -56,6 +62,7 @@ export const SERVICES: ServiceConfig[] = [
     statusUrl: 'https://www.google.com/appsstatus/dashboard/',
     downdetectorSlug: 'google',
     fetcher: 'google',
+    brandFont: 'var(--font-brand-roboto), Roboto, system-ui, sans-serif',
   },
 ];
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,7 @@ export interface ServiceConfig {
   statusUrl: string;
   downdetectorSlug: string;
   fetcher: FetcherType;
+  brandFont: string;
 }
 
 export interface StatusResult {
@@ -48,6 +49,9 @@ export interface ServiceStatusResponse {
   overallStatus: ServiceStatus;
   details: string | null;
   lastChecked: string | null;
+  statusUrl: string;
+  downdetectorUrl: string;
+  brandFont: string;
 }
 
 export interface IncidentResponse {
@@ -68,6 +72,7 @@ export interface HistoryPoint {
   date: string;
   status: ServiceStatus;
   reports: number;
+  incidents: number;
   outageMinutes: number;
 }
 


### PR DESCRIPTION
## Summary
This PR enhances the status dashboard with incident tracking visualization and per-service brand font support, improving both data accuracy and visual branding consistency.

## Key Changes

### Incident Tracking
- Added `incident_count` column to `status_history` table with safe migration for existing databases
- Track active (unresolved) incidents from official status pages alongside Downdetector reports
- Display incidents in outage charts with orange gradient visualization, allowing services with Statuspage incidents to show activity even when Downdetector reports are zero
- Updated chart tooltip to show incident count when present
- Modified poller to count and record active incidents during each poll cycle

### Brand Font Support
- Imported Google Fonts (Inter, Roboto, Source Sans 3, Lato) as CSS variables in layout
- Added `brandFont` property to all service configurations with font-family fallback chains
- Applied brand fonts to service names in:
  - Service cards
  - Service detail view
  - Service detail modal
- Fonts are applied inline via `style={{ fontFamily: service.brandFont }}` for per-service customization

### UI/UX Improvements
- Enhanced chart styling: improved axis label colors, better gradient definitions, and conditional stroke rendering
- Updated tooltip text colors for better contrast (gray-300 → gray-200/gray-300)
- Improved Downdetector status display with "no data" state and conditional messaging
- Added direct links to official status pages and Downdetector in service cards and modals
- Refined button styling in outage map view (rounded-full, better spacing)
- Better error handling in Google fetcher with scoped HTML parsing to avoid false positives

### Data & API Updates
- Updated `/api/history` endpoint to include `incidents` field in response
- Updated `/api/status` endpoint to include `statusUrl`, `downdetectorUrl`, and `brandFont` in service responses
- Enhanced logging in poller to show active incident counts

## Implementation Details
- Incidents are only counted when `resolvedAt` is null, ensuring only active incidents are tracked
- Chart rendering conditionally shows incident area only when incidents exist (`hasIncidents` flag)
- Safe database migration checks for existing `incident_count` column before adding it
- Google status parser now requires whole-word regex matches to prevent false positives from generic page text

https://claude.ai/code/session_01PyWmaCVNqezGV54bYtUoKK