### PR TITLE
Fix broken functionality: icons, settings wiring, dynamic routes, font

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enterprise Outage Dashboard
 
-A live US enterprise application outage monitoring dashboard that tracks 7 major services with real-time status aggregation, 30-day outage history charts, and email alerting.
+A live US enterprise application outage monitoring dashboard that tracks 14 major services with real-time status aggregation, 30-day outage history charts, and email alerting.
 
 ## Monitored Services
 
@@ -11,6 +11,13 @@ A live US enterprise application outage monitoring dashboard that tracks 7 major
 - **Workday** - HR and finance platform
 - **Zoom** - Video conferencing
 - **Google Workspace** - Gmail, Drive, Meet, Calendar
+- **Slack** - Team messaging and collaboration
+- **GitHub** - Source control and CI/CD
+- **Atlassian** - Jira, Confluence, Bitbucket
+- **Okta** - Identity and single sign-on
+- **Cloudflare** - CDN, DNS, and edge services
+- **Dropbox** - File storage and sharing
+- **Amazon Web Services** - Cloud infrastructure
 
 ## Features
 
@@ -172,7 +179,7 @@ remove `pull_policy: build` (and optionally the `build:` block).
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/status` | GET | Current status for all 7 services |
+| `/api/status` | GET | Current status for all 14 services |
 | `/api/incidents?days=7` | GET | Recent incidents feed |
 | `/api/history?days=30` | GET | 30-day outage history for charts |
 | `/api/cron` | POST | Manually trigger a poll cycle (requires `Bearer $CRON_SECRET` when set) |

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -3,6 +3,8 @@ import { getStatusHistory } from '@/lib/db';
 import { SERVICES } from '@/lib/services';
 import { HistoryPoint, ServiceStatus } from '@/lib/types';
 
+export const dynamic = 'force-dynamic';
+
 function statusToMinutes(status: ServiceStatus): number {
   switch (status) {
     case 'major_outage':

--- a/src/app/api/incidents/route.ts
+++ b/src/app/api/incidents/route.ts
@@ -3,6 +3,8 @@ import { getRecentIncidents } from '@/lib/db';
 import { SERVICES } from '@/lib/services';
 import { IncidentResponse } from '@/lib/types';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,6 +33,7 @@ body {
     radial-gradient(circle at 20% -10%, rgba(99, 102, 241, 0.12), transparent 40%),
     radial-gradient(circle at 90% 10%, rgba(34, 211, 238, 0.08), transparent 35%);
   background-attachment: fixed;
+  font-family: var(--font-sans), system-ui, -apple-system, sans-serif;
 }
 
 html.light body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,7 +42,7 @@ const brandLato = Lato({
 export const metadata: Metadata = {
   title: "Outage Map · Enterprise Status",
   description:
-    "Real-time outage monitoring with analytics, geographic insights, and alerts for Microsoft 365, Adobe, ServiceNow, Salesforce, Workday, Zoom, and Google Workspace.",
+    "Real-time outage monitoring with analytics, geographic insights, and alerts for Microsoft 365, Adobe, ServiceNow, Salesforce, Workday, Zoom, Google Workspace, Slack, GitHub, Atlassian, Okta, Cloudflare, Dropbox, and AWS.",
   keywords: [
     "outage",
     "dashboard",
@@ -53,6 +53,10 @@ export const metadata: Metadata = {
     "Microsoft 365",
     "Salesforce",
     "Zoom",
+    "Slack",
+    "GitHub",
+    "AWS",
+    "Cloudflare",
   ],
 };
 
@@ -64,7 +68,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
       <body
-        className={`${notoSans.variable} ${notoSansMono.variable} ${brandInter.variable} ${brandRoboto.variable} ${brandSourceSans.variable} ${brandLato.variable} antialiased`}
+        className={`${notoSans.variable} ${notoSansMono.variable} ${brandInter.variable} ${brandRoboto.variable} ${brandSourceSans.variable} ${brandLato.variable} font-sans antialiased`}
       >
         <ThemeProvider>
           <AppShell>{children}</AppShell>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useServiceStatus, useIncidents, useHistory } from '@/hooks/useStatus';
+import { usePreferences } from '@/hooks/usePreferences';
 import { SERVICES } from '@/lib/services';
 import ServiceCard from './ServiceCard';
 import IncidentFeed from './IncidentFeed';
@@ -25,7 +26,9 @@ function formatTimestamp(ts: string | null | undefined): string {
 }
 
 export default function Dashboard() {
-  const { data: statusData, error: statusError, isLoading: statusLoading } = useServiceStatus();
+  const prefs = usePreferences();
+  const refreshMs = prefs.refreshInterval * 1000;
+  const { data: statusData, error: statusError, isLoading: statusLoading } = useServiceStatus(refreshMs);
   const { data: incidentData } = useIncidents(7);
   const { data: historyData } = useHistory(30);
   const [selectedService, setSelectedService] = useState<string | null>(null);
@@ -35,6 +38,7 @@ export default function Dashboard() {
   const services = useMemo(() => statusData?.services || [], [statusData]);
   const incidents = useMemo(() => incidentData?.incidents || [], [incidentData]);
   const history = useMemo(() => historyData?.history || {}, [historyData]);
+  const pinnedSet = useMemo(() => new Set(prefs.pinnedServices), [prefs.pinnedServices]);
 
   const stats = useMemo(() => {
     const total = services.length || SERVICES.length;
@@ -50,13 +54,19 @@ export default function Dashboard() {
   }, [services, incidents]);
 
   const filteredServices = useMemo(() => {
-    return services.filter((s) => {
+    const matched = services.filter((s) => {
       if (search && !s.name.toLowerCase().includes(search.toLowerCase())) return false;
       if (filter === 'operational' && s.overallStatus !== 'operational') return false;
       if (filter === 'issues' && s.overallStatus === 'operational') return false;
       return true;
     });
-  }, [services, search, filter]);
+    if (pinnedSet.size === 0) return matched;
+    // Stable partition: pinned services first, others after, order within each group preserved.
+    return [
+      ...matched.filter((s) => pinnedSet.has(s.slug)),
+      ...matched.filter((s) => !pinnedSet.has(s.slug)),
+    ];
+  }, [services, search, filter, pinnedSet]);
 
   if (statusLoading) {
     return (
@@ -105,7 +115,9 @@ export default function Dashboard() {
         actions={
           <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20">
             <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
-            <span className="text-xs font-medium text-emerald-300">Auto-refresh · 30s</span>
+            <span className="text-xs font-medium text-emerald-300">
+              Auto-refresh · {prefs.refreshInterval < 60 ? `${prefs.refreshInterval}s` : `${prefs.refreshInterval / 60}m`}
+            </span>
           </div>
         }
       />
@@ -144,17 +156,31 @@ export default function Dashboard() {
             </svg>
           }
         />
-        <StatTile
-          label="DD Reports (now)"
-          value={stats.reports.toLocaleString()}
-          accent="indigo"
-          hint="Aggregated across services"
-          icon={
-            <svg className="w-5 h-5 text-indigo-300" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
-            </svg>
-          }
-        />
+        {prefs.showDowndetector ? (
+          <StatTile
+            label="DD Reports (now)"
+            value={stats.reports.toLocaleString()}
+            accent="indigo"
+            hint="Aggregated across services"
+            icon={
+              <svg className="w-5 h-5 text-indigo-300" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
+              </svg>
+            }
+          />
+        ) : (
+          <StatTile
+            label="Services Tracked"
+            value={stats.total}
+            accent="indigo"
+            hint="Total monitored services"
+            icon={
+              <svg className="w-5 h-5 text-indigo-300" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25A2.25 2.25 0 018.25 10.5H6A2.25 2.25 0 013.75 8.25V6zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25A2.25 2.25 0 0113.5 8.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 018.25 20.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+              </svg>
+            }
+          />
+        )}
       </section>
 
       <section>
@@ -195,12 +221,20 @@ export default function Dashboard() {
             No services match your filters.
           </Card>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          <div
+            className={
+              prefs.compactCards
+                ? 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3'
+                : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4'
+            }
+          >
             {filteredServices.map((service) => (
               <ServiceCard
                 key={service.slug}
                 service={service}
                 onClick={() => setSelectedService(service.slug)}
+                compact={prefs.compactCards}
+                showDowndetector={prefs.showDowndetector}
               />
             ))}
           </div>

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -8,6 +8,8 @@ interface ServiceCardProps {
   service: ServiceStatusResponse;
   onClick?: () => void;
   href?: string;
+  compact?: boolean;
+  showDowndetector?: boolean;
 }
 
 const SERVICE_ICONS: Record<string, string> = {
@@ -18,6 +20,13 @@ const SERVICE_ICONS: Record<string, string> = {
   'workday': 'W',
   'zoom': 'Z',
   'google-workspace': 'G',
+  'slack': 'S',
+  'github': 'GH',
+  'atlassian': 'A',
+  'okta': 'Ok',
+  'cloudflare': 'CF',
+  'dropbox': 'Db',
+  'aws': 'AWS',
 };
 
 function formatTimestamp(ts: string | null): string {
@@ -44,14 +53,20 @@ function getStatusAccent(status: string): string {
   }
 }
 
-export default function ServiceCard({ service, onClick, href }: ServiceCardProps) {
-  const icon = SERVICE_ICONS[service.slug] || '?';
+export default function ServiceCard({
+  service,
+  onClick,
+  href,
+  compact = false,
+  showDowndetector = true,
+}: ServiceCardProps) {
+  const icon = SERVICE_ICONS[service.slug] || service.name.charAt(0);
   const accent = getStatusAccent(service.overallStatus);
 
   const content = (
     <div
       onClick={onClick}
-      className={`group relative surface-card rounded-2xl p-5 cursor-pointer transition-all duration-200 hover:border-strong hover:-translate-y-0.5 hover:shadow-[0_8px_24px_-12px_rgba(0,0,0,0.6)] before:absolute before:left-0 before:top-4 before:bottom-4 before:w-0.5 before:rounded-r ${accent}`}
+      className={`group relative surface-card rounded-2xl cursor-pointer transition-all duration-200 hover:border-strong hover:-translate-y-0.5 hover:shadow-[0_8px_24px_-12px_rgba(0,0,0,0.6)] before:absolute before:left-0 before:top-4 before:bottom-4 before:w-0.5 before:rounded-r ${accent} ${compact ? 'p-3' : 'p-5'}`}
     >
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center gap-3">
@@ -82,66 +97,76 @@ export default function ServiceCard({ service, onClick, href }: ServiceCardProps
         <StatusBadge status={service.overallStatus} size="md" />
       </div>
 
-      <div className="flex items-center justify-between text-xs">
-        <div className="text-gray-400">
-          <span className="text-gray-500">Official:</span>{' '}
-          <span className={
-            service.officialStatus === 'operational' ? 'text-emerald-400' :
-            service.officialStatus === 'degraded' ? 'text-yellow-400' :
-            service.officialStatus === 'major_outage' ? 'text-orange-400' :
-            service.officialStatus === 'down' ? 'text-red-400' :
-            'text-gray-400'
-          }>
-            {service.officialStatus === 'operational' ? 'OK' :
-             service.officialStatus === 'unknown' ? '--' :
-             service.officialStatus.replace('_', ' ')}
-          </span>
+      {!compact && (
+        <div className="flex items-center justify-between text-xs">
+          <div className="text-gray-400">
+            <span className="text-gray-500">Official:</span>{' '}
+            <span className={
+              service.officialStatus === 'operational' ? 'text-emerald-400' :
+              service.officialStatus === 'degraded' ? 'text-yellow-400' :
+              service.officialStatus === 'major_outage' ? 'text-orange-400' :
+              service.officialStatus === 'down' ? 'text-red-400' :
+              'text-gray-400'
+            }>
+              {service.officialStatus === 'operational' ? 'OK' :
+               service.officialStatus === 'unknown' ? '--' :
+               service.officialStatus.replace('_', ' ')}
+            </span>
+          </div>
+          {showDowndetector && (
+            <div className="text-gray-400">
+              <span className="text-gray-500">DD:</span>{' '}
+              <span className={
+                service.downdetectorReports >= 500 ? 'text-red-400 font-semibold' :
+                service.downdetectorReports >= 100 ? 'text-yellow-400' :
+                service.downdetectorStatus === 'unknown' ? 'text-gray-500 italic' :
+                'text-gray-300'
+              }>
+                {service.downdetectorStatus === 'unknown'
+                  ? 'no data'
+                  : service.downdetectorReports > 0
+                    ? service.downdetectorReports.toLocaleString()
+                    : '--'}
+              </span>
+            </div>
+          )}
         </div>
-        <div className="text-gray-400">
-          <span className="text-gray-500">DD:</span>{' '}
-          <span className={
-            service.downdetectorReports >= 500 ? 'text-red-400 font-semibold' :
-            service.downdetectorReports >= 100 ? 'text-yellow-400' :
-            service.downdetectorStatus === 'unknown' ? 'text-gray-500 italic' :
-            'text-gray-300'
-          }>
-            {service.downdetectorStatus === 'unknown'
-              ? 'no data'
-              : service.downdetectorReports > 0
-                ? service.downdetectorReports.toLocaleString()
-                : '--'}
-          </span>
-        </div>
-      </div>
+      )}
 
-      {service.details && service.overallStatus !== 'operational' && (
+      {!compact && service.details && service.overallStatus !== 'operational' && (
         <p className="text-xs text-gray-400 mt-2 truncate border-t border-subtle pt-2">
           {service.details}
         </p>
       )}
 
-      <div
-        onClick={(e) => e.stopPropagation()}
-        className="mt-3 pt-2 border-t border-subtle flex items-center gap-3 text-[10px]"
-      >
-        <a
-          href={service.statusUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-accent-cyan hover:underline"
+      {!compact && (
+        <div
+          onClick={(e) => e.stopPropagation()}
+          className="mt-3 pt-2 border-t border-subtle flex items-center gap-3 text-[10px]"
         >
-          Official ↗
-        </a>
-        <span className="text-gray-700">·</span>
-        <a
-          href={service.downdetectorUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-accent-cyan hover:underline"
-        >
-          {service.downdetectorStatus === 'unknown' ? 'Open Downdetector ↗' : 'Downdetector ↗'}
-        </a>
-      </div>
+          <a
+            href={service.statusUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-cyan hover:underline"
+          >
+            Official ↗
+          </a>
+          {showDowndetector && (
+            <>
+              <span className="text-gray-700">·</span>
+              <a
+                href={service.downdetectorUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent-cyan hover:underline"
+              >
+                {service.downdetectorStatus === 'unknown' ? 'Open Downdetector ↗' : 'Downdetector ↗'}
+              </a>
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -2,80 +2,55 @@
 
 import { useEffect, useState } from 'react';
 import { SERVICES } from '@/lib/services';
+import {
+  DEFAULT_PREFERENCES,
+  Preferences,
+  clearPreferences,
+  usePreferences,
+  writePreferences,
+} from '@/hooks/usePreferences';
 import { useTheme } from './ThemeProvider';
 import PageHeader from './ui/PageHeader';
 import Card from './ui/Card';
 
-interface Preferences {
-  refreshInterval: 15 | 30 | 60 | 300;
-  compactCards: boolean;
-  showDowndetector: boolean;
-  pinnedServices: string[];
-}
-
-const DEFAULTS: Preferences = {
-  refreshInterval: 30,
-  compactCards: false,
-  showDowndetector: true,
-  pinnedServices: [],
-};
-
-const STORAGE_KEY = 'outage-map-prefs';
-
-function loadPrefs(): Preferences {
-  if (typeof window === 'undefined') return DEFAULTS;
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? { ...DEFAULTS, ...JSON.parse(raw) } : DEFAULTS;
-  } catch {
-    return DEFAULTS;
-  }
-}
-
 export default function SettingsView() {
   const { theme, setTheme } = useTheme();
-  const [prefs, setPrefs] = useState<Preferences>(DEFAULTS);
+  const synced = usePreferences();
+  const [prefs, setPrefs] = useState<Preferences>(synced);
   const [saved, setSaved] = useState(false);
 
+  // Reflect external preference changes (e.g. reset from another tab) into
+  // local state so controls stay in sync with storage.
   useEffect(() => {
-    setPrefs(loadPrefs());
-  }, []);
+    setPrefs(synced);
+  }, [synced]);
 
-  const update = <K extends keyof Preferences>(key: K, value: Preferences[K]) => {
-    setPrefs((prev) => {
-      const next = { ...prev, [key]: value };
-      try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-      } catch {
-        /* ignore */
-      }
-      return next;
-    });
+  const persist = (next: Preferences) => {
+    setPrefs(next);
+    writePreferences(next);
     setSaved(true);
     setTimeout(() => setSaved(false), 1500);
+  };
+
+  const update = <K extends keyof Preferences>(key: K, value: Preferences[K]) => {
+    persist({ ...prefs, [key]: value });
   };
 
   const togglePin = (slug: string) => {
-    setPrefs((prev) => {
-      const nextPinned = prev.pinnedServices.includes(slug)
-        ? prev.pinnedServices.filter((s) => s !== slug)
-        : [...prev.pinnedServices, slug];
-      const next = { ...prev, pinnedServices: nextPinned };
-      try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-      } catch {
-        /* ignore */
-      }
-      return next;
-    });
-    setSaved(true);
-    setTimeout(() => setSaved(false), 1500);
+    const nextPinned = prefs.pinnedServices.includes(slug)
+      ? prefs.pinnedServices.filter((s) => s !== slug)
+      : [...prefs.pinnedServices, slug];
+    persist({ ...prefs, pinnedServices: nextPinned });
   };
 
   const resetAll = () => {
-    localStorage.removeItem(STORAGE_KEY);
-    localStorage.removeItem('outage-map-alert-rules');
-    setPrefs(DEFAULTS);
+    clearPreferences();
+    try {
+      localStorage.removeItem('outage-map-alert-rules');
+    } catch {
+      /* ignore */
+    }
+    setPrefs(DEFAULT_PREFERENCES);
     setTheme('dark');
   };
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useServiceStatus } from '@/hooks/useStatus';
+import { SERVICES } from '@/lib/services';
 import { useSidebar } from './SidebarContext';
 
 interface NavItem {
@@ -158,7 +159,7 @@ export default function Sidebar() {
             <span className={`text-xs font-medium ${health.tone}`}>{health.label}</span>
           </div>
           <div className="text-[11px] text-gray-500">
-            {operational}/{services.length || 7} services operational
+            {operational}/{services.length || SERVICES.length} services operational
           </div>
           <div className="mt-2 w-full h-1 rounded-full bg-white/5 overflow-hidden">
             <div

--- a/src/hooks/usePreferences.ts
+++ b/src/hooks/usePreferences.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface Preferences {
+  refreshInterval: 15 | 30 | 60 | 300;
+  compactCards: boolean;
+  showDowndetector: boolean;
+  pinnedServices: string[];
+}
+
+export const DEFAULT_PREFERENCES: Preferences = {
+  refreshInterval: 30,
+  compactCards: false,
+  showDowndetector: true,
+  pinnedServices: [],
+};
+
+export const PREFERENCES_STORAGE_KEY = 'outage-map-prefs';
+export const PREFERENCES_UPDATED_EVENT = 'outage-map-prefs-updated';
+
+function readPreferences(): Preferences {
+  if (typeof window === 'undefined') return DEFAULT_PREFERENCES;
+  try {
+    const raw = localStorage.getItem(PREFERENCES_STORAGE_KEY);
+    return raw ? { ...DEFAULT_PREFERENCES, ...JSON.parse(raw) } : DEFAULT_PREFERENCES;
+  } catch {
+    return DEFAULT_PREFERENCES;
+  }
+}
+
+export function writePreferences(next: Preferences) {
+  try {
+    localStorage.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    /* ignore */
+  }
+  // Notify same-tab listeners; the browser only fires `storage` events for
+  // other tabs, so components in this tab need a custom signal to re-read.
+  window.dispatchEvent(new Event(PREFERENCES_UPDATED_EVENT));
+}
+
+export function clearPreferences() {
+  try {
+    localStorage.removeItem(PREFERENCES_STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+  window.dispatchEvent(new Event(PREFERENCES_UPDATED_EVENT));
+}
+
+export function usePreferences(): Preferences {
+  const [prefs, setPrefs] = useState<Preferences>(DEFAULT_PREFERENCES);
+
+  useEffect(() => {
+    setPrefs(readPreferences());
+
+    const sync = () => setPrefs(readPreferences());
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === PREFERENCES_STORAGE_KEY || e.key === null) sync();
+    };
+
+    window.addEventListener(PREFERENCES_UPDATED_EVENT, sync);
+    window.addEventListener('storage', onStorage);
+    return () => {
+      window.removeEventListener(PREFERENCES_UPDATED_EVENT, sync);
+      window.removeEventListener('storage', onStorage);
+    };
+  }, []);
+
+  return prefs;
+}

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -9,35 +9,35 @@ const fetcher = async (url: string) => {
   return res.json();
 };
 
-export function useServiceStatus() {
+export function useServiceStatus(refreshIntervalMs?: number) {
   return useSWR<{ services: ServiceStatusResponse[]; lastUpdated: string }>(
     '/api/status',
     fetcher,
     {
-      refreshInterval: 30000, // Refresh every 30 seconds
+      refreshInterval: refreshIntervalMs ?? 30000,
       revalidateOnFocus: true,
-      dedupingInterval: 10000,
+      dedupingInterval: Math.min(10000, refreshIntervalMs ?? 10000),
     }
   );
 }
 
-export function useIncidents(days: number = 7) {
+export function useIncidents(days: number = 7, refreshIntervalMs?: number) {
   return useSWR<{ incidents: IncidentResponse[] }>(
     `/api/incidents?days=${days}`,
     fetcher,
     {
-      refreshInterval: 60000, // Refresh every minute
+      refreshInterval: refreshIntervalMs ?? 60000,
       revalidateOnFocus: true,
     }
   );
 }
 
-export function useHistory(days: number = 30) {
+export function useHistory(days: number = 30, refreshIntervalMs?: number) {
   return useSWR<HistoryResponse>(
     `/api/history?days=${days}`,
     fetcher,
     {
-      refreshInterval: 300000, // Refresh every 5 minutes
+      refreshInterval: refreshIntervalMs ?? 300000,
       revalidateOnFocus: true,
     }
   );


### PR DESCRIPTION
- ServiceCard: add icons for slack, github, atlassian, okta, cloudflare,
  dropbox, and aws (previously fell through to "?"); fall back to the
  service name's first character instead of "?" for any future gap.
- Wire up Settings preferences via new usePreferences hook. Dashboard
  now honors refreshInterval (SWR polling), compactCards (5-up grid +
  denser cards), showDowndetector (hide DD stat + rows), and
  pinnedServices (sorted first). ServiceCard accepts compact and
  showDowndetector props.
- Sidebar/README/layout metadata: replace stale "7 services" copy with
  the full 14-service roster.
- API routes: add export const dynamic = "force-dynamic" to
  /api/incidents and /api/history to silence build warnings.
- Apply font-sans on body and set body font-family in globals.css so
  elements without an explicit family inherit Noto Sans instead of the
  system default.

https://claude.ai/code/session_01CN5VXZwqsohfJRLmAp2EPQ