### PR TITLE
Update deployment docs and configure local image building

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,16 @@ database across redeploys.
 
 ### Updating
 
-From the stack page, click **Pull and redeploy** (or **Update the stack**
-for the repository-based option) to rebuild with the latest code. The
-SQLite volume is preserved automatically.
+From the stack page, click **Update the stack** (repository-based
+deployment) and enable **Re-pull image and redeploy** to rebuild with the
+latest code. The compose file sets `pull_policy: build`, so Portainer
+will build the image from the bundled `Dockerfile` rather than trying to
+pull a prebuilt image from a registry — this avoids "image not found"
+errors during re-pull. The SQLite volume is preserved automatically.
+
+If you host your own prebuilt image in a registry (e.g. GHCR, Docker
+Hub), change the `image:` tag in `docker-compose.yml` to point at it and
+remove `pull_policy: build` (and optionally the `build:` block).
 
 ## API Endpoints
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   outage-map:
-    image: ghcr.io/tri-lumen/outage-map:latest
+    image: outage-map:local
+    pull_policy: build
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
Updated the deployment documentation to clarify the update process for repository-based deployments and configured the Docker Compose setup to build images locally rather than pulling from a registry.

## Key Changes
- **Docker Compose configuration**: Changed the image reference from `ghcr.io/tri-lumen/outage-map:latest` to `outage-map:local` and added `pull_policy: build` to ensure Portainer builds the image from the bundled Dockerfile instead of attempting to pull from a registry
- **Documentation**: Clarified the update workflow by specifying the correct button sequence ("Update the stack" + "Re-pull image and redeploy") and explained why `pull_policy: build` is necessary to avoid "image not found" errors
- **Registry guidance**: Added instructions for users who want to host their own prebuilt images in a registry, including how to update the image tag and remove the build policy

## Implementation Details
The `pull_policy: build` setting prevents Portainer from attempting to pull a non-existent prebuilt image from a registry, which would fail during re-deployment. Instead, it builds the image locally from the Dockerfile. This is a sensible default for self-hosted deployments while remaining flexible for users who want to use prebuilt images.

https://claude.ai/code/session_01T5r3U2gpKALPTMkisCYKcL