### PR TITLE
Fix visual bugs: toggle alignment, hardcoded grays, layout issues, icon visibility

### DIFF
--- a/src/components/AlertsView.tsx
+++ b/src/components/AlertsView.tsx
@@ -424,16 +424,17 @@ export default function AlertsView() {
               <Card key={r.id} className="flex flex-col gap-3">
                 <div className="flex items-center gap-4 flex-wrap">
                   <button
+                    role="switch"
+                    aria-checked={r.enabled}
                     onClick={() => toggleEnabled(r)}
                     aria-label={`Toggle rule for ${r.email}`}
-                    aria-pressed={r.enabled}
-                    className={`relative w-11 h-6 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                    className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                       r.enabled ? 'bg-accent' : 'bg-white/10'
                     }`}
                   >
                     <span
-                      className={`absolute top-0.5 w-5 h-5 rounded-full bg-white transition-transform ${
-                        r.enabled ? 'translate-x-5' : 'translate-x-0.5'
+                      className={`inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
+                        r.enabled ? 'translate-x-[22px]' : 'translate-x-0.5'
                       }`}
                     />
                   </button>

--- a/src/components/AnalyticsView.tsx
+++ b/src/components/AnalyticsView.tsx
@@ -125,7 +125,7 @@ export default function AnalyticsView() {
           <div className="flex items-center justify-between mb-4">
             <div>
               <h2 className="text-sm font-semibold text-foreground">Uptime by service</h2>
-              <p className="text-xs text-gray-400 mt-0.5">30-day rolling window</p>
+              <p className="text-xs text-muted mt-0.5">30-day rolling window</p>
             </div>
             <span className="text-xs text-muted">SLA target: {aggregate.slaTarget}%</span>
           </div>
@@ -210,16 +210,16 @@ export default function AnalyticsView() {
                           {r.uptimeLabel}%
                         </span>
                       </td>
-                      <td className="px-5 py-3 text-right text-gray-300 tabular-nums">
+                      <td className="px-5 py-3 text-right text-foreground tabular-nums">
                         {r.totalDowntime > 60
                           ? `${(r.totalDowntime / 60).toFixed(1)}h`
                           : `${r.totalDowntime}m`}
                       </td>
-                      <td className="px-5 py-3 text-right text-gray-300 tabular-nums">
+                      <td className="px-5 py-3 text-right text-foreground tabular-nums">
                         {r.mttr > 0 ? `${r.mttr}m` : '—'}
                       </td>
                       <td className="px-5 py-3 text-right">
-                        <span className="text-gray-300 tabular-nums">{r.incidents}</span>
+                        <span className="text-foreground tabular-nums">{r.incidents}</span>
                         {r.criticalIncidents > 0 && (
                           <span className="ml-2 text-[10px] px-1.5 py-0.5 rounded bg-red-500/10 text-red-400">
                             {r.criticalIncidents} critical

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,7 +25,7 @@ function getOverallHealth(services: ServiceStatusResponse[]): {
     return { label: 'Some Services Degraded', color: 'text-yellow-400', bgColor: 'bg-yellow-500/10' };
   }
   if (statuses.every((s) => s === 'unknown')) {
-    return { label: 'Checking Services...', color: 'text-gray-400', bgColor: 'bg-gray-500/10' };
+    return { label: 'Checking Services...', color: 'text-muted', bgColor: 'bg-white/5' };
   }
   return { label: 'All Systems Operational', color: 'text-green-400', bgColor: 'bg-green-500/10' };
 }

--- a/src/components/OutageMapView.tsx
+++ b/src/components/OutageMapView.tsx
@@ -170,7 +170,7 @@ export default function OutageMapView() {
               <h2 className="text-sm font-semibold text-foreground">
                 {scope === 'global' ? 'Report density by region' : 'US regional breakdown'}
               </h2>
-              <p className="text-xs text-gray-500 mt-0.5">
+              <p className="text-xs text-muted mt-0.5">
                 {scope === 'global'
                   ? 'Redder fill = higher concentration of reports.'
                   : 'Reports distributed across us-east, us-west, us-central, us-south.'}
@@ -294,7 +294,7 @@ function ScopeButton({
     <button
       onClick={onClick}
       className={`px-3 py-1.5 text-xs font-medium rounded-full whitespace-nowrap transition-colors ${
-        active ? 'bg-accent-soft text-foreground' : 'text-gray-400 hover:text-foreground'
+        active ? 'bg-accent-soft text-foreground' : 'text-muted hover:text-foreground'
       }`}
     >
       {label}

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -41,7 +41,7 @@ function getStatusAccent(status: string): string {
     case 'down':
       return 'before:bg-red-400/70';
     default:
-      return 'before:bg-gray-500/40';
+      return 'before:bg-white/20';
   }
 }
 
@@ -63,7 +63,7 @@ export default function ServiceCard({
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center gap-3">
           <div
-            className="w-10 h-10 rounded-xl flex items-center justify-center text-white font-bold text-sm shadow-lg"
+            className="w-10 h-10 rounded-xl flex items-center justify-center text-white font-bold text-sm shadow-lg ring-1 ring-white/20"
             style={{ backgroundColor: service.color }}
           >
             {icon}
@@ -85,7 +85,7 @@ export default function ServiceCard({
         </svg>
       </div>
 
-      <div className="mb-3">
+      <div className={compact ? '' : 'mb-3'}>
         <StatusBadge status={service.overallStatus} size="md" />
       </div>
 
@@ -112,7 +112,7 @@ export default function ServiceCard({
                 service.downdetectorReports >= 500 ? 'text-red-400 font-semibold' :
                 service.downdetectorReports >= 100 ? 'text-yellow-400' :
                 service.downdetectorStatus === 'unknown' ? 'text-muted-strong italic' :
-                'text-foreground'
+                service.downdetectorReports > 0 ? 'text-foreground' : 'text-muted'
               }>
                 {service.downdetectorStatus === 'unknown'
                   ? 'no data'

--- a/src/components/ServiceDetailModal.tsx
+++ b/src/components/ServiceDetailModal.tsx
@@ -83,7 +83,7 @@ export default function ServiceDetailModal({
         <div className="sticky top-0 bg-surface/95 backdrop-blur-sm border-b border-subtle px-6 py-4 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div
-              className="w-10 h-10 rounded-lg flex items-center justify-center text-white font-bold text-sm"
+              className="w-10 h-10 rounded-lg flex items-center justify-center text-white font-bold text-sm ring-1 ring-white/20"
               style={{ backgroundColor: service.color }}
             >
               {service.name.charAt(0)}

--- a/src/components/ServiceDetailView.tsx
+++ b/src/components/ServiceDetailView.tsx
@@ -58,7 +58,7 @@ export default function ServiceDetailView({ slug }: Props) {
   if (!config) {
     return (
       <Card className="text-center py-14">
-        <p className="text-sm text-gray-400">Service not found.</p>
+        <p className="text-sm text-muted">Service not found.</p>
         <Link href="/" className="text-xs text-accent-cyan mt-3 inline-block">
           ← Back to overview
         </Link>
@@ -80,7 +80,7 @@ export default function ServiceDetailView({ slug }: Props) {
 
   return (
     <div className="space-y-8">
-      <Link href="/" className="inline-flex items-center gap-1.5 text-xs text-gray-400 hover:text-foreground">
+      <Link href="/" className="inline-flex items-center gap-1.5 text-xs text-muted hover:text-foreground">
         <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
         </svg>
@@ -97,7 +97,7 @@ export default function ServiceDetailView({ slug }: Props) {
               {config.name.charAt(0)}
             </div>
             <div>
-              <p className="text-[11px] uppercase tracking-widest text-gray-500 mb-1">
+              <p className="text-[11px] uppercase tracking-widest text-muted mb-1">
                 {config.fetcher} · {config.slug}
               </p>
               <h1
@@ -109,7 +109,7 @@ export default function ServiceDetailView({ slug }: Props) {
               <div className="mt-3 flex items-center gap-3">
                 <StatusBadge status={heroStatus} size="md" />
                 {service?.details && (
-                  <span className="text-xs text-gray-400 max-w-md truncate">{service.details}</span>
+                  <span className="text-xs text-muted max-w-md truncate">{service.details}</span>
                 )}
               </div>
             </div>
@@ -170,24 +170,22 @@ export default function ServiceDetailView({ slug }: Props) {
 
       <section>
         <h2 className="text-base font-semibold text-foreground mb-3">History</h2>
-        <Card>
-          <OutageChart
-            serviceName={config.name}
-            serviceColor={config.color}
-            data={history}
-          />
-        </Card>
+        <OutageChart
+          serviceName={config.name}
+          serviceColor={config.color}
+          data={history}
+        />
       </section>
 
       <section>
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-base font-semibold text-foreground">Recent incidents</h2>
-          <span className="text-xs text-gray-500">
+          <span className="text-xs text-muted">
             {incidents.length} in last 30 days · {metrics.critical} critical
           </span>
         </div>
         {incidents.length === 0 ? (
-          <Card className="text-center py-10 text-sm text-gray-500">
+          <Card className="text-center py-10 text-sm text-muted">
             No incidents reported in the last 30 days.
           </Card>
         ) : (
@@ -220,18 +218,18 @@ export default function ServiceDetailView({ slug }: Props) {
                       className={`text-[10px] uppercase px-1.5 py-0.5 rounded ${
                         inc.status === 'resolved'
                           ? 'bg-emerald-500/10 text-emerald-400'
-                          : 'bg-white/5 text-gray-400'
+                          : 'bg-white/5 text-muted'
                       }`}
                     >
                       {inc.status}
                     </span>
-                    <span className="text-[11px] text-gray-500">
+                    <span className="text-[11px] text-muted">
                       {formatDateTime(inc.startedAt)}
                     </span>
                   </div>
                   <p className="text-sm text-foreground font-medium mt-1.5">{inc.title}</p>
                   {inc.description && (
-                    <p className="text-xs text-gray-400 mt-1 line-clamp-2">{inc.description}</p>
+                    <p className="text-xs text-muted mt-1 line-clamp-2">{inc.description}</p>
                   )}
                   {inc.sourceUrl && (
                     <a

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -125,7 +125,7 @@ export default function SettingsView() {
                   <span className="text-xs text-accent-cyan">● Active</span>
                 )}
               </div>
-              <p className="text-[11px] text-gray-400 mt-1">{description}</p>
+              <p className="text-[11px] text-muted mt-1">{description}</p>
             </button>
           ))}
         </div>
@@ -135,7 +135,7 @@ export default function SettingsView() {
         <h3 className="text-sm font-semibold text-foreground mb-4">Data & refresh</h3>
         <div className="space-y-5">
           <div>
-            <label className="block text-xs font-medium text-gray-400 mb-2">Refresh interval</label>
+            <label className="block text-xs font-medium text-muted mb-2">Refresh interval</label>
             <div className="flex items-center gap-0.5 p-1 rounded-lg bg-surface border border-subtle">
               {([15, 30, 60, 300] as const).map((v) => (
                 <button
@@ -151,7 +151,7 @@ export default function SettingsView() {
                 </button>
               ))}
             </div>
-            <p className="text-[11px] text-gray-500 mt-1.5">
+            <p className="text-[11px] text-muted mt-1.5">
               How often the overview polls for new status data.
             </p>
           </div>
@@ -162,15 +162,17 @@ export default function SettingsView() {
               <p className="text-[11px] text-muted-strong">Include crowd-sourced data alongside official statuses. Thresholds are configured server-side via <code className="text-foreground">DD_REPORT_THRESHOLD_DEGRADED</code> and <code className="text-foreground">DD_REPORT_THRESHOLD_MAJOR</code>.</p>
             </div>
             <button
+              role="switch"
+              aria-checked={prefs.showDowndetector}
               onClick={() => update('showDowndetector', !prefs.showDowndetector)}
-              className={`relative w-11 h-6 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+              className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                 prefs.showDowndetector ? 'bg-accent' : 'bg-white/10'
               }`}
               aria-label="Toggle Downdetector"
             >
               <span
-                className={`absolute top-0.5 w-5 h-5 rounded-full bg-white transition-transform ${
-                  prefs.showDowndetector ? 'translate-x-5' : 'translate-x-0.5'
+                className={`inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
+                  prefs.showDowndetector ? 'translate-x-[22px]' : 'translate-x-0.5'
                 }`}
               />
             </button>
@@ -179,18 +181,20 @@ export default function SettingsView() {
           <div className="flex items-center justify-between py-2 border-t border-subtle">
             <div>
               <p className="text-sm text-foreground">Compact service cards</p>
-              <p className="text-[11px] text-gray-500">Denser layout on the overview page</p>
+              <p className="text-[11px] text-muted">Denser layout on the overview page</p>
             </div>
             <button
+              role="switch"
+              aria-checked={prefs.compactCards}
               onClick={() => update('compactCards', !prefs.compactCards)}
-              className={`relative w-11 h-6 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+              className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                 prefs.compactCards ? 'bg-accent' : 'bg-white/10'
               }`}
               aria-label="Toggle compact"
             >
               <span
-                className={`absolute top-0.5 w-5 h-5 rounded-full bg-white transition-transform ${
-                  prefs.compactCards ? 'translate-x-5' : 'translate-x-0.5'
+                className={`inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
+                  prefs.compactCards ? 'translate-x-[22px]' : 'translate-x-0.5'
                 }`}
               />
             </button>
@@ -202,11 +206,11 @@ export default function SettingsView() {
         <div className="flex items-start justify-between mb-4">
           <div>
             <h3 className="text-sm font-semibold text-foreground">Pinned services</h3>
-            <p className="text-[11px] text-gray-500 mt-1">
+            <p className="text-[11px] text-muted mt-1">
               Pinned services appear first on the overview.
             </p>
           </div>
-          <span className="text-xs text-gray-500">{prefs.pinnedServices.length} pinned</span>
+          <span className="text-xs text-muted">{prefs.pinnedServices.length} pinned</span>
         </div>
         <div className="flex flex-wrap gap-2">
           {SERVICES.map((s) => {
@@ -232,7 +236,7 @@ export default function SettingsView() {
 
       <Card elevated>
         <h3 className="text-sm font-semibold text-foreground mb-1">Reset preferences</h3>
-        <p className="text-[11px] text-gray-500 mb-4">
+        <p className="text-[11px] text-muted mb-4">
           Clears stored preferences and alert rules on this device.
         </p>
         <button

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -20,7 +20,7 @@ export default function PageHeader({ eyebrow, title, description, actions }: Pag
           {title}
         </h1>
         {description && (
-          <p className="text-sm text-gray-400 mt-2 max-w-2xl">{description}</p>
+          <p className="text-sm text-muted mt-2 max-w-2xl">{description}</p>
         )}
       </div>
       {actions && <div className="flex items-center gap-2 flex-wrap">{actions}</div>}

--- a/src/components/ui/StatTile.tsx
+++ b/src/components/ui/StatTile.tsx
@@ -29,7 +29,7 @@ export default function StatTile({
 }: StatTileProps) {
   const accentClasses = ACCENT_BG[accent];
   const trendColor =
-    trend === 'up' ? 'text-emerald-400' : trend === 'down' ? 'text-red-400' : 'text-gray-500';
+    trend === 'up' ? 'text-emerald-400' : trend === 'down' ? 'text-red-400' : 'text-muted';
 
   return (
     <div className="relative rounded-2xl surface-card p-5 overflow-hidden">
@@ -37,7 +37,7 @@ export default function StatTile({
       <div className="relative">
         <div className="flex items-start justify-between gap-3">
           <div>
-            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider">{label}</p>
+            <p className="text-xs font-medium text-muted uppercase tracking-wider">{label}</p>
             <p className="text-3xl font-semibold tracking-tight mt-2 text-foreground tabular-nums">{value}</p>
           </div>
           {icon && (
@@ -53,7 +53,7 @@ export default function StatTile({
                 {trend === 'up' ? '↑' : trend === 'down' ? '↓' : '→'} {trendLabel}
               </span>
             )}
-            {hint && <span className="text-gray-500">{hint}</span>}
+            {hint && <span className="text-muted">{hint}</span>}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- **Toggle switches rebuilt** — All 3 toggle switches (SettingsView ×2, AlertsView) had a misaligned knob: `absolute top-0.5` with no `left` (fragile static positioning) and `translate-x-5` (20px) left a 4px gap on the right vs 2px on the left. Rebuilt using `inline-flex items-center` on the button and `inline-block` on the knob, with corrected `translate-x-[22px]` for symmetric 2px margins. Also added `role="switch"` + `aria-checked` and `shrink-0`.
- **Hardcoded gray colors eliminated** — Replaced all `text-gray-300/400/500` and `bg-gray-500/10` across 8 components (StatTile, AnalyticsView, SettingsView, ServiceDetailView, Header, OutageMapView, PageHeader, ServiceCard) with semantic theme tokens (`text-muted`, `text-foreground`, `bg-white/5`). Fixes readability on the solarized-light theme.
- **Double-card layout fixed** — `ServiceDetailView` was wrapping `<OutageChart>` in a `<Card>`, but OutageChart already renders its own `surface-card` container. Removed the redundant wrapper (double border + 20px dead space between them).
- **ServiceCard compact mode margin** — Removed wasteful `mb-3` below the StatusBadge in compact mode where nothing follows it.
- **Service icon ring** — Added `ring-1 ring-white/20` to service icon divs in `ServiceCard` and `ServiceDetailModal` so near-black icons (GitHub `#181717`) have a visible boundary on dark surfaces.
- **DD placeholder color** — The `'--'` placeholder in the ServiceCard DD row now renders as `text-muted` instead of `text-foreground`, distinguishing it from actual report counts.

## Test plan

- [ ] Switch to **solarized-light** theme — verify all secondary text is readable (no gray-on-off-white)
- [ ] Switch to **black-grey** theme — GitHub service icon should show a faint ring boundary against the dark card background
- [ ] Toggle the "Show Downdetector reports" and "Compact service cards" switches in Settings — knob should travel smoothly to the right end with equal margins on both sides
- [ ] Toggle an alert rule on/off in Notifications — same knob alignment check
- [ ] Navigate to a service detail page — OutageChart should render with a single card border, no double-bordered nesting
- [ ] Enable compact cards — service cards should not have extra blank space below the status badge
- [ ] On a service card where DD reports = 0 (but status ≠ unknown), the `--` should appear dimmed/muted
- [ ] Switch back to **solarized-dark** — verify no regressions across the dashboard

https://claude.ai/code/session_01Nthx8pzJzsMWU9DVjUsvio

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nthx8pzJzsMWU9DVjUsvio)_