### PR TITLE
Implement modular tile-grid dashboard design (v3)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,33 +2,42 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Solarized Dark — default. Ethan Schoonover's base03/base02 surfaces
-   paired with base1 text and solarized blue/cyan accents. */
+/* ============================================================
+   THEME TOKENS — applied via both class (legacy) and data-theme
+   ============================================================ */
+
+/* Solarized Dark — default */
 :root,
-html.solarized-dark {
+html.solarized-dark,
+:root[data-theme="solarized-dark"] {
   --background: #002b36;
   --foreground: #93a1a1;
+  --foreground-strong: #eee8d5;
   --muted: #839496;
   --muted-strong: #657b83;
   --surface: #073642;
   --surface-elevated: #0e4450;
-  --border-subtle: rgba(147, 161, 161, 0.1);
+  --surface-glass: rgba(7, 54, 66, 0.6);
+  --border-subtle: rgba(147, 161, 161, 0.10);
   --border-strong: rgba(147, 161, 161, 0.22);
   --accent: #268bd2;
   --accent-soft: rgba(38, 139, 210, 0.18);
   --accent-cyan: #2aa198;
   --glow-primary: rgba(38, 139, 210, 0.14);
-  --glow-secondary: rgba(42, 161, 152, 0.1);
+  --glow-secondary: rgba(42, 161, 152, 0.10);
 }
 
-/* Solarized Light — the canonical base3/base2 palette with base00 text. */
-html.solarized-light {
+/* Solarized Light */
+html.solarized-light,
+:root[data-theme="solarized-light"] {
   --background: #fdf6e3;
   --foreground: #586e75;
+  --foreground-strong: #073642;
   --muted: #657b83;
   --muted-strong: #073642;
   --surface: #eee8d5;
   --surface-elevated: #e4dcba;
+  --surface-glass: rgba(238, 232, 213, 0.6);
   --border-subtle: rgba(88, 110, 117, 0.14);
   --border-strong: rgba(88, 110, 117, 0.28);
   --accent: #268bd2;
@@ -38,14 +47,17 @@ html.solarized-light {
   --glow-secondary: rgba(42, 161, 152, 0.06);
 }
 
-/* Traditional black/grey dark theme — pure neutrals with a blue accent. */
-html.black-grey {
+/* Classic dark (black/grey) */
+html.black-grey,
+:root[data-theme="black-grey"] {
   --background: #0a0a0a;
   --foreground: #e5e5e5;
+  --foreground-strong: #ffffff;
   --muted: #a3a3a3;
   --muted-strong: #737373;
   --surface: #141414;
   --surface-elevated: #1f1f1f;
+  --surface-glass: rgba(20, 20, 20, 0.6);
   --border-subtle: rgba(255, 255, 255, 0.06);
   --border-strong: rgba(255, 255, 255, 0.14);
   --accent: #3b82f6;
@@ -55,39 +67,52 @@ html.black-grey {
   --glow-secondary: rgba(6, 182, 212, 0.08);
 }
 
+/* Midnight */
+html.midnight,
+:root[data-theme="midnight"] {
+  --background: #0b1220;
+  --foreground: #cbd5e1;
+  --foreground-strong: #f1f5f9;
+  --muted: #94a3b8;
+  --muted-strong: #64748b;
+  --surface: #111a2c;
+  --surface-elevated: #182338;
+  --surface-glass: rgba(17, 26, 44, 0.6);
+  --border-subtle: rgba(148, 163, 184, 0.10);
+  --border-strong: rgba(148, 163, 184, 0.22);
+  --accent: #60a5fa;
+  --accent-soft: rgba(96, 165, 250, 0.15);
+  --accent-cyan: #22d3ee;
+  --glow-primary: rgba(96, 165, 250, 0.14);
+  --glow-secondary: rgba(34, 211, 238, 0.10);
+}
+
+/* ============================================================
+   BASE
+   ============================================================ */
+
 body {
   color: var(--foreground);
   background: var(--background);
   background-image:
-    radial-gradient(circle at 20% -10%, var(--glow-primary), transparent 40%),
-    radial-gradient(circle at 90% 10%, var(--glow-secondary), transparent 35%);
+    radial-gradient(circle at 18% -8%, var(--glow-primary), transparent 42%),
+    radial-gradient(circle at 88% 12%, var(--glow-secondary), transparent 38%);
   background-attachment: fixed;
   font-family: var(--font-sans), system-ui, -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
 }
 
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { opacity: 0.8; }
 
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--border-strong);
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--border-strong);
-  opacity: 0.8;
-}
+/* ============================================================
+   TAILWIND LAYER UTILITIES (legacy — kept for existing components)
+   ============================================================ */
 
 @layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
+  .text-balance { text-wrap: balance; }
 
   .surface-card {
     background: var(--surface);
@@ -119,9 +144,13 @@ body {
   }
 }
 
+/* ============================================================
+   ANIMATIONS
+   ============================================================ */
+
 @keyframes shimmer {
-  0% { background-position: -1000px 0; }
-  100% { background-position: 1000px 0; }
+  0%   { background-position: -1000px 0; }
+  100% { background-position:  1000px 0; }
 }
 
 .shimmer {
@@ -129,3 +158,888 @@ body {
   background-size: 1000px 100%;
   animation: shimmer 2s infinite;
 }
+
+@keyframes pulse-ring {
+  0%, 100% { box-shadow: 0 0 0 0 currentColor; opacity: 1; }
+  50%        { box-shadow: 0 0 0 6px transparent; opacity: 0.6; }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slide-from-right {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+/* ============================================================
+   TILE GRID
+   ============================================================ */
+
+.tile-grid {
+  display: grid;
+  gap: 16px;
+  grid-auto-rows: 88px;
+  grid-auto-flow: dense;
+}
+
+:root[data-density="compact"] .tile-grid,
+html[data-density="compact"] .tile-grid {
+  gap: 10px;
+  grid-auto-rows: 72px;
+}
+
+/* Grid lines in edit mode */
+:root[data-grid-lines="on"] .tile-grid-edit,
+html[data-grid-lines="on"] .tile-grid-edit {
+  background-image:
+    linear-gradient(var(--border-subtle) 1px, transparent 1px),
+    linear-gradient(90deg, var(--border-subtle) 1px, transparent 1px);
+  background-size: calc((100% - 80px) / 6) 88px;
+  border-radius: 8px;
+}
+
+/* ============================================================
+   TILES
+   ============================================================ */
+
+.tile {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--tile-radius, 14px);
+  overflow: hidden;
+  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+  min-width: 0;
+}
+
+.tile:hover { border-color: var(--border-strong); }
+
+.tile-edit-mode {
+  border-color: var(--border-strong);
+  border-style: dashed;
+  cursor: grab;
+}
+
+.tile-edit-mode:hover {
+  box-shadow: 0 8px 24px -12px rgba(0, 0, 0, 0.6);
+  transform: translateY(-1px);
+}
+
+.tile-dragging { opacity: 0.4; cursor: grabbing !important; }
+
+.tile-drag-over { border-color: var(--accent) !important; border-style: solid !important; }
+
+.drag-handle {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 2;
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  background: var(--surface-elevated);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  pointer-events: none;
+}
+
+.tile-inner {
+  padding: 14px 14px 12px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+:root[data-density="compact"] .tile-inner,
+html[data-density="compact"] .tile-inner {
+  padding: 10px 12px;
+}
+
+.tile-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.tile-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--foreground);
+  letter-spacing: -0.1px;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tile-title > span {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.tile-actions { display: flex; gap: 2px; }
+
+.tile-btn {
+  width: 24px;
+  height: 24px;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--muted-strong);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.tile-btn:hover { background: rgba(255, 255, 255, 0.06); color: var(--foreground); }
+.tile-btn-danger:hover { color: #EF5350; background: rgba(239, 83, 80, 0.10); }
+
+.tile-body { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+
+/* ============================================================
+   PILLS, CHIPS, BADGES
+   ============================================================ */
+
+.count-pill {
+  display: inline-flex;
+  padding: 2px 7px;
+  font-size: 10px;
+  font-weight: 600;
+  background: rgba(38, 139, 210, 0.18);
+  color: var(--accent);
+  border-radius: 999px;
+  letter-spacing: 0.3px;
+}
+
+.live-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(124, 179, 66, 0.10);
+  border: 1px solid rgba(124, 179, 66, 0.22);
+  font-size: 11px;
+  font-weight: 600;
+  color: #9CCC65;
+}
+
+.live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: #7CB342;
+  box-shadow: 0 0 0 4px rgba(124, 179, 66, 0.18);
+  animation: pulse-ring 2s ease-in-out infinite;
+}
+
+.datapoint-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--border-subtle);
+  margin-top: 8px;
+}
+
+.chip {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--surface-elevated);
+  color: var(--muted);
+  border: 1px solid var(--border-subtle);
+  font-size: 10px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.chip:hover { color: var(--foreground); border-color: var(--border-strong); }
+.chip-on { background: rgba(42, 161, 152, 0.15); color: var(--accent-cyan); border-color: var(--accent-cyan); }
+
+/* ============================================================
+   ADD-TILE SLOT
+   ============================================================ */
+
+.add-tile-slot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 2px dashed var(--border-strong);
+  color: var(--muted);
+  border-radius: var(--tile-radius, 14px);
+  transition: all 160ms ease;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.add-tile-slot:hover {
+  background: var(--surface);
+  border-color: var(--accent);
+  color: var(--foreground);
+}
+
+/* ============================================================
+   SERVICE GRID MINI CARDS
+   ============================================================ */
+
+.mini-service {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9px;
+  min-width: 0;
+}
+
+/* ============================================================
+   INCIDENT ROWS
+   ============================================================ */
+
+.incident-row {
+  display: flex;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-row:last-child { border-bottom: 0; }
+
+/* ============================================================
+   RSS ROWS
+   ============================================================ */
+
+.rss-row {
+  display: block;
+  text-decoration: none;
+  padding: 8px 10px;
+  border-radius: 7px;
+  border: 1px solid var(--border-subtle);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.rss-row:hover { border-color: var(--border-strong); background: rgba(255, 255, 255, 0.04); }
+
+/* ============================================================
+   STATUS MAP
+   ============================================================ */
+
+.map-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(147, 161, 161, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(147, 161, 161, 0.05) 1px, transparent 1px);
+  background-size: 12% 16%;
+}
+
+/* ============================================================
+   SLIDE-OVER
+   ============================================================ */
+
+.slideover-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+  animation: fade-in 200ms ease;
+}
+
+.slideover {
+  position: fixed;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 60;
+  width: 520px;
+  max-width: 100vw;
+  background: var(--surface);
+  border-left: 1px solid var(--border-strong);
+  display: flex;
+  flex-direction: column;
+  box-shadow: -20px 0 60px -10px rgba(0, 0, 0, 0.6);
+  animation: slide-from-right 280ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.slideover-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 20px 24px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.slideover-stepper {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 24px;
+  background: var(--surface-elevated);
+  border-bottom: 1px solid var(--border-subtle);
+  overflow-x: auto;
+}
+
+.step {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted-strong);
+}
+
+.step-num {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  font-weight: 700;
+  border: 1px solid var(--border-subtle);
+}
+
+.step-on { color: var(--foreground); }
+.step-on .step-num { background: var(--accent-cyan); color: #001f1d; border-color: transparent; }
+.step-current { background: var(--surface); }
+.step-current .step-num { background: var(--accent); color: white; }
+
+.slideover-body {
+  flex: 1;
+  padding: 20px 24px;
+  overflow-y: auto;
+}
+
+.field-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  margin-bottom: 6px;
+}
+
+.field-input {
+  width: 100%;
+  padding: 9px 12px;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9px;
+  color: var(--foreground);
+  font-size: 13px;
+  outline: 0;
+  font-family: inherit;
+}
+
+.field-input:focus { border-color: var(--accent); }
+.field-input::placeholder { color: var(--muted-strong); }
+.field-hint { font-size: 11px; color: var(--muted-strong); margin: 6px 0 0; }
+
+.separator {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--muted-strong);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+
+.separator::before, .separator::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-subtle);
+}
+
+.source-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+
+.source-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  text-align: left;
+  transition: all 140ms ease;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.source-card:hover { border-color: var(--accent); transform: translateY(-1px); }
+
+.source-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  background: var(--surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: var(--accent-cyan);
+  border: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+.preset-list { display: flex; flex-direction: column; gap: 4px; max-height: 320px; overflow-y: auto; }
+
+.preset-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.preset-row:hover { background: var(--surface-elevated); border-color: var(--border-subtle); }
+
+.preset-logo {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  color: white;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.kind-pill {
+  font-size: 9px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--surface-elevated);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.detect-card {
+  padding: 14px;
+  background: var(--surface-elevated);
+  border: 1px solid rgba(124, 179, 66, 0.30);
+  border-radius: 10px;
+}
+
+.detect-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #7CB342;
+  box-shadow: 0 0 0 4px rgba(124, 179, 66, 0.18);
+  animation: pulse-ring 2s ease-in-out infinite;
+  display: inline-block;
+}
+
+.seg {
+  display: inline-flex;
+  padding: 3px;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9px;
+}
+
+.seg button {
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--muted);
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.seg button:hover { color: var(--foreground); }
+.seg .seg-on, .seg button.seg-on { background: var(--surface); color: var(--foreground); font-weight: 600; }
+
+.check-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--foreground); }
+.check-row input { accent-color: var(--accent); }
+
+.slideover-footer-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 8px;
+}
+
+.confirm-card {
+  padding: 18px;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+}
+
+.kv { margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.kv > div { display: flex; justify-content: space-between; font-size: 12px; padding: 6px 0; border-top: 1px solid var(--border-subtle); }
+.kv > div:first-child { border-top: 0; }
+.kv dt { color: var(--muted); margin: 0; }
+.kv dd { color: var(--foreground); margin: 0; font-weight: 500; }
+
+/* ============================================================
+   ADD-TILE POPOVER
+   ============================================================ */
+
+.add-popover {
+  position: fixed;
+  z-index: 60;
+  top: 80px;
+  right: 28px;
+  width: 380px;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: 0 20px 60px -10px rgba(0, 0, 0, 0.5);
+  animation: fade-in 160ms ease;
+}
+
+.add-tile-card {
+  display: flex;
+  flex-direction: column;
+  padding: 10px 12px;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9px;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 140ms ease;
+}
+
+.add-tile-card:hover { border-color: var(--accent); transform: translateY(-1px); }
+
+.import-cta {
+  margin-top: 10px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-cyan));
+  color: white;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.import-cta:hover { filter: brightness(1.06); }
+
+/* ============================================================
+   TWEAKS PANEL (floating)
+   ============================================================ */
+
+.twk-panel {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 2147483646;
+  width: 280px;
+  max-height: calc(100vh - 32px);
+  display: flex;
+  flex-direction: column;
+  background: rgba(7, 54, 66, 0.92);
+  color: var(--foreground-strong);
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  font-size: 11.5px;
+  line-height: 1.4;
+  overflow: hidden;
+}
+
+:root[data-theme="black-grey"] .twk-panel,
+html.black-grey .twk-panel {
+  background: rgba(20, 20, 20, 0.92);
+}
+
+:root[data-theme="midnight"] .twk-panel,
+html.midnight .twk-panel {
+  background: rgba(17, 26, 44, 0.92);
+}
+
+:root[data-theme="solarized-light"] .twk-panel,
+html.solarized-light .twk-panel {
+  background: rgba(238, 232, 213, 0.92);
+  color: #073642;
+}
+
+.twk-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 8px 10px 14px;
+  cursor: move;
+  user-select: none;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.twk-hd b { font-size: 12px; font-weight: 600; letter-spacing: 0.01em; }
+
+.twk-x {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: inherit;
+}
+
+.twk-x:hover { background: rgba(255, 255, 255, 0.08); color: var(--foreground); }
+
+.twk-body {
+  padding: 2px 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+  min-height: 0;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+}
+
+.twk-sect {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted-strong);
+  padding: 10px 0 0;
+}
+
+.twk-sect:first-child { padding-top: 6px; }
+
+.twk-row { display: flex; flex-direction: column; gap: 5px; }
+.twk-row-h { flex-direction: row; align-items: center; justify-content: space-between; gap: 10px; }
+.twk-lbl { display: flex; justify-content: space-between; align-items: baseline; color: var(--muted); }
+.twk-lbl > span:first-child { font-weight: 500; color: var(--foreground); }
+.twk-val { color: var(--muted); font-variant-numeric: tabular-nums; }
+
+.twk-field {
+  appearance: none;
+  width: 100%;
+  height: 26px;
+  padding: 0 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  background: var(--surface-elevated);
+  color: var(--foreground);
+  font: inherit;
+  outline: none;
+}
+
+.twk-field:focus { border-color: var(--accent); }
+
+select.twk-field {
+  padding-right: 22px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='rgba(147,161,161,0.7)' d='M0 0h10L5 6z'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+}
+
+.twk-slider {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  height: 4px;
+  margin: 6px 0;
+  border-radius: 999px;
+  background: var(--border-strong);
+  outline: none;
+  cursor: pointer;
+}
+
+.twk-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+}
+
+.twk-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: none;
+  cursor: pointer;
+}
+
+.twk-seg {
+  position: relative;
+  display: flex;
+  padding: 2px;
+  border-radius: 8px;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  user-select: none;
+}
+
+.twk-seg button {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  min-height: 22px;
+  border-radius: 6px;
+  cursor: pointer;
+  padding: 4px 6px;
+  line-height: 1.2;
+}
+
+.twk-seg button:hover { color: var(--foreground); }
+.twk-seg button[data-on="true"], .twk-seg button.seg-on {
+  background: var(--surface);
+  color: var(--foreground);
+  font-weight: 600;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.twk-toggle {
+  position: relative;
+  width: 32px;
+  height: 18px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--border-strong);
+  transition: background 0.15s;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.twk-toggle[data-on="true"] { background: #34c759; }
+
+.twk-toggle i {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  transition: transform 0.15s;
+  pointer-events: none;
+  display: block;
+}
+
+.twk-toggle[data-on="true"] i { transform: translateX(14px); }
+
+.twk-swatch {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 56px;
+  height: 22px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  flex-shrink: 0;
+}
+
+.twk-swatch::-webkit-color-swatch-wrapper { padding: 0; }
+.twk-swatch::-webkit-color-swatch { border: 0; border-radius: 5px; }
+
+.twk-chips { display: flex; gap: 6px; }
+
+.twk-chip {
+  position: relative;
+  appearance: none;
+  flex: 1;
+  min-width: 0;
+  height: 28px;
+  padding: 0 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.12s ease;
+  background: var(--surface-elevated);
+  color: var(--muted);
+  font: inherit;
+  font-size: 11px;
+}
+
+.twk-chip:hover { border-color: var(--border-strong); color: var(--foreground); }
+.twk-chip[data-on="true"] { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); font-weight: 600; }
+
+/* ============================================================
+   BOARD SHELL BUTTONS (used in Dashboard/Header)
+   ============================================================ */
+
+.board-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 9px;
+  background: var(--surface);
+  color: var(--foreground);
+  border: 1px solid var(--border-subtle);
+  font-size: 12.5px;
+  font-weight: 500;
+  transition: all 120ms ease;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.board-btn:hover { border-color: var(--border-strong); background: var(--surface-elevated); }
+.board-btn-primary { background: var(--accent); color: white; border-color: transparent; }
+.board-btn-primary:hover { filter: brightness(1.08); }
+.board-btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+.board-btn-edit-on { background: var(--accent-cyan); color: #001f1d; border-color: transparent; font-weight: 600; }
+.board-btn-edit-on:hover { filter: brightness(1.08); }

--- a/src/app/sources/page.tsx
+++ b/src/app/sources/page.tsx
@@ -1,0 +1,11 @@
+import SourcesView from '@/components/SourcesView';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Sources · Outage Map',
+};
+
+export default function SourcesPage() {
+  return <SourcesView />;
+}

--- a/src/components/AddTilePopover.tsx
+++ b/src/components/AddTilePopover.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { TileType } from '@/hooks/useBoard';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onAdd: (type: TileType) => void;
+  onOpenImport: () => void;
+}
+
+const TILES: { type: TileType; name: string; desc: string }[] = [
+  { type: 'stat',          name: 'Stat',          desc: 'Single metric: uptime, MTTR, incidents…' },
+  { type: 'service-watch', name: 'Service Watch',  desc: 'Single service with sparkline + datapoints' },
+  { type: 'service-grid',  name: 'Service Grid',   desc: 'Status of many services at a glance' },
+  { type: 'incident-feed', name: 'Incident Feed',  desc: 'Recent + active incidents timeline' },
+  { type: 'uptime-chart',  name: 'Uptime Chart',   desc: '30-day uptime history for one service' },
+  { type: 'status-map',    name: 'Heat Map',       desc: 'Geographic outage report density' },
+  { type: 'rss',           name: 'RSS Feed',       desc: 'Engineering blogs, release notes' },
+];
+
+export default function AddTilePopover({ open, onClose, onAdd, onOpenImport }: Props) {
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="slideover-backdrop" onClick={onClose} />
+      <div className="add-popover">
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+          <h3 style={{ margin: 0, fontSize: 14, fontWeight: 700, color: 'var(--foreground)' }}>Add a tile</h3>
+          <button
+            style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 28, height: 28, background: 'transparent', border: 0, color: 'var(--muted)', borderRadius: 7, cursor: 'pointer' }}
+            onClick={onClose}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+          {TILES.map((t) => (
+            <button
+              key={t.type}
+              className="add-tile-card"
+              onClick={() => { onAdd(t.type); onClose(); }}
+            >
+              <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--foreground)' }}>{t.name}</div>
+              <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 4 }}>{t.desc}</div>
+            </button>
+          ))}
+        </div>
+
+        <button
+          className="import-cta"
+          onClick={() => { onClose(); onOpenImport(); }}
+        >
+          <span style={{ fontSize: 18 }}>＋</span>
+          <div style={{ textAlign: 'left' }}>
+            <div style={{ fontSize: 13, fontWeight: 600 }}>Import a custom service</div>
+            <div style={{ fontSize: 11, opacity: 0.8 }}>Paste an RSS feed, Statuspage, or HTTP endpoint</div>
+          </div>
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,313 +1,181 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useMemo, useState } from 'react';
 import { useServiceStatus, useIncidents, useHistory } from '@/hooks/useStatus';
 import { usePreferences } from '@/hooks/usePreferences';
-import { SERVICES } from '@/lib/services';
-import ServiceCard from './ServiceCard';
-import IncidentFeed from './IncidentFeed';
-import OutageChart from './OutageChart';
-import ServiceDetailModal from './ServiceDetailModal';
-import PageHeader from './ui/PageHeader';
-import StatTile from './ui/StatTile';
-import Card from './ui/Card';
+import { useBoard } from '@/hooks/useBoard';
+import { useTweaks } from '@/hooks/useTweaks';
+import { useTheme } from './ThemeProvider';
 import { formatRelativeTime } from '@/lib/format';
-
-type StatusFilter = 'all' | 'operational' | 'issues';
-
-function isStatusFilter(v: string | null): v is StatusFilter {
-  return v === 'all' || v === 'operational' || v === 'issues';
-}
+import type { LiveData } from './tiles/types';
+import type { TileType } from '@/hooks/useBoard';
+import TileGrid from './TileGrid';
+import ImportSlideOver from './ImportSlideOver';
+import AddTilePopover from './AddTilePopover';
+import TweaksPanel from './TweaksPanel';
 
 export default function Dashboard() {
-  const prefs = usePreferences();
+  const { theme, setTheme } = useTheme();
+  const [tweaks, setTweak] = useTweaks();
+  const [board, actions]   = useBoard();
+  const prefs              = usePreferences();
+
+  const [editing, setEditing]       = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
+  const [addOpen, setAddOpen]       = useState(false);
+  const [tweaksOpen, setTweaksOpen] = useState(false);
+
   const refreshMs = prefs.refreshInterval * 1000;
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const { data: statusData, error: statusError, isLoading: statusLoading } = useServiceStatus(refreshMs);
-  const { data: incidentData } = useIncidents(7);
-  const { data: historyData } = useHistory(30);
-  const [selectedService, setSelectedService] = useState<string | null>(null);
+  const { data: statusData, isLoading } = useServiceStatus(refreshMs);
+  const { data: incidentData }          = useIncidents(7);
+  const { data: historyData }           = useHistory(30);
 
-  const initialFilter = isStatusFilter(searchParams.get('filter')) ? (searchParams.get('filter') as StatusFilter) : 'all';
-  const initialSearch = searchParams.get('q') ?? '';
-  const [search, setSearch] = useState(initialSearch);
-  const [filter, setFilter] = useState<StatusFilter>(initialFilter);
-
-  // Sync filter + search to the URL so links are shareable.
-  useEffect(() => {
-    const params = new URLSearchParams(Array.from(searchParams.entries()));
-    if (filter === 'all') params.delete('filter'); else params.set('filter', filter);
-    if (!search) params.delete('q'); else params.set('q', search);
-    const next = params.toString();
-    const current = searchParams.toString();
-    if (next !== current) {
-      router.replace(next ? `?${next}` : '?', { scroll: false });
-    }
-    // We deliberately depend on filter/search only — re-syncing on every searchParams
-    // change would create a feedback loop with the router.replace above.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filter, search]);
-
-  const services = useMemo(() => statusData?.services || [], [statusData]);
-  const incidents = useMemo(() => incidentData?.incidents || [], [incidentData]);
-  const history = useMemo(() => historyData?.history || {}, [historyData]);
-  const pinnedSet = useMemo(() => new Set(prefs.pinnedServices), [prefs.pinnedServices]);
+  const live: LiveData = useMemo(() => ({
+    services:    statusData?.services    ?? [],
+    incidents:   incidentData?.incidents ?? [],
+    history:     historyData?.history    ?? {},
+    isLoading,
+    lastUpdated: statusData?.lastUpdated,
+  }), [statusData, incidentData, historyData, isLoading]);
 
   const stats = useMemo(() => {
-    const total = services.length || SERVICES.length;
-    const operational = services.filter((s) => s.overallStatus === 'operational').length;
-    const degraded = services.filter((s) => s.overallStatus === 'degraded').length;
-    const outage = services.filter(
-      (s) => s.overallStatus === 'major_outage' || s.overallStatus === 'down'
-    ).length;
-    const reports = services.reduce((sum, s) => sum + (s.downdetectorReports || 0), 0);
-    const activeIncidents = incidents.filter((i) => i.status !== 'resolved').length;
-    const uptime = total > 0 ? ((operational / total) * 100).toFixed(1) : '0.0';
-    return { total, operational, degraded, outage, reports, activeIncidents, uptime };
-  }, [services, incidents]);
+    const total       = live.services.length;
+    const operational = live.services.filter((s) => s.overallStatus === 'operational').length;
+    const active      = live.incidents.filter((i) => i.status !== 'resolved').length;
+    return { total, operational, active };
+  }, [live]);
 
-  const filteredServices = useMemo(() => {
-    const matched = services.filter((s) => {
-      if (search && !s.name.toLowerCase().includes(search.toLowerCase())) return false;
-      if (filter === 'operational' && s.overallStatus !== 'operational') return false;
-      if (filter === 'issues' && s.overallStatus === 'operational') return false;
-      return true;
+  const handleAddImported = (svc: { type: string; name: string; url: string; refresh: number; color: string }) => {
+    actions.addTile('statuspage', {
+      name:  svc.name,
+      color: svc.color,
+      url:   svc.url,
     });
-    if (pinnedSet.size === 0) return matched;
-    // Stable partition: pinned services first, others after, order within each group preserved.
-    return [
-      ...matched.filter((s) => pinnedSet.has(s.slug)),
-      ...matched.filter((s) => !pinnedSet.has(s.slug)),
-    ];
-  }, [services, search, filter, pinnedSet]);
+  };
 
-  if (statusLoading) {
-    return (
-      <div className="space-y-8" aria-busy="true">
-        <div className="h-20 surface-card rounded-2xl animate-pulse" />
-        <section className="grid grid-cols-2 lg:grid-cols-4 gap-3 lg:gap-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="h-24 surface-card rounded-2xl animate-pulse" />
-          ))}
-        </section>
+  return (
+    <div className="space-y-6">
+      {/* ── Board toolbar ── */}
+      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+        {/* Left: headline */}
+        <div className="flex-1 min-w-0">
+          <div style={{ fontSize: 11, color: 'var(--muted-strong)', textTransform: 'uppercase', letterSpacing: 1.5, fontWeight: 600 }}>
+            Live overview
+          </div>
+          <h1 style={{ margin: '4px 0 4px', fontSize: 24, fontWeight: 700, color: 'var(--foreground)', letterSpacing: -0.4 }}>
+            My outage board
+          </h1>
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--muted)' }}>
+            {stats.operational}/{stats.total} services healthy
+            {' · '}
+            {stats.active} active incident{stats.active !== 1 ? 's' : ''}
+            {statusData?.lastUpdated
+              ? ` · Updated ${formatRelativeTime(statusData.lastUpdated)}`
+              : ''}
+          </p>
+        </div>
+
+        {/* Right: actions + live pill */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <div className="live-pill">
+            <span className="live-dot" />
+            <span>Auto-refresh · {prefs.refreshInterval < 60 ? `${prefs.refreshInterval}s` : `${prefs.refreshInterval / 60}m`}</span>
+          </div>
+
+          <button
+            className={`board-btn ${editing ? 'board-btn-edit-on' : ''}`}
+            onClick={() => setEditing((e) => !e)}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M12 20h9M16.5 3.5a2.121 2.121 0 113 3L7 19l-4 1 1-4L16.5 3.5z" />
+            </svg>
+            {editing ? 'Done editing' : 'Edit board'}
+          </button>
+
+          <button className="board-btn" onClick={() => setAddOpen(true)}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+            Add tile
+          </button>
+
+          <button className="board-btn board-btn-primary" onClick={() => setImportOpen(true)}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
+            </svg>
+            Import
+          </button>
+
+          <button
+            className="board-btn"
+            onClick={() => setTweaksOpen((o) => !o)}
+            style={tweaksOpen ? { borderColor: 'var(--accent)', color: 'var(--accent)' } : {}}
+            title="Tweaks"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M10.5 6h9.75M10.5 6a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M3.75 6H7.5M4.5 12h9.75M4.5 12a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M14.25 12h5.25M4.5 18h9.75M4.5 18a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M14.25 18h5.25" />
+            </svg>
+            Tweaks
+          </button>
+        </div>
+      </div>
+
+      {/* ── Tile grid ── */}
+      {isLoading && board.length === 0 ? (
         <div
-          className={
-            prefs.compactCards
-              ? 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3'
-              : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4'
-          }
+          className="tile-grid"
+          style={{ gridTemplateColumns: 'repeat(6,1fr)' }}
         >
-          {Array.from({ length: SERVICES.length }).map((_, i) => (
+          {[
+            { col: 1, row: 2 }, { col: 1, row: 2 }, { col: 1, row: 2 }, { col: 1, row: 2 },
+            { col: 2, row: 2 }, { col: 2, row: 2 },
+            { col: 2, row: 3 },
+            { col: 4, row: 2 },
+            { col: 2, row: 2 },
+          ].map((s, i) => (
             <div
               key={i}
-              className={`surface-card rounded-2xl animate-pulse ${prefs.compactCards ? 'h-24' : 'h-44'}`}
+              className="tile animate-pulse"
+              style={{ gridColumn: `span ${s.col}`, gridRow: `span ${s.row}` }}
             />
           ))}
         </div>
-        <span className="sr-only">Loading dashboard…</span>
-      </div>
-    );
-  }
-
-  if (statusError) {
-    return (
-      <div className="min-h-[60vh] flex items-center justify-center">
-        <Card className="text-center max-w-md">
-          <div className="w-14 h-14 bg-red-500/10 rounded-full flex items-center justify-center mx-auto mb-4">
-            <svg className="w-7 h-7 text-red-400" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
-            </svg>
-          </div>
-          <h2 className="text-lg font-semibold tracking-tight text-foreground mb-1">Unable to load dashboard</h2>
-          <p className="text-muted text-sm mb-4">
-            Could not fetch service statuses. The polling service may not have run yet.
-          </p>
-          <button
-            onClick={() => window.location.reload()}
-            className="px-4 py-2 bg-accent hover:opacity-90 text-white text-sm rounded-lg transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-          >
-            Retry
-          </button>
-        </Card>
-      </div>
-    );
-  }
-
-  const selected = services.find((s) => s.slug === selectedService);
-
-  return (
-    <div className="space-y-8">
-      <PageHeader
-        eyebrow="Live Overview"
-        title="Status command center"
-        description={`Monitoring ${stats.total} enterprise services. Last updated ${formatRelativeTime(statusData?.lastUpdated)}.`}
-        actions={
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20">
-            <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
-            <span className="text-xs font-medium text-emerald-300">
-              Auto-refresh · {prefs.refreshInterval < 60 ? `${prefs.refreshInterval}s` : `${prefs.refreshInterval / 60}m`}
-            </span>
-          </div>
-        }
-      />
-
-      <section className="grid grid-cols-2 lg:grid-cols-4 gap-3 lg:gap-4">
-        <StatTile
-          label="Overall Uptime"
-          value={`${stats.uptime}%`}
-          accent="green"
-          hint={`${stats.operational}/${stats.total} services healthy`}
-          icon={
-            <svg className="w-5 h-5 text-emerald-300" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          }
-        />
-        <StatTile
-          label="Active Incidents"
-          value={stats.activeIncidents}
-          accent={stats.activeIncidents > 0 ? 'amber' : 'cyan'}
-          hint={`${incidents.length} in last 7 days`}
-          icon={
-            <svg className="w-5 h-5 text-amber-300" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          }
-        />
-        <StatTile
-          label="Services with issues"
-          value={stats.degraded + stats.outage}
-          accent={stats.outage > 0 ? 'red' : stats.degraded > 0 ? 'amber' : 'cyan'}
-          hint={`${stats.outage} major · ${stats.degraded} minor`}
-          icon={
-            <svg className="w-5 h-5 text-cyan-300" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
-            </svg>
-          }
-        />
-        {prefs.showDowndetector ? (
-          <StatTile
-            label="DD Reports (now)"
-            value={stats.reports.toLocaleString()}
-            accent="indigo"
-            hint="Aggregated across services"
-            icon={
-              <svg className="w-5 h-5 text-indigo-300" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
-              </svg>
-            }
-          />
-        ) : (
-          <StatTile
-            label="Services Tracked"
-            value={stats.total}
-            accent="indigo"
-            hint="Total monitored services"
-            icon={
-              <svg className="w-5 h-5 text-indigo-300" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25A2.25 2.25 0 018.25 10.5H6A2.25 2.25 0 013.75 8.25V6zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25A2.25 2.25 0 0113.5 8.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 018.25 20.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
-              </svg>
-            }
-          />
-        )}
-      </section>
-
-      <section>
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
-          <h2 className="text-base font-semibold tracking-tight text-foreground flex items-center gap-2">
-            <span className="w-1 h-5 rounded-full bg-accent-cyan" />
-            Service Status
-          </h2>
-          <div className="flex items-center gap-2">
-            <div className="relative">
-              <label className="sr-only" htmlFor="dashboard-service-search">Search services</label>
-              <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-strong" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-              </svg>
-              <input
-                id="dashboard-service-search"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search services…"
-                className="w-44 sm:w-56 pl-9 pr-3 py-1.5 rounded-md bg-white/5 border border-subtle text-sm text-foreground placeholder:text-muted-strong focus:outline-none focus:border-accent/50 focus:bg-white/10 transition-colors"
-              />
-            </div>
-            <div role="tablist" aria-label="Service filter" className="flex items-center gap-0.5 p-1 rounded-lg bg-surface border border-subtle">
-              {(['all', 'operational', 'issues'] as const).map((f) => (
-                <button
-                  key={f}
-                  role="tab"
-                  aria-selected={filter === f}
-                  onClick={() => setFilter(f)}
-                  className={`px-3 py-1 text-xs rounded-md transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                    filter === f
-                      ? 'bg-surface-elevated text-foreground font-semibold shadow-sm'
-                      : 'font-medium text-muted hover:text-foreground'
-                  }`}
-                >
-                  {f === 'all' ? 'All' : f === 'operational' ? 'OK' : 'Issues'}
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
-        {filteredServices.length === 0 ? (
-          <Card className="text-center text-sm text-muted">
-            No services match your filters.
-          </Card>
-        ) : (
-          <div
-            className={
-              prefs.compactCards
-                ? 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3'
-                : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4'
-            }
-          >
-            {filteredServices.map((service) => (
-              <ServiceCard
-                key={service.slug}
-                service={service}
-                onClick={() => setSelectedService(service.slug)}
-                compact={prefs.compactCards}
-                showDowndetector={prefs.showDowndetector}
-              />
-            ))}
-          </div>
-        )}
-      </section>
-
-      <section className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-        <div className="xl:col-span-2 space-y-4">
-          <h2 className="text-base font-semibold tracking-tight text-foreground flex items-center gap-2">
-            <span className="w-1 h-5 rounded-full bg-purple-400" />
-            30-Day Outage History
-          </h2>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            {SERVICES.map((service) => (
-              <OutageChart
-                key={service.slug}
-                serviceName={service.name}
-                serviceColor={service.color}
-                data={history[service.slug] || []}
-              />
-            ))}
-          </div>
-        </div>
-        <div className="space-y-4">
-          <IncidentFeed incidents={incidents} />
-        </div>
-      </section>
-
-      {selected && (
-        <ServiceDetailModal
-          service={selected}
-          history={history[selected.slug] || []}
-          incidents={incidents}
-          onClose={() => setSelectedService(null)}
+      ) : (
+        <TileGrid
+          board={board}
+          editing={editing}
+          live={live}
+          onUpdateTile={actions.updateTile}
+          onRemoveTile={actions.removeTile}
+          onCycleResize={actions.cycleResize}
+          onToggleDataPoint={actions.toggleDataPoint}
+          onSwapTiles={actions.swapTiles}
+          onAddClick={() => setAddOpen(true)}
         />
       )}
+
+      {/* ── Overlays ── */}
+      <ImportSlideOver
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onAdd={handleAddImported}
+      />
+
+      <AddTilePopover
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        onAdd={(type: TileType) => actions.addTile(type)}
+        onOpenImport={() => { setAddOpen(false); setImportOpen(true); }}
+      />
+
+      <TweaksPanel
+        open={tweaksOpen}
+        onClose={() => setTweaksOpen(false)}
+        tweaks={tweaks}
+        setTweak={setTweak}
+        theme={theme}
+        setTheme={setTheme}
+      />
     </div>
   );
 }

--- a/src/components/ImportSlideOver.tsx
+++ b/src/components/ImportSlideOver.tsx
@@ -1,0 +1,342 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface ImportedService {
+  type: string;
+  name: string;
+  url: string;
+  refresh: number;
+  color: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onAdd: (svc: ImportedService) => void;
+}
+
+const PRESETS = [
+  { id: 'sp.atlassian', name: 'Atlassian Statuspage', kind: 'statuspage', url: 'https://status.atlassian.com',  logo: '#0052CC', desc: 'Jira, Confluence, Bitbucket' },
+  { id: 'sp.github',    name: 'GitHub',               kind: 'statuspage', url: 'https://www.githubstatus.com',  logo: '#24292F', desc: 'Repository, Actions, Codespaces' },
+  { id: 'sp.openai',    name: 'OpenAI',               kind: 'statuspage', url: 'https://status.openai.com',     logo: '#10A37F', desc: 'API, ChatGPT, Playground' },
+  { id: 'sp.stripe',    name: 'Stripe',               kind: 'statuspage', url: 'https://status.stripe.com',     logo: '#635BFF', desc: 'Payments, Dashboard, Webhooks' },
+  { id: 'sp.discord',   name: 'Discord',              kind: 'statuspage', url: 'https://discordstatus.com',     logo: '#5865F2', desc: 'API, voice, gateway' },
+  { id: 'sp.shopify',   name: 'Shopify',              kind: 'statuspage', url: 'https://www.shopifystatus.com', logo: '#96BF48', desc: 'Admin, Checkout, Storefront' },
+  { id: 'rss.hn',       name: 'Hacker News',          kind: 'rss',        url: 'https://hnrss.org/frontpage',   logo: '#FF6600', desc: 'Front page RSS feed' },
+  { id: 'rss.aws',      name: "AWS What's New",       kind: 'rss',        url: 'https://aws.amazon.com/new/feed/', logo: '#FF9900', desc: 'Product launches and updates' },
+];
+
+function detect(u: string): { kind: string; name: string; color?: string } | null {
+  if (!u) return null;
+  if (u.includes('status.') || u.includes('statuspage')) return { kind: 'statuspage', name: u.replace(/https?:\/\//, '').split('/')[0] };
+  if (u.includes('rss') || u.includes('feed') || u.endsWith('.xml') || u.includes('atom')) return { kind: 'rss', name: u.replace(/https?:\/\//, '').split('/')[0] };
+  if (u.includes('github')) return { kind: 'github', name: 'GitHub Status' };
+  if (u.includes('aws.amazon')) return { kind: 'aws', name: 'AWS Health' };
+  if (u.startsWith('http')) return { kind: 'http', name: u.replace(/https?:\/\//, '').split('/')[0] };
+  return null;
+}
+
+const STATUS_COLORS: Record<string, { dot: string; text: string; label: string }> = {
+  operational: { dot: '#7CB342', text: '#9CCC65', label: 'Operational' },
+  degraded:    { dot: '#F0C419', text: '#FFD54F', label: 'Degraded'    },
+};
+
+export default function ImportSlideOver({ open, onClose, onAdd }: Props) {
+  const [step, setStep]         = useState(0);
+  const [kind, setKind]         = useState('auto');
+  const [url, setUrl]           = useState('');
+  const [detected, setDetected] = useState<{ kind: string; name: string; color?: string } | null>(null);
+  const [name, setName]         = useState('');
+  const [refresh, setRefresh]   = useState(60);
+  const [search, setSearch]     = useState('');
+
+  useEffect(() => {
+    if (!open) { setStep(0); setKind('auto'); setUrl(''); setDetected(null); setName(''); setSearch(''); }
+  }, [open]);
+
+  useEffect(() => {
+    if (step === 1) {
+      const d = detect(url);
+      setDetected(d);
+      if (d && !name) setName(d.name);
+    }
+  }, [url, step]);
+
+  const usePreset = (p: (typeof PRESETS)[0]) => {
+    setUrl(p.url);
+    setKind(p.kind);
+    setName(p.name);
+    setDetected({ kind: p.kind, name: p.name, color: p.logo });
+    setStep(2);
+  };
+
+  const filteredPresets = PRESETS.filter(
+    (p) => !search || p.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const finish = () => {
+    onAdd({
+      type: detected?.kind === 'rss' ? 'rss' : 'statuspage',
+      name: name || detected?.name || 'New service',
+      url,
+      refresh,
+      color: detected?.color || '#268bd2',
+    });
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="slideover-backdrop" onClick={onClose} />
+      <aside className="slideover">
+        {/* Header */}
+        <div className="slideover-header">
+          <div>
+            <div style={{ fontSize: 11, color: 'var(--muted-strong)', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 4 }}>
+              Add data source
+            </div>
+            <h2 style={{ margin: 0, fontSize: 20, fontWeight: 700, color: 'var(--foreground)', letterSpacing: -0.2 }}>
+              Import a service
+            </h2>
+          </div>
+          <button
+            style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 30, height: 30, background: 'transparent', border: 0, color: 'var(--muted)', borderRadius: 8, cursor: 'pointer' }}
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Stepper */}
+        <div className="slideover-stepper">
+          {['Source', 'Connect', 'Configure', 'Confirm'].map((label, i) => (
+            <div
+              key={i}
+              className={`step ${step >= i ? 'step-on' : ''} ${step === i ? 'step-current' : ''}`}
+            >
+              <span className="step-num">{step > i ? '✓' : i + 1}</span>
+              <span>{label}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Body */}
+        <div className="slideover-body">
+          {/* Step 0: Source pick */}
+          {step === 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div>
+                <label className="field-label">Quick add — paste any URL</label>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <input
+                    className="field-input"
+                    placeholder="https://status.openai.com  ·  https://hnrss.org/frontpage"
+                    value={url}
+                    onChange={(e) => setUrl(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && url && setStep(1)}
+                  />
+                  <button className="board-btn board-btn-primary" disabled={!url} onClick={() => setStep(1)}>
+                    Detect →
+                  </button>
+                </div>
+                <p className="field-hint">We&apos;ll auto-detect Statuspage.io, RSS/Atom, and known vendors.</p>
+              </div>
+
+              <div className="separator"><span>or pick a source type</span></div>
+
+              <div className="source-grid">
+                {[
+                  { k: 'statuspage', name: 'Statuspage.io', desc: 'Hosted status pages', icon: '◐' },
+                  { k: 'rss',        name: 'RSS / Atom',    desc: 'Any blog or feed URL', icon: '📡' },
+                  { k: 'http',       name: 'HTTP probe',    desc: 'Custom endpoint health', icon: '⊹' },
+                  { k: 'github',     name: 'GitHub Status', desc: 'githubstatus.com', icon: 'GH' },
+                ].map((s) => (
+                  <button key={s.k} className="source-card" onClick={() => { setKind(s.k); setStep(1); }}>
+                    <div className="source-icon">{s.icon}</div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--foreground)' }}>{s.name}</div>
+                      <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 2 }}>{s.desc}</div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+
+              <div className="separator"><span>or browse the catalog</span></div>
+
+              <input
+                className="field-input"
+                placeholder="Search presets…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+
+              <div className="preset-list">
+                {filteredPresets.map((p) => (
+                  <button key={p.id} className="preset-row" onClick={() => usePreset(p)}>
+                    <div className="preset-logo" style={{ background: p.logo }}>{p.name.charAt(0)}</div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--foreground)' }}>{p.name}</div>
+                      <div style={{ fontSize: 11, color: 'var(--muted)' }}>{p.desc}</div>
+                    </div>
+                    <span className="kind-pill">{p.kind}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Step 1: Connect */}
+          {step === 1 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div>
+                <label className="field-label">Feed or status page URL</label>
+                <input
+                  className="field-input"
+                  placeholder="https://…"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  autoFocus
+                />
+              </div>
+
+              {detected ? (
+                <div className="detect-card">
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+                    <span className="detect-pulse" />
+                    <span style={{ fontSize: 12, color: '#7CB342', fontWeight: 600 }}>
+                      Connected · {detected.kind.toUpperCase()}
+                    </span>
+                  </div>
+                  <div style={{ fontSize: 13, color: 'var(--foreground)', marginBottom: 8 }}>Live preview</div>
+                  {detected.kind === 'rss' ? (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                      {['Latest article from the feed…', 'Second most recent item', 'Third item shows here'].map((t, i) => (
+                        <div key={i} style={{ fontSize: 12, color: 'var(--muted)', padding: '4px 0', borderBottom: i < 2 ? '1px solid var(--border-subtle)' : 'none' }}>
+                          {t}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                      {[['API', 'operational'], ['Dashboard', 'operational'], ['Webhooks', 'degraded']].map(([n, s], i) => {
+                        const sc = STATUS_COLORS[s] ?? STATUS_COLORS.operational;
+                        return (
+                          <div key={i} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, padding: '4px 0' }}>
+                            <span style={{ color: 'var(--foreground)' }}>{n}</span>
+                            <span style={{ color: sc.text, display: 'flex', alignItems: 'center', gap: 6 }}>
+                              <span style={{ width: 6, height: 6, borderRadius: 999, background: sc.dot, display: 'inline-block' }} />
+                              {sc.label}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="detect-card" style={{ borderStyle: 'dashed' }}>
+                  <div style={{ fontSize: 12, color: 'var(--muted)' }}>Enter a URL above to auto-detect the source.</div>
+                </div>
+              )}
+
+              <div className="slideover-footer-actions">
+                <button className="board-btn" onClick={() => setStep(0)}>← Back</button>
+                <button className="board-btn board-btn-primary" disabled={!detected} onClick={() => setStep(2)}>
+                  Continue →
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Step 2: Configure */}
+          {step === 2 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div>
+                <label className="field-label">Display name</label>
+                <input className="field-input" value={name} onChange={(e) => setName(e.target.value)} />
+              </div>
+              <div>
+                <label className="field-label">Refresh interval</label>
+                <div className="seg">
+                  {[30, 60, 300, 900].map((v) => (
+                    <button
+                      key={v}
+                      className={refresh === v ? 'seg-on' : ''}
+                      onClick={() => setRefresh(v)}
+                    >
+                      {v < 60 ? `${v}s` : `${v / 60}m`}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <label className="field-label">Default tile type</label>
+                <div className="seg">
+                  <button className="seg-on">
+                    {detected?.kind === 'rss' ? 'Feed reader' : 'Component list'}
+                  </button>
+                  <button>Compact card</button>
+                  <button>Stat tile</button>
+                </div>
+              </div>
+              <div>
+                <label className="field-label">Alert when</label>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  <label className="check-row"><input type="checkbox" defaultChecked /> Any component reports a major outage</label>
+                  <label className="check-row"><input type="checkbox" defaultChecked /> A new incident is posted</label>
+                  <label className="check-row"><input type="checkbox" /> Components stay degraded for 10+ minutes</label>
+                </div>
+              </div>
+              <div className="slideover-footer-actions">
+                <button className="board-btn" onClick={() => setStep(1)}>← Back</button>
+                <button className="board-btn board-btn-primary" onClick={() => setStep(3)}>Continue →</button>
+              </div>
+            </div>
+          )}
+
+          {/* Step 3: Confirm */}
+          {step === 3 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div className="confirm-card">
+                <div style={{ fontSize: 11, color: 'var(--muted-strong)', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 8 }}>
+                  Ready to add
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+                  <div
+                    style={{
+                      width: 40, height: 40, borderRadius: 10,
+                      background: detected?.color || '#268bd2',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      color: 'white', fontWeight: 700,
+                    }}
+                  >
+                    {(name || 'N').charAt(0)}
+                  </div>
+                  <div>
+                    <div style={{ fontSize: 16, fontWeight: 700, color: 'var(--foreground)' }}>{name}</div>
+                    <div style={{ fontSize: 11, color: 'var(--muted)', wordBreak: 'break-all' }}>{url}</div>
+                  </div>
+                </div>
+                <dl className="kv">
+                  <div><dt>Source type</dt><dd>{detected?.kind?.toUpperCase()}</dd></div>
+                  <div><dt>Refresh</dt><dd>every {refresh < 60 ? `${refresh}s` : `${refresh / 60}m`}</dd></div>
+                  <div><dt>Tile will appear</dt><dd>at top of your board</dd></div>
+                </dl>
+              </div>
+              <div className="slideover-footer-actions">
+                <button className="board-btn" onClick={() => setStep(2)}>← Back</button>
+                <button className="board-btn board-btn-primary" onClick={finish}>+ Add to dashboard</button>
+              </div>
+            </div>
+          )}
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -8,6 +8,7 @@ const ITEMS = [
   { href: '/analytics', label: 'Analytics' },
   { href: '/map', label: 'Map' },
   { href: '/alerts', label: 'Alerts' },
+  { href: '/sources', label: 'Sources' },
   { href: '/settings', label: 'Settings' },
 ];
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,7 +17,7 @@ const NAV_ITEMS: NavItem[] = [
   {
     href: '/',
     label: 'Overview',
-    description: 'Live status of every service',
+    description: 'Your modular board',
     icon: (
       <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25A2.25 2.25 0 018.25 10.5H6A2.25 2.25 0 013.75 8.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 018.25 20.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6A2.25 2.25 0 0115.75 3.75H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25A2.25 2.25 0 0113.5 8.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
@@ -36,8 +36,8 @@ const NAV_ITEMS: NavItem[] = [
   },
   {
     href: '/map',
-    label: 'Outage Map',
-    description: 'Geographic report density',
+    label: 'Heat Map',
+    description: 'Geographic density',
     icon: (
       <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" d="M9 6.75V15m0-8.25l-3.388-1.694a.75.75 0 00-1.087.671v9.795a.75.75 0 00.415.671L9 18m0-11.25l6 3M9 18l6-3m0 0l3.388 1.694a.75.75 0 001.087-.671V6.228a.75.75 0 00-.415-.67L15 3.75M15 15V6.75" />
@@ -47,10 +47,20 @@ const NAV_ITEMS: NavItem[] = [
   {
     href: '/alerts',
     label: 'Alerts',
-    description: 'Subscriptions & rules',
+    description: 'Rules & subscriptions',
     icon: (
       <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
+      </svg>
+    ),
+  },
+  {
+    href: '/sources',
+    label: 'Sources',
+    description: 'Imported services',
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.6} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4 11a9 9 0 019 9M4 4a16 16 0 0116 16M5 19a1 1 0 11-2 0 1 1 0 012 0z" />
       </svg>
     ),
   },
@@ -104,7 +114,7 @@ export default function Sidebar() {
           {!collapsed && (
             <div>
               <p className="text-sm font-semibold text-foreground leading-none">Outage Map</p>
-              <p className="text-[11px] text-muted-strong mt-1">Enterprise · v2</p>
+              <p className="text-[11px] text-muted-strong mt-1">Enterprise · v3</p>
             </div>
           )}
         </Link>

--- a/src/components/SourcesView.tsx
+++ b/src/components/SourcesView.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useState } from 'react';
+import PageHeader from './ui/PageHeader';
+import ImportSlideOver from './ImportSlideOver';
+
+interface ImportedSource {
+  id: string;
+  type: string;
+  name: string;
+  url: string;
+  refresh: number;
+  color: string;
+  addedAt: string;
+}
+
+const PRESET_SOURCES: ImportedSource[] = [
+  { id: 'p1', type: 'statuspage', name: 'Atlassian Statuspage', url: 'https://status.atlassian.com',  color: '#0052CC', refresh: 60,  addedAt: '2026-05-01T10:00:00Z' },
+  { id: 'p2', type: 'statuspage', name: 'OpenAI',               url: 'https://status.openai.com',     color: '#10A37F', refresh: 60,  addedAt: '2026-05-03T14:22:00Z' },
+  { id: 'p3', type: 'rss',        name: "AWS What's New",       url: 'https://aws.amazon.com/new/feed/', color: '#FF9900', refresh: 300, addedAt: '2026-05-05T09:00:00Z' },
+];
+
+const KIND_COLOR: Record<string, string> = {
+  statuspage: 'rgba(38,139,210,0.15)',
+  rss:        'rgba(42,161,152,0.15)',
+  http:       'rgba(208,135,32,0.15)',
+  github:     'rgba(36,41,47,0.25)',
+  aws:        'rgba(255,153,0,0.15)',
+};
+
+const KIND_TEXT: Record<string, string> = {
+  statuspage: '#268bd2',
+  rss:        '#2aa198',
+  http:       '#D08720',
+  github:     '#839496',
+  aws:        '#FF9900',
+};
+
+function relTime(iso: string): string {
+  const d = new Date(iso);
+  const diff = (Date.now() - d.getTime()) / 1000;
+  if (diff < 3600) return `${Math.round(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.round(diff / 3600)}h ago`;
+  return `${Math.round(diff / 86400)}d ago`;
+}
+
+export default function SourcesView() {
+  const [sources, setSources] = useState<ImportedSource[]>(PRESET_SOURCES);
+  const [importOpen, setImportOpen] = useState(false);
+  const [search, setSearch] = useState('');
+
+  const handleAdd = (svc: { type: string; name: string; url: string; refresh: number; color: string }) => {
+    setSources((prev) => [
+      ...prev,
+      { id: 't' + Date.now(), ...svc, addedAt: new Date().toISOString() },
+    ]);
+  };
+
+  const handleRemove = (id: string) => setSources((prev) => prev.filter((s) => s.id !== id));
+
+  const filtered = sources.filter(
+    (s) => !search || s.name.toLowerCase().includes(search.toLowerCase()) || s.url.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="Data Sources"
+        title="Imported services"
+        description="Manage RSS feeds, Statuspage integrations, and HTTP endpoints that power your board tiles."
+        actions={
+          <button className="board-btn board-btn-primary" onClick={() => setImportOpen(true)}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+            Add source
+          </button>
+        }
+      />
+
+      {/* Search + count */}
+      <div className="flex items-center gap-3">
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '7px 12px',
+            borderRadius: 10,
+            background: 'var(--surface)',
+            border: '1px solid var(--border-subtle)',
+            color: 'var(--muted-strong)',
+            flex: 1,
+            maxWidth: 380,
+          }}
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="7" /><path d="M21 21l-4.35-4.35" />
+          </svg>
+          <input
+            style={{ flex: 1, background: 'transparent', border: 0, outline: 0, color: 'var(--foreground)', fontSize: 13, fontFamily: 'inherit' }}
+            placeholder="Search sources…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <span style={{ fontSize: 12, color: 'var(--muted-strong)' }}>
+          {filtered.length} source{filtered.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {/* Source list */}
+      {filtered.length === 0 ? (
+        <div
+          style={{
+            padding: 40,
+            textAlign: 'center',
+            border: '2px dashed var(--border-strong)',
+            borderRadius: 14,
+            color: 'var(--muted)',
+          }}
+        >
+          <div style={{ fontSize: 36, marginBottom: 12 }}>📡</div>
+          <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--foreground)', marginBottom: 6 }}>No sources yet</div>
+          <div style={{ fontSize: 13, marginBottom: 20 }}>Import a Statuspage, RSS feed, or HTTP endpoint to get started.</div>
+          <button className="board-btn board-btn-primary" onClick={() => setImportOpen(true)}>
+            + Add your first source
+          </button>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {filtered.map((src) => (
+            <div
+              key={src.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 14,
+                padding: '14px 16px',
+                background: 'var(--surface)',
+                border: '1px solid var(--border-subtle)',
+                borderRadius: 12,
+                transition: 'border-color 140ms ease',
+              }}
+            >
+              {/* Logo */}
+              <div
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: 10,
+                  background: src.color,
+                  color: 'white',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontWeight: 700,
+                  fontSize: 14,
+                  flexShrink: 0,
+                }}
+              >
+                {src.name.charAt(0)}
+              </div>
+
+              {/* Info */}
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
+                  <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--foreground)' }}>{src.name}</span>
+                  <span
+                    style={{
+                      fontSize: 10,
+                      padding: '2px 7px',
+                      borderRadius: 999,
+                      background: KIND_COLOR[src.type] ?? 'rgba(255,255,255,0.06)',
+                      color: KIND_TEXT[src.type] ?? 'var(--muted)',
+                      fontWeight: 600,
+                      textTransform: 'uppercase',
+                      letterSpacing: 0.4,
+                    }}
+                  >
+                    {src.type}
+                  </span>
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {src.url}
+                </div>
+              </div>
+
+              {/* Meta */}
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3, flexShrink: 0, fontSize: 11, color: 'var(--muted-strong)' }}>
+                <span>Refresh every {src.refresh < 60 ? `${src.refresh}s` : `${src.refresh / 60}m`}</span>
+                <span>Added {relTime(src.addedAt)}</span>
+              </div>
+
+              {/* Remove */}
+              <button
+                onClick={() => handleRemove(src.id)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 30,
+                  height: 30,
+                  background: 'transparent',
+                  border: 0,
+                  color: 'var(--muted-strong)',
+                  borderRadius: 8,
+                  cursor: 'pointer',
+                  flexShrink: 0,
+                }}
+                title="Remove source"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M18 6L6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <ImportSlideOver open={importOpen} onClose={() => setImportOpen(false)} onAdd={handleAdd} />
+    </div>
+  );
+}

--- a/src/components/Sparkline.tsx
+++ b/src/components/Sparkline.tsx
@@ -1,0 +1,47 @@
+interface SparklineProps {
+  data: number[];
+  color?: string;
+  height?: number;
+}
+
+export default function Sparkline({ data, color = '#268bd2', height = 32 }: SparklineProps) {
+  if (!data || data.length === 0) return null;
+
+  const w = 100;
+  const h = height;
+  const points = data
+    .map((v, i) => {
+      const x = (i / (data.length - 1)) * w;
+      const y = h - v * h;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+
+  const areaPoints = `0,${h} ${points} ${w},${h}`;
+  const gradId = `spark-${color.replace('#', '')}`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      preserveAspectRatio="none"
+      style={{ width: '100%', height, display: 'block' }}
+    >
+      <defs>
+        <linearGradient id={gradId} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity="0.35" />
+          <stop offset="100%" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <polygon points={areaPoints} fill={`url(#${gradId})`} />
+      <polyline
+        points={points}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 
-export type Theme = 'solarized-dark' | 'solarized-light' | 'black-grey';
+export type Theme = 'solarized-dark' | 'solarized-light' | 'black-grey' | 'midnight';
 
 export const THEMES: { value: Theme; label: string; description: string }[] = [
   {
@@ -19,6 +19,11 @@ export const THEMES: { value: Theme; label: string; description: string }[] = [
     value: 'black-grey',
     label: 'Classic Dark',
     description: 'Traditional near-black background with neutral greys.',
+  },
+  {
+    value: 'midnight',
+    label: 'Midnight',
+    description: 'Deep navy blue with slate accents.',
   },
 ];
 
@@ -42,6 +47,15 @@ function isTheme(value: string | null): value is Theme {
   return !!value && (VALID_THEMES as string[]).includes(value);
 }
 
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  // Remove all theme classes and set the new one
+  root.classList.remove(...VALID_THEMES);
+  root.classList.add(theme);
+  // Also set data-theme attribute for CSS selectors in the new design
+  root.dataset.theme = theme;
+}
+
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<Theme>(DEFAULT_THEME);
 
@@ -56,9 +70,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    const root = document.documentElement;
-    root.classList.remove(...VALID_THEMES);
-    root.classList.add(theme);
+    applyTheme(theme);
     try {
       localStorage.setItem(STORAGE_KEY, theme);
     } catch {

--- a/src/components/TileGrid.tsx
+++ b/src/components/TileGrid.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useState } from 'react';
+import type { TileConfig } from '@/hooks/useBoard';
+import type { LiveData } from './tiles/types';
+import ServiceWatchTile from './tiles/ServiceWatchTile';
+import ServiceGridTile from './tiles/ServiceGridTile';
+import IncidentFeedTile from './tiles/IncidentFeedTile';
+import BoardStatTile from './tiles/BoardStatTile';
+import RssFeedTile from './tiles/RssFeedTile';
+import UptimeChartTile from './tiles/UptimeChartTile';
+import StatusMapTile from './tiles/StatusMapTile';
+import StatusPageTile from './tiles/StatusPageTile';
+
+const GRID_COLS = 6;
+
+interface TileGridProps {
+  board: TileConfig[];
+  editing: boolean;
+  live: LiveData;
+  onUpdateTile: (id: string, patch: Partial<TileConfig>) => void;
+  onRemoveTile: (id: string) => void;
+  onCycleResize: (id: string) => void;
+  onToggleDataPoint: (id: string, key: string) => void;
+  onSwapTiles: (srcId: string, tgtId: string) => void;
+  onAddClick: () => void;
+}
+
+function TileComponent({ tile, editing, live, onUpdate, onRemove, onResize, onToggleDataPoint }: {
+  tile: TileConfig;
+  editing: boolean;
+  live: LiveData;
+  onUpdate: (patch: Partial<TileConfig>) => void;
+  onRemove: () => void;
+  onResize: () => void;
+  onToggleDataPoint: (key: string) => void;
+}) {
+  const common = {
+    config: tile.config,
+    editing,
+    dataPoints: tile.dataPoints,
+    toggleDataPoint: onToggleDataPoint,
+    onConfigChange: (patch: Record<string, unknown>) => onUpdate({ config: patch }),
+    onResize,
+    onRemove,
+    live,
+  };
+
+  switch (tile.type) {
+    case 'service-watch':  return <ServiceWatchTile  {...common} config={tile.config as { service?: string }} />;
+    case 'service-grid':   return <ServiceGridTile   {...common} />;
+    case 'incident-feed':  return <IncidentFeedTile  {...common} />;
+    case 'stat':           return <BoardStatTile      {...common} />;
+    case 'rss':            return <RssFeedTile        {...common} />;
+    case 'uptime-chart':   return <UptimeChartTile    {...common} />;
+    case 'status-map':     return <StatusMapTile      {...common} />;
+    case 'statuspage':     return <StatusPageTile     {...common} />;
+    default:               return null;
+  }
+}
+
+export default function TileGrid({
+  board,
+  editing,
+  live,
+  onUpdateTile,
+  onRemoveTile,
+  onCycleResize,
+  onToggleDataPoint,
+  onSwapTiles,
+  onAddClick,
+}: TileGridProps) {
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [dragOverId, setDragOverId] = useState<string | null>(null);
+
+  const sorted = [...board].sort((a, b) => a.y - b.y || a.x - b.x);
+
+  return (
+    <div
+      className={`tile-grid ${editing ? 'tile-grid-edit' : ''}`}
+      style={{ gridTemplateColumns: `repeat(${GRID_COLS}, 1fr)` }}
+    >
+      {sorted.map((tile) => (
+        <div
+          key={tile.id}
+          className={[
+            'tile',
+            editing ? 'tile-edit-mode' : '',
+            dragId === tile.id ? 'tile-dragging' : '',
+            dragOverId === tile.id && dragId !== tile.id ? 'tile-drag-over' : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+          style={{
+            gridColumn: `span ${Math.min(tile.w, GRID_COLS)}`,
+            gridRow: `span ${tile.h}`,
+          }}
+          draggable={editing}
+          onDragStart={() => { setDragId(tile.id); setDragOverId(null); }}
+          onDragOver={(e) => { e.preventDefault(); setDragOverId(tile.id); }}
+          onDragLeave={() => setDragOverId(null)}
+          onDrop={() => {
+            if (dragId) onSwapTiles(dragId, tile.id);
+            setDragId(null);
+            setDragOverId(null);
+          }}
+          onDragEnd={() => { setDragId(null); setDragOverId(null); }}
+        >
+          {editing && (
+            <div className="drag-handle" aria-hidden="true">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                <circle cx="9" cy="6"  r="1.4" />
+                <circle cx="9" cy="12" r="1.4" />
+                <circle cx="9" cy="18" r="1.4" />
+                <circle cx="15" cy="6"  r="1.4" />
+                <circle cx="15" cy="12" r="1.4" />
+                <circle cx="15" cy="18" r="1.4" />
+              </svg>
+            </div>
+          )}
+          <TileComponent
+            tile={tile}
+            editing={editing}
+            live={live}
+            onUpdate={(patch) => onUpdateTile(tile.id, patch)}
+            onRemove={() => onRemoveTile(tile.id)}
+            onResize={() => onCycleResize(tile.id)}
+            onToggleDataPoint={(key) => onToggleDataPoint(tile.id, key)}
+          />
+        </div>
+      ))}
+
+      {editing && (
+        <button
+          className="add-tile-slot"
+          style={{ gridColumn: 'span 2', gridRow: 'span 2' }}
+          onClick={onAddClick}
+        >
+          <div style={{ fontSize: 36, fontWeight: 200, color: 'var(--muted)' }}>＋</div>
+          <div style={{ fontSize: 13, color: 'var(--muted)', marginTop: 4 }}>Add tile</div>
+          <div style={{ fontSize: 11, color: 'var(--muted-strong)', marginTop: 2 }}>
+            or drag from palette
+          </div>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/TweaksPanel.tsx
+++ b/src/components/TweaksPanel.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useRef } from 'react';
+import type { Tweaks } from '@/hooks/useTweaks';
+import { THEMES, type Theme } from './ThemeProvider';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  tweaks: Tweaks;
+  setTweak: (key: keyof Tweaks, value: unknown) => void;
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+}
+
+const ACCENT_OPTIONS = ['#268bd2', '#2aa198', '#b58900', '#d33682', '#859900', '#3b82f6'];
+
+export default function TweaksPanel({ open, onClose, tweaks, setTweak, theme, setTheme }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const offsetRef = useRef({ x: 16, y: 16 });
+
+  const onDragStart = (e: React.MouseEvent) => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    const r = panel.getBoundingClientRect();
+    const sx = e.clientX, sy = e.clientY;
+    const startRight = window.innerWidth - r.right;
+    const startBottom = window.innerHeight - r.bottom;
+
+    const move = (ev: MouseEvent) => {
+      offsetRef.current = {
+        x: Math.max(8, startRight - (ev.clientX - sx)),
+        y: Math.max(8, startBottom - (ev.clientY - sy)),
+      };
+      if (panel) {
+        panel.style.right = offsetRef.current.x + 'px';
+        panel.style.bottom = offsetRef.current.y + 'px';
+      }
+    };
+    const up = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div ref={panelRef} className="twk-panel">
+      {/* Header */}
+      <div className="twk-hd" onMouseDown={onDragStart}>
+        <b>Tweaks</b>
+        <button className="twk-x" onClick={onClose} aria-label="Close tweaks">✕</button>
+      </div>
+
+      <div className="twk-body">
+        {/* Layout section */}
+        <div className="twk-sect">Layout</div>
+
+        {/* Density */}
+        <div className="twk-row">
+          <div className="twk-lbl"><span>Density</span></div>
+          <div className="twk-seg">
+            {(['compact', 'comfortable'] as const).map((v) => (
+              <button
+                key={v}
+                data-on={tweaks.density === v}
+                onClick={() => setTweak('density', v)}
+              >
+                {v.charAt(0).toUpperCase() + v.slice(1)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Grid lines */}
+        <div className="twk-row twk-row-h">
+          <div className="twk-lbl"><span>Grid lines</span></div>
+          <button
+            type="button"
+            className="twk-toggle"
+            data-on={tweaks.showGridLines}
+            role="switch"
+            aria-checked={tweaks.showGridLines}
+            onClick={() => setTweak('showGridLines', !tweaks.showGridLines)}
+          >
+            <i />
+          </button>
+        </div>
+
+        {/* Tile radius */}
+        <div className="twk-row">
+          <div className="twk-lbl">
+            <span>Tile radius</span>
+            <span className="twk-val">{tweaks.tileRadius}px</span>
+          </div>
+          <input
+            type="range"
+            className="twk-slider"
+            min={0}
+            max={24}
+            step={2}
+            value={tweaks.tileRadius}
+            onChange={(e) => setTweak('tileRadius', Number(e.target.value))}
+          />
+        </div>
+
+        {/* Theme section */}
+        <div className="twk-sect">Theme</div>
+
+        {/* Theme select */}
+        <div className="twk-row">
+          <div className="twk-lbl"><span>Theme</span></div>
+          <select
+            className="twk-field"
+            value={theme}
+            onChange={(e) => setTheme(e.target.value as Theme)}
+          >
+            {THEMES.map((t) => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Accent */}
+        <div className="twk-row">
+          <div className="twk-lbl"><span>Accent color</span></div>
+          <div className="twk-chips">
+            {ACCENT_OPTIONS.map((color) => (
+              <button
+                key={color}
+                className="twk-chip"
+                data-on={tweaks.accent === color}
+                style={{ background: color }}
+                onClick={() => setTweak('accent', color)}
+                title={color}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tiles/BoardStatTile.tsx
+++ b/src/components/tiles/BoardStatTile.tsx
@@ -1,0 +1,58 @@
+import TileChrome from './TileChrome';
+import type { TileProps } from './types';
+
+type MetricKey = 'uptime' | 'incidents' | 'dd' | 'mttr';
+
+export default function BoardStatTile({ config, editing, onResize, onRemove, onConfigChange, live }: TileProps) {
+  const metric = (config.metric as MetricKey) || 'uptime';
+  const { services, incidents } = live;
+
+  const operational = services.filter((s) => s.overallStatus === 'operational').length;
+  const total = services.length;
+  const activeIncidents = incidents.filter((i) => i.status !== 'resolved').length;
+  const totalDD = services.reduce((sum, s) => sum + (s.downdetectorReports || 0), 0);
+  const uptimePct = total > 0 ? ((operational / total) * 100).toFixed(1) : '0.0';
+
+  const metrics: Record<MetricKey, { label: string; value: string | number; sub: string; accent: string }> = {
+    uptime:    { label: 'Fleet Uptime',     value: `${uptimePct}%`,           sub: `${operational}/${total} services healthy`, accent: '#7CB342' },
+    incidents: { label: 'Active Incidents', value: activeIncidents,           sub: `${incidents.length} total in view`,         accent: '#FFD54F' },
+    dd:        { label: 'DD Reports',       value: totalDD.toLocaleString(),  sub: 'Aggregated across services',                 accent: '#2aa198' },
+    mttr:      { label: 'MTTR (30d)',       value: '38m',                     sub: 'Mean time to recovery',                     accent: '#268bd2' },
+  };
+
+  const m = metrics[metric] ?? metrics.uptime;
+
+  return (
+    <TileChrome title={m.label} editing={editing} onResize={onResize} onRemove={onRemove}>
+      <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100%', gap: 4 }}>
+        <div
+          style={{
+            fontSize: 32,
+            fontWeight: 700,
+            color: m.accent,
+            fontVariantNumeric: 'tabular-nums',
+            lineHeight: 1,
+            letterSpacing: -0.5,
+          }}
+        >
+          {m.value}
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--muted)' }}>{m.sub}</div>
+      </div>
+
+      {editing && (
+        <div className="datapoint-chips" style={{ marginTop: 8 }}>
+          {(Object.keys(metrics) as MetricKey[]).map((k) => (
+            <button
+              key={k}
+              onClick={() => onConfigChange({ metric: k })}
+              className={`chip ${metric === k ? 'chip-on' : ''}`}
+            >
+              {metrics[k].label}
+            </button>
+          ))}
+        </div>
+      )}
+    </TileChrome>
+  );
+}

--- a/src/components/tiles/IncidentFeedTile.tsx
+++ b/src/components/tiles/IncidentFeedTile.tsx
@@ -1,0 +1,68 @@
+import TileChrome from './TileChrome';
+import { relTime } from '@/lib/boardColors';
+import type { TileProps } from './types';
+
+const SEV_COLOR: Record<string, string> = {
+  critical: '#EF5350',
+  major:    '#EF5350',
+  minor:    '#FFD54F',
+  warning:  '#FFB74D',
+  resolved: '#7CB342',
+};
+
+export default function IncidentFeedTile({ editing, onResize, onRemove, live }: TileProps) {
+  const { incidents, services } = live;
+  const activeCount = incidents.filter((i) => i.status !== 'resolved').length;
+
+  return (
+    <TileChrome
+      title="Incident Feed"
+      icon={
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0zM12 9v4M12 17h.01" />
+        </svg>
+      }
+      badge={
+        <span
+          className="count-pill"
+          style={{ background: 'rgba(239,83,80,0.18)', color: '#EF5350' }}
+        >
+          {activeCount} active
+        </span>
+      }
+      editing={editing}
+      onResize={onResize}
+      onRemove={onRemove}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', overflowY: 'auto', flex: 1 }}>
+        {incidents.length === 0 ? (
+          <div style={{ fontSize: 12, color: 'var(--muted)', padding: '8px 0' }}>No incidents.</div>
+        ) : (
+          incidents.map((inc) => {
+            const svc = services.find((s) => s.slug === inc.service);
+            const sevKey = inc.severity === 'critical' ? 'critical' : inc.severity;
+            const color = SEV_COLOR[inc.status === 'resolved' ? 'resolved' : sevKey] ?? '#FFD54F';
+            return (
+              <div key={inc.id} className="incident-row">
+                <div style={{ width: 3, alignSelf: 'stretch', background: color, borderRadius: 2 }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+                    <span style={{ fontSize: 10, fontWeight: 700, color, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                      {inc.severity}
+                    </span>
+                    <span style={{ fontSize: 11, color: 'var(--muted-strong)' }}>·</span>
+                    <span style={{ fontSize: 11, color: 'var(--muted)' }}>{svc?.name ?? inc.service}</span>
+                    <span style={{ fontSize: 11, color: 'var(--muted-strong)', marginLeft: 'auto' }}>
+                      {relTime(inc.startedAt)}
+                    </span>
+                  </div>
+                  <div style={{ fontSize: 12, color: 'var(--foreground)', lineHeight: 1.4 }}>{inc.title}</div>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </TileChrome>
+  );
+}

--- a/src/components/tiles/RssFeedTile.tsx
+++ b/src/components/tiles/RssFeedTile.tsx
@@ -1,0 +1,52 @@
+import TileChrome from './TileChrome';
+import type { TileProps } from './types';
+
+const FEEDS = [
+  {
+    id: 'aws-blog',
+    name: "AWS What's New",
+    items: [
+      { title: 'Amazon RDS announces Multi-AZ deployments with two readable standbys', time: '2h ago' },
+      { title: 'AWS Lambda now supports SnapStart for Python and .NET functions', time: '4h ago' },
+      { title: 'Amazon EKS now supports Kubernetes version 1.30', time: '7h ago' },
+    ],
+  },
+  {
+    id: 'gh-blog',
+    name: 'GitHub Engineering',
+    items: [
+      { title: 'Inside the migration to Kubernetes for GitHub.com', time: '1d ago' },
+      { title: 'How we reduced p99 latency on the issues API by 60%', time: '2d ago' },
+    ],
+  },
+];
+
+export default function RssFeedTile({ config, editing, onResize, onRemove }: TileProps) {
+  const feedId = (config.feed as string) || 'aws-blog';
+  const feed = FEEDS.find((f) => f.id === feedId) ?? FEEDS[0];
+
+  return (
+    <TileChrome
+      title={feed.name}
+      icon={
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M4 11a9 9 0 019 9M4 4a16 16 0 0116 16" />
+          <circle cx="5" cy="19" r="1" />
+        </svg>
+      }
+      badge={<span className="count-pill">RSS</span>}
+      editing={editing}
+      onResize={onResize}
+      onRemove={onRemove}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, overflowY: 'auto', flex: 1 }}>
+        {feed.items.map((item, i) => (
+          <a key={i} className="rss-row" href="#" onClick={(e) => e.preventDefault()}>
+            <div style={{ fontSize: 12, color: 'var(--foreground)', lineHeight: 1.4 }}>{item.title}</div>
+            <div style={{ fontSize: 10, color: 'var(--muted-strong)', marginTop: 2 }}>{item.time}</div>
+          </a>
+        ))}
+      </div>
+    </TileChrome>
+  );
+}

--- a/src/components/tiles/ServiceGridTile.tsx
+++ b/src/components/tiles/ServiceGridTile.tsx
@@ -1,0 +1,66 @@
+import TileChrome from './TileChrome';
+import { getStatusColor } from '@/lib/boardColors';
+import type { TileProps } from './types';
+
+export default function ServiceGridTile({ config, editing, onResize, onRemove, live }: TileProps) {
+  const filterSlugs = config.services as string[] | undefined;
+  const shown = filterSlugs?.length
+    ? live.services.filter((s) => filterSlugs.includes(s.slug))
+    : live.services;
+
+  return (
+    <TileChrome
+      title="Service Grid"
+      icon={
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <rect x="3" y="3" width="7" height="7" />
+          <rect x="14" y="3" width="7" height="7" />
+          <rect x="3" y="14" width="7" height="7" />
+          <rect x="14" y="14" width="7" height="7" />
+        </svg>
+      }
+      badge={
+        <span className="count-pill">{shown.length}</span>
+      }
+      editing={editing}
+      onResize={onResize}
+      onRemove={onRemove}
+    >
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))', gap: 8, overflowY: 'auto', flex: 1 }}>
+        {shown.map((s) => {
+          const c = getStatusColor(s.overallStatus);
+          return (
+            <div key={s.slug} className="mini-service">
+              <div
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: 7,
+                  background: s.color,
+                  color: 'white',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontWeight: 700,
+                  fontSize: 9,
+                  flexShrink: 0,
+                }}
+              >
+                {s.name.substring(0, 2).toUpperCase()}
+              </div>
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--foreground)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {s.name}
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 2 }}>
+                  <span style={{ width: 6, height: 6, borderRadius: 999, background: c.dot, display: 'inline-block' }} />
+                  <span style={{ fontSize: 10, color: c.text }}>{c.label}</span>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </TileChrome>
+  );
+}

--- a/src/components/tiles/ServiceWatchTile.tsx
+++ b/src/components/tiles/ServiceWatchTile.tsx
@@ -1,0 +1,218 @@
+import TileChrome from './TileChrome';
+import Sparkline from '../Sparkline';
+import { getStatusColor, historyToSparkline } from '@/lib/boardColors';
+import type { LiveData } from './types';
+
+interface Props {
+  config: { service?: string };
+  editing?: boolean;
+  dataPoints: string[];
+  toggleDataPoint: (key: string) => void;
+  onConfigChange: (patch: Record<string, unknown>) => void;
+  onResize?: () => void;
+  onRemove?: () => void;
+  live: LiveData;
+}
+
+function StatusDot({ status, pulse = false }: { status: string; pulse?: boolean }) {
+  const c = getStatusColor(status);
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+      <span
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: 999,
+          background: c.dot,
+          boxShadow: pulse ? `0 0 0 4px ${c.bg}` : 'none',
+          animation: pulse && status !== 'operational' ? 'pulse-ring 2s ease-in-out infinite' : 'none',
+          display: 'inline-block',
+        }}
+      />
+    </span>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const c = getStatusColor(status);
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '3px 8px',
+        borderRadius: 999,
+        fontSize: 11,
+        fontWeight: 600,
+        background: c.bg,
+        color: c.text,
+        letterSpacing: 0.2,
+      }}
+    >
+      <StatusDot status={status} pulse />
+      {c.label}
+    </span>
+  );
+}
+
+export default function ServiceWatchTile({
+  config,
+  editing,
+  dataPoints,
+  toggleDataPoint,
+  onConfigChange,
+  onResize,
+  onRemove,
+  live,
+}: Props) {
+  const slug = (config.service as string) || '';
+  const svc = live.services.find((s) => s.slug === slug) || live.services[0];
+
+  if (!svc) {
+    return (
+      <TileChrome title="Service Watch" editing={editing} onResize={onResize} onRemove={onRemove}>
+        <div style={{ color: 'var(--muted)', fontSize: 12 }}>No service data</div>
+      </TileChrome>
+    );
+  }
+
+  const status = svc.overallStatus;
+  const c = getStatusColor(status);
+  const hist = live.history[svc.slug] || [];
+  const sparkData = historyToSparkline(hist as Parameters<typeof historyToSparkline>[0]);
+
+  const showSpark = dataPoints.includes('sparkline');
+  const showDD = dataPoints.includes('downdetector');
+  const showUptime = dataPoints.includes('uptime');
+  const showOfficial = dataPoints.includes('official');
+
+  const uptimePct =
+    hist.length > 0
+      ? ((hist.filter((p) => p.status === 'operational').length / hist.length) * 100).toFixed(2)
+      : '—';
+
+  return (
+    <TileChrome
+      title={svc.name}
+      icon={
+        <div
+          style={{
+            width: 24,
+            height: 24,
+            borderRadius: 6,
+            background: svc.color,
+            color: 'white',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 700,
+            fontSize: 9,
+            flexShrink: 0,
+          }}
+        >
+          {svc.name.substring(0, 2).toUpperCase()}
+        </div>
+      }
+      editing={editing}
+      onResize={onResize}
+      onRemove={onRemove}
+      onConfigure={() => {
+        const next = live.services[(live.services.findIndex((s) => s.slug === svc.slug) + 1) % live.services.length];
+        if (next) onConfigChange({ service: next.slug });
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, height: '100%' }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+          <div>
+            <StatusBadge status={status} />
+            {svc.details && (
+              <p style={{ margin: '8px 0 0', fontSize: 12, color: 'var(--muted)', lineHeight: 1.4 }}>
+                {svc.details}
+              </p>
+            )}
+          </div>
+          {showUptime && (
+            <div style={{ textAlign: 'right' }}>
+              <div style={{ fontSize: 22, fontWeight: 700, color: 'var(--foreground-strong, var(--foreground))', fontVariantNumeric: 'tabular-nums' }}>
+                {uptimePct}%
+              </div>
+              <div style={{ fontSize: 10, color: 'var(--muted-strong)', textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                30d uptime
+              </div>
+            </div>
+          )}
+        </div>
+
+        {showSpark && sparkData.length > 0 && (
+          <div style={{ marginTop: 'auto' }}>
+            <Sparkline data={sparkData} color={c.dot} height={36} />
+            <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 9, color: 'var(--muted-strong)', marginTop: 4 }}>
+              <span>30 days ago</span>
+              <span>now</span>
+            </div>
+          </div>
+        )}
+
+        {(showDD || showOfficial) && (
+          <div
+            style={{
+              display: 'flex',
+              gap: 16,
+              fontSize: 11,
+              color: 'var(--muted)',
+              paddingTop: 8,
+              borderTop: '1px solid var(--border-subtle)',
+            }}
+          >
+            {showOfficial && (
+              <div>
+                <span style={{ color: 'var(--muted-strong)' }}>Official </span>
+                <span style={{ color: getStatusColor(svc.officialStatus).text }}>
+                  {getStatusColor(svc.officialStatus).label}
+                </span>
+              </div>
+            )}
+            {showDD && (
+              <div>
+                <span style={{ color: 'var(--muted-strong)' }}>DD </span>
+                <span
+                  style={{
+                    color:
+                      svc.downdetectorReports > 500
+                        ? '#EF5350'
+                        : svc.downdetectorReports > 100
+                        ? '#FFD54F'
+                        : 'var(--foreground)',
+                    fontWeight: 600,
+                  }}
+                >
+                  {svc.downdetectorReports.toLocaleString()}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {editing && (
+          <div className="datapoint-chips">
+            {[
+              ['sparkline', '30d chart'],
+              ['uptime', 'Uptime %'],
+              ['official', 'Official'],
+              ['downdetector', 'DD reports'],
+            ].map(([k, label]) => (
+              <button
+                key={k}
+                onClick={() => toggleDataPoint(k)}
+                className={`chip ${dataPoints.includes(k) ? 'chip-on' : ''}`}
+              >
+                {dataPoints.includes(k) ? '●' : '○'} {label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </TileChrome>
+  );
+}

--- a/src/components/tiles/StatusMapTile.tsx
+++ b/src/components/tiles/StatusMapTile.tsx
@@ -1,0 +1,93 @@
+import TileChrome from './TileChrome';
+import type { TileProps } from './types';
+
+const REGIONS = [
+  { x: 18, y: 38, r: 14, hot: 0.9, label: 'us-west' },
+  { x: 38, y: 32, r: 10, hot: 0.3, label: 'us-central' },
+  { x: 72, y: 28, r: 16, hot: 0.7, label: 'us-east' },
+  { x: 88, y: 48, r: 8,  hot: 0.2, label: 'eu-west' },
+  { x: 50, y: 58, r: 9,  hot: 0.4, label: 'sa-east' },
+];
+
+function regionColor(hot: number): string {
+  if (hot > 0.6) return '#EF5350';
+  if (hot > 0.4) return '#FFD54F';
+  return '#7CB342';
+}
+
+export default function StatusMapTile({ editing, onResize, onRemove, live }: TileProps) {
+  // Compute a rough "heat" per region based on active incidents
+  const activeIncidents = live.incidents.filter((i) => i.status !== 'resolved').length;
+  const totalServices = live.services.length || 1;
+  const issueServices = live.services.filter((s) => s.overallStatus !== 'operational').length;
+  const baseHeat = issueServices / totalServices;
+
+  const regions = REGIONS.map((r, i) => ({
+    ...r,
+    hot: Math.min(1, r.hot * (1 + baseHeat) * (activeIncidents > 0 ? 1.2 : 1)),
+  }));
+
+  return (
+    <TileChrome
+      title="Outage Heat Map"
+      icon={
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <circle cx="12" cy="10" r="3" />
+          <path d="M12 2a8 8 0 018 8c0 6-8 12-8 12s-8-6-8-12a8 8 0 018-8z" />
+        </svg>
+      }
+      editing={editing}
+      onResize={onResize}
+      onRemove={onRemove}
+    >
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          minHeight: 140,
+          borderRadius: 8,
+          background: 'radial-gradient(ellipse at center, rgba(38,139,210,0.06), transparent 60%)',
+          border: '1px solid var(--border-subtle)',
+          overflow: 'hidden',
+          flex: 1,
+        }}
+      >
+        <div className="map-grid" />
+        <svg
+          viewBox="0 0 100 80"
+          preserveAspectRatio="none"
+          style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+        >
+          {regions.map((r, i) => {
+            const col = regionColor(Math.min(1, r.hot));
+            return (
+              <g key={i}>
+                <circle cx={r.x} cy={r.y} r={r.r} fill={col} opacity={0.18} />
+                <circle cx={r.x} cy={r.y} r={r.r * 0.4} fill={col} opacity={0.6} />
+              </g>
+            );
+          })}
+        </svg>
+        {regions.map((r, i) => (
+          <span
+            key={i}
+            style={{
+              position: 'absolute',
+              left: `${r.x}%`,
+              top: `${r.y}%`,
+              transform: 'translate(-50%, -50%)',
+              fontSize: 9,
+              color: 'var(--muted)',
+              whiteSpace: 'nowrap',
+              pointerEvents: 'none',
+              textShadow: '0 1px 2px rgba(0,0,0,0.6)',
+            }}
+          >
+            {r.label}
+          </span>
+        ))}
+      </div>
+    </TileChrome>
+  );
+}

--- a/src/components/tiles/StatusPageTile.tsx
+++ b/src/components/tiles/StatusPageTile.tsx
@@ -1,0 +1,73 @@
+import TileChrome from './TileChrome';
+import { getStatusColor } from '@/lib/boardColors';
+import type { TileProps } from './types';
+
+interface Component {
+  name: string;
+  status: string;
+}
+
+const DEFAULT_COMPONENTS: Component[] = [
+  { name: 'API',       status: 'operational' },
+  { name: 'Dashboard', status: 'operational' },
+  { name: 'Webhooks',  status: 'degraded'    },
+  { name: 'Search',    status: 'operational' },
+];
+
+export default function StatusPageTile({ config, editing, onResize, onRemove }: TileProps) {
+  const components = (config.components as Component[]) ?? DEFAULT_COMPONENTS;
+  const name = (config.name as string) || 'Imported Status Page';
+  const color = (config.color as string) || '#635BFF';
+
+  return (
+    <TileChrome
+      title={name}
+      icon={
+        <div
+          style={{
+            width: 20,
+            height: 20,
+            borderRadius: 5,
+            background: color,
+            flexShrink: 0,
+          }}
+        />
+      }
+      badge={
+        <span
+          className="count-pill"
+          style={{ background: 'rgba(42,161,152,0.15)', color: '#2aa198' }}
+        >
+          Statuspage
+        </span>
+      }
+      editing={editing}
+      onResize={onResize}
+      onRemove={onRemove}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6, overflowY: 'auto', flex: 1 }}>
+        {components.map((c, i) => {
+          const sc = getStatusColor(c.status);
+          return (
+            <div
+              key={i}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '6px 0',
+                borderBottom: i < components.length - 1 ? '1px solid var(--border-subtle)' : 'none',
+              }}
+            >
+              <span style={{ fontSize: 12, color: 'var(--foreground)' }}>{c.name}</span>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 10, color: sc.text }}>
+                <span style={{ width: 6, height: 6, borderRadius: 999, background: sc.dot, display: 'inline-block' }} />
+                {sc.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </TileChrome>
+  );
+}

--- a/src/components/tiles/TileChrome.tsx
+++ b/src/components/tiles/TileChrome.tsx
@@ -1,0 +1,58 @@
+import { ReactNode } from 'react';
+
+interface TileChromeProps {
+  title: string;
+  icon?: ReactNode;
+  badge?: ReactNode;
+  children: ReactNode;
+  editing?: boolean;
+  onResize?: () => void;
+  onRemove?: () => void;
+  onConfigure?: () => void;
+}
+
+export default function TileChrome({
+  title,
+  icon,
+  badge,
+  children,
+  editing,
+  onResize,
+  onRemove,
+  onConfigure,
+}: TileChromeProps) {
+  return (
+    <div className="tile-inner">
+      <div className="tile-header">
+        <div className="tile-title">
+          {icon}
+          <span>{title}</span>
+          {badge}
+        </div>
+        <div className="tile-actions">
+          {editing && (
+            <>
+              <button className="tile-btn" onClick={onConfigure} title="Configure">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="12" cy="12" r="3" />
+                  <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 11-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 11-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 11-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 110-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 112.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 114 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 112.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 110 4h-.09a1.65 1.65 0 00-1.51 1z" />
+                </svg>
+              </button>
+              <button className="tile-btn" onClick={onResize} title="Resize">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" />
+                </svg>
+              </button>
+              <button className="tile-btn tile-btn-danger" onClick={onRemove} title="Remove">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M18 6L6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+      <div className="tile-body">{children}</div>
+    </div>
+  );
+}

--- a/src/components/tiles/UptimeChartTile.tsx
+++ b/src/components/tiles/UptimeChartTile.tsx
@@ -1,0 +1,78 @@
+import TileChrome from './TileChrome';
+import Sparkline from '../Sparkline';
+import { getStatusColor, historyToSparkline } from '@/lib/boardColors';
+import type { TileProps } from './types';
+
+export default function UptimeChartTile({ config, editing, onResize, onRemove, live }: TileProps) {
+  const slug = (config.service as string) || '';
+  const svc = live.services.find((s) => s.slug === slug) ?? live.services[0];
+
+  if (!svc) {
+    return (
+      <TileChrome title="Uptime Chart" editing={editing} onResize={onResize} onRemove={onRemove}>
+        <div style={{ color: 'var(--muted)', fontSize: 12 }}>No service data</div>
+      </TileChrome>
+    );
+  }
+
+  const hist = live.history[svc.slug] ?? [];
+  const sparkData = historyToSparkline(hist as Parameters<typeof historyToSparkline>[0]);
+  const c = getStatusColor(svc.overallStatus);
+  const uptimePct =
+    hist.length > 0
+      ? ((hist.filter((p) => p.status === 'operational').length / hist.length) * 100).toFixed(2)
+      : '—';
+
+  const today = new Date();
+  const thirtyAgo = new Date(today);
+  thirtyAgo.setDate(today.getDate() - 30);
+  const fmt = (d: Date) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+
+  return (
+    <TileChrome
+      title={`${svc.name} — 30 day`}
+      icon={
+        <div
+          style={{
+            width: 20,
+            height: 20,
+            borderRadius: 5,
+            background: svc.color,
+            color: 'white',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontWeight: 700,
+            fontSize: 8,
+            flexShrink: 0,
+          }}
+        >
+          {svc.name.substring(0, 2).toUpperCase()}
+        </div>
+      }
+      editing={editing}
+      onResize={onResize}
+      onRemove={onRemove}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100%', gap: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <div style={{ fontSize: 24, fontWeight: 700, color: 'var(--foreground)', fontVariantNumeric: 'tabular-nums' }}>
+            {uptimePct}%
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--muted-strong)' }}>uptime over 30 days</div>
+        </div>
+        <div style={{ flex: 1, minHeight: 60 }}>
+          {sparkData.length > 0 ? (
+            <Sparkline data={sparkData} color={c.dot} height={80} />
+          ) : (
+            <div style={{ color: 'var(--muted)', fontSize: 12 }}>No history data</div>
+          )}
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 9, color: 'var(--muted-strong)' }}>
+          <span>{fmt(thirtyAgo)}</span>
+          <span>{fmt(today)}</span>
+        </div>
+      </div>
+    </TileChrome>
+  );
+}

--- a/src/components/tiles/types.ts
+++ b/src/components/tiles/types.ts
@@ -1,0 +1,20 @@
+import type { ServiceStatusResponse, IncidentResponse, HistoryPoint } from '@/lib/types';
+
+export interface LiveData {
+  services: ServiceStatusResponse[];
+  incidents: IncidentResponse[];
+  history: Record<string, HistoryPoint[]>;
+  isLoading: boolean;
+  lastUpdated?: string;
+}
+
+export interface TileProps {
+  config: Record<string, unknown>;
+  editing?: boolean;
+  dataPoints: string[];
+  toggleDataPoint: (key: string) => void;
+  onConfigChange: (patch: Record<string, unknown>) => void;
+  onResize?: () => void;
+  onRemove?: () => void;
+  live: LiveData;
+}

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -1,0 +1,205 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+
+export type TileType =
+  | 'stat'
+  | 'service-watch'
+  | 'service-grid'
+  | 'incident-feed'
+  | 'rss'
+  | 'uptime-chart'
+  | 'status-map'
+  | 'statuspage';
+
+export interface TileConfig {
+  id: string;
+  type: TileType;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  config: Record<string, unknown>;
+  dataPoints: string[];
+}
+
+const BOARD_STORAGE_KEY = 'outage-board-v3';
+
+const DEFAULT_BOARD: TileConfig[] = [
+  { id: 't1', type: 'stat',          x: 0, y: 0, w: 1, h: 2, config: { metric: 'uptime' },     dataPoints: [] },
+  { id: 't2', type: 'stat',          x: 1, y: 0, w: 1, h: 2, config: { metric: 'incidents' },   dataPoints: [] },
+  { id: 't3', type: 'stat',          x: 2, y: 0, w: 1, h: 2, config: { metric: 'mttr' },        dataPoints: [] },
+  { id: 't4', type: 'stat',          x: 3, y: 0, w: 1, h: 2, config: { metric: 'dd' },          dataPoints: [] },
+  { id: 't5', type: 'service-watch', x: 0, y: 1, w: 2, h: 2, config: { service: 'slack' },      dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 't6', type: 'service-watch', x: 2, y: 1, w: 2, h: 2, config: { service: 'github' },     dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 't7', type: 'incident-feed', x: 4, y: 0, w: 2, h: 3, config: {},                        dataPoints: [] },
+  { id: 't8', type: 'service-grid',  x: 0, y: 3, w: 4, h: 2, config: {},                        dataPoints: [] },
+  { id: 't9', type: 'status-map',    x: 4, y: 3, w: 2, h: 2, config: {},                        dataPoints: [] },
+];
+
+const TILE_SIZES: { w: number; h: number }[] = [
+  { w: 1, h: 1 }, { w: 1, h: 2 }, { w: 2, h: 1 }, { w: 2, h: 2 }, { w: 3, h: 2 }, { w: 2, h: 3 },
+];
+
+function readBoard(): TileConfig[] {
+  if (typeof window === 'undefined') return DEFAULT_BOARD;
+  try {
+    const raw = localStorage.getItem(BOARD_STORAGE_KEY);
+    if (raw) return JSON.parse(raw) as TileConfig[];
+  } catch {
+    // ignore
+  }
+  return DEFAULT_BOARD;
+}
+
+function writeBoard(board: TileConfig[]) {
+  try {
+    localStorage.setItem(BOARD_STORAGE_KEY, JSON.stringify(board));
+  } catch {
+    // ignore
+  }
+}
+
+export interface BoardActions {
+  updateTile: (id: string, patch: Partial<TileConfig>) => void;
+  removeTile: (id: string) => void;
+  cycleResize: (id: string) => void;
+  toggleDataPoint: (id: string, key: string) => void;
+  addTile: (type: TileType, extraConfig?: Record<string, unknown>) => void;
+  swapTiles: (srcId: string, tgtId: string) => void;
+  resetBoard: () => void;
+}
+
+export function useBoard(): [TileConfig[], BoardActions] {
+  const [board, setBoard] = useState<TileConfig[]>(DEFAULT_BOARD);
+
+  // Hydrate from localStorage after mount
+  useEffect(() => {
+    setBoard(readBoard());
+  }, []);
+
+  // Persist whenever board changes
+  useEffect(() => {
+    writeBoard(board);
+  }, [board]);
+
+  const updateTile = useCallback((id: string, patch: Partial<TileConfig>) => {
+    setBoard((b) =>
+      b.map((t) =>
+        t.id === id
+          ? {
+              ...t,
+              ...patch,
+              config: patch.config ? { ...t.config, ...patch.config } : t.config,
+            }
+          : t
+      )
+    );
+  }, []);
+
+  const removeTile = useCallback((id: string) => {
+    setBoard((b) => b.filter((t) => t.id !== id));
+  }, []);
+
+  const cycleResize = useCallback((id: string) => {
+    setBoard((b) =>
+      b.map((t) => {
+        if (t.id !== id) return t;
+        const idx = TILE_SIZES.findIndex((s) => s.w === t.w && s.h === t.h);
+        const next = TILE_SIZES[(idx + 1) % TILE_SIZES.length];
+        return { ...t, w: next.w, h: next.h };
+      })
+    );
+  }, []);
+
+  const toggleDataPoint = useCallback((id: string, key: string) => {
+    setBoard((b) =>
+      b.map((t) => {
+        if (t.id !== id) return t;
+        const has = t.dataPoints.includes(key);
+        return {
+          ...t,
+          dataPoints: has ? t.dataPoints.filter((k) => k !== key) : [...t.dataPoints, key],
+        };
+      })
+    );
+  }, []);
+
+  const addTile = useCallback((type: TileType, extraConfig: Record<string, unknown> = {}) => {
+    const defaultConfigs: Record<TileType, Record<string, unknown>> = {
+      'stat':          { metric: 'uptime' },
+      'service-watch': { service: 'github' },
+      'service-grid':  {},
+      'incident-feed': {},
+      'rss':           { feed: 'aws-blog' },
+      'uptime-chart':  { service: 'github' },
+      'status-map':    {},
+      'statuspage':    { name: 'New Service', color: '#268bd2' },
+    };
+    const defaultSizes: Record<TileType, { w: number; h: number }> = {
+      'stat':          { w: 1, h: 2 },
+      'service-watch': { w: 2, h: 2 },
+      'service-grid':  { w: 4, h: 2 },
+      'incident-feed': { w: 2, h: 3 },
+      'rss':           { w: 2, h: 2 },
+      'uptime-chart':  { w: 2, h: 2 },
+      'status-map':    { w: 2, h: 2 },
+      'statuspage':    { w: 2, h: 2 },
+    };
+    const defaultDataPoints: Record<TileType, string[]> = {
+      'stat':          [],
+      'service-watch': ['sparkline', 'uptime', 'official', 'downdetector'],
+      'service-grid':  [],
+      'incident-feed': [],
+      'rss':           [],
+      'uptime-chart':  [],
+      'status-map':    [],
+      'statuspage':    [],
+    };
+    const id = 't' + Date.now();
+    const size = defaultSizes[type];
+    setBoard((b) => [
+      ...b,
+      {
+        id,
+        type,
+        x: 0,
+        y: 99,
+        w: size.w,
+        h: size.h,
+        config: { ...defaultConfigs[type], ...extraConfig },
+        dataPoints: defaultDataPoints[type],
+      },
+    ]);
+  }, []);
+
+  const swapTiles = useCallback((srcId: string, tgtId: string) => {
+    if (srcId === tgtId) return;
+    setBoard((b) => {
+      const src = b.find((t) => t.id === srcId);
+      const tgt = b.find((t) => t.id === tgtId);
+      if (!src || !tgt) return b;
+      return b.map((t) => {
+        if (t.id === srcId) return { ...t, x: tgt.x, y: tgt.y, w: tgt.w, h: tgt.h };
+        if (t.id === tgtId) return { ...t, x: src.x, y: src.y, w: src.w, h: src.h };
+        return t;
+      });
+    });
+  }, []);
+
+  const resetBoard = useCallback(() => {
+    setBoard(DEFAULT_BOARD);
+  }, []);
+
+  const actions: BoardActions = {
+    updateTile,
+    removeTile,
+    cycleResize,
+    toggleDataPoint,
+    addTile,
+    swapTiles,
+    resetBoard,
+  };
+
+  return [board, actions];
+}

--- a/src/hooks/useTweaks.ts
+++ b/src/hooks/useTweaks.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface Tweaks {
+  accent: string;
+  density: 'compact' | 'comfortable';
+  showGridLines: boolean;
+  tileRadius: number;
+}
+
+const TWEAKS_STORAGE_KEY = 'outage-board-tweaks';
+
+const DEFAULT_TWEAKS: Tweaks = {
+  accent: '#268bd2',
+  density: 'comfortable',
+  showGridLines: true,
+  tileRadius: 14,
+};
+
+function readTweaks(): Tweaks {
+  if (typeof window === 'undefined') return DEFAULT_TWEAKS;
+  try {
+    const raw = localStorage.getItem(TWEAKS_STORAGE_KEY);
+    if (raw) return { ...DEFAULT_TWEAKS, ...JSON.parse(raw) };
+  } catch {
+    // ignore
+  }
+  return DEFAULT_TWEAKS;
+}
+
+function applyTweaks(t: Tweaks) {
+  const root = document.documentElement;
+  root.style.setProperty('--accent', t.accent);
+  root.style.setProperty('--tile-radius', `${t.tileRadius}px`);
+  root.dataset.density = t.density;
+  root.dataset.gridLines = t.showGridLines ? 'on' : 'off';
+}
+
+export function useTweaks(): [Tweaks, (key: keyof Tweaks, value: unknown) => void] {
+  const [tweaks, setTweaks] = useState<Tweaks>(DEFAULT_TWEAKS);
+
+  useEffect(() => {
+    const stored = readTweaks();
+    setTweaks(stored);
+    applyTweaks(stored);
+  }, []);
+
+  useEffect(() => {
+    applyTweaks(tweaks);
+    try {
+      localStorage.setItem(TWEAKS_STORAGE_KEY, JSON.stringify(tweaks));
+    } catch {
+      // ignore
+    }
+  }, [tweaks]);
+
+  const setTweak = useCallback((key: keyof Tweaks, value: unknown) => {
+    setTweaks((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  return [tweaks, setTweak];
+}

--- a/src/lib/boardColors.ts
+++ b/src/lib/boardColors.ts
@@ -1,0 +1,41 @@
+import type { ServiceStatus } from './types';
+
+export interface StatusColor {
+  dot: string;
+  text: string;
+  bg: string;
+  label: string;
+}
+
+export const STATUS_COLORS: Record<string, StatusColor> = {
+  operational:  { dot: '#7CB342', text: '#9CCC65', bg: 'rgba(124,179,66,0.12)',  label: 'Operational'  },
+  degraded:     { dot: '#F0C419', text: '#FFD54F', bg: 'rgba(240,196,25,0.12)',  label: 'Degraded'     },
+  major_outage: { dot: '#D08720', text: '#FFB74D', bg: 'rgba(208,135,32,0.14)', label: 'Major Outage' },
+  down:         { dot: '#DC322F', text: '#EF5350', bg: 'rgba(220,50,47,0.14)',  label: 'Down'         },
+  unknown:      { dot: '#586E75', text: '#93A1A1', bg: 'rgba(88,110,117,0.18)', label: 'Unknown'      },
+};
+
+export function getStatusColor(status: ServiceStatus | string): StatusColor {
+  return STATUS_COLORS[status] ?? STATUS_COLORS.unknown;
+}
+
+export function relTime(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  const diff = (Date.now() - d.getTime()) / 1000;
+  if (diff < 60) return `${Math.round(diff)}s ago`;
+  if (diff < 3600) return `${Math.round(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.round(diff / 3600)}h ago`;
+  return `${Math.round(diff / 86400)}d ago`;
+}
+
+/** Convert HistoryPoint array to 0-1 uptime values for sparklines */
+export function historyToSparkline(points: { status: ServiceStatus; outageMinutes: number }[]): number[] {
+  return points.map((p) => {
+    if (p.status === 'operational') return 1;
+    if (p.status === 'degraded') return 0.75;
+    if (p.status === 'major_outage') return 0.4;
+    if (p.status === 'down') return 0.1;
+    return 0.9;
+  });
+}


### PR DESCRIPTION
## Summary

- **Modular tile grid** replaces the static dashboard — 6-column CSS grid with drag-and-drop rearrangement, persistent board layout via `localStorage`, and configurable tile sizes (column/row spans)
- **9 tile types** wired to live API data: `BoardStat`, `ServiceWatch` (sparkline + Downdetector/official indicators), `ServiceGrid`, `IncidentFeed`, `UptimeChart`, `StatusMap`, `RssFeed`, `StatusPage`
- **Edit mode** with drag handles, resize cycling, per-tile delete, and datapoint toggles; **Add Tile popover** for quick palette; **Import Service wizard** (4-step slide-over: Source → Connect → Configure → Confirm) for Statuspage/RSS/HTTP sources
- **Tweaks panel** — floating draggable overlay to tune accent color, tile radius, density, grid lines, and theme live
- **Midnight theme** added; `ThemeProvider` now sets both class and `data-theme` attribute; `useTweaks` hook persists appearance settings as CSS custom properties
- **Sources page** at `/sources` for managing imported integrations; sidebar updated with Sources nav item and version bumped to v3

## Test plan

- [ ] Navigate to `/` — board renders with 9 default tiles (4 stat, 2 service-watch, 1 incident-feed, 1 service-grid, 1 status-map)
- [ ] Click **Edit board** — tiles show drag handle, resize, delete buttons; grid lines appear; dragging a tile swaps it with the drop target
- [ ] Click **Add tile** — popover opens; selecting a type adds a new tile at the bottom of the board
- [ ] Click **Import** — 4-step slide-over opens; paste a URL (e.g. `https://status.openai.com`), auto-detects as `statuspage`, steps through to "Add to dashboard"
- [ ] Click **Tweaks** — floating panel opens; change accent color, density (compact vs comfortable), tile radius slider, and theme select — all apply instantly
- [ ] Navigate to `/sources` — list of preset imported sources; "Add source" button opens the same import slide-over; removing a source works
- [ ] Sidebar shows **Sources** nav item; version label reads "Enterprise · v3"
- [ ] Switch theme to **Midnight** in Tweaks — deep navy palette applies; switch back to Solarized Dark
- [ ] Board layout persists across page refresh (localStorage)

https://claude.ai/code/session_01ENuMZ1t26iXLmvaK6bg3Qa

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENuMZ1t26iXLmvaK6bg3Qa)_