### PR TITLE
Fix ESLint/TypeScript errors blocking Docker production build

### DIFF
--- a/src/components/ImportSlideOver.tsx
+++ b/src/components/ImportSlideOver.tsx
@@ -44,7 +44,7 @@ const STATUS_COLORS: Record<string, { dot: string; text: string; label: string }
 
 export default function ImportSlideOver({ open, onClose, onAdd }: Props) {
   const [step, setStep]         = useState(0);
-  const [kind, setKind]         = useState('auto');
+  const [, setKind]             = useState('auto');
   const [url, setUrl]           = useState('');
   const [detected, setDetected] = useState<{ kind: string; name: string; color?: string } | null>(null);
   const [name, setName]         = useState('');
@@ -61,9 +61,9 @@ export default function ImportSlideOver({ open, onClose, onAdd }: Props) {
       setDetected(d);
       if (d && !name) setName(d.name);
     }
-  }, [url, step]);
+  }, [url, step, name]);
 
-  const usePreset = (p: (typeof PRESETS)[0]) => {
+  const applyPreset = (p: (typeof PRESETS)[0]) => {
     setUrl(p.url);
     setKind(p.kind);
     setName(p.name);
@@ -178,7 +178,7 @@ export default function ImportSlideOver({ open, onClose, onAdd }: Props) {
 
               <div className="preset-list">
                 {filteredPresets.map((p) => (
-                  <button key={p.id} className="preset-row" onClick={() => usePreset(p)}>
+                  <button key={p.id} className="preset-row" onClick={() => applyPreset(p)}>
                     <div className="preset-logo" style={{ background: p.logo }}>{p.name.charAt(0)}</div>
                     <div style={{ flex: 1, minWidth: 0 }}>
                       <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--foreground)' }}>{p.name}</div>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -37,6 +37,12 @@ const THEME_PREVIEWS: Record<Theme, {
     secondaryBar: 'bg-neutral-500',
     accentBar: 'bg-blue-500',
   },
+  'midnight': {
+    wrapper: 'bg-[#0b1220] border-[#1e2d45]',
+    primaryBar: 'bg-[#cbd5e1]',
+    secondaryBar: 'bg-[#64748b]',
+    accentBar: 'bg-[#38bdf8]',
+  },
 };
 
 export default function SettingsView() {

--- a/src/components/tiles/StatusMapTile.tsx
+++ b/src/components/tiles/StatusMapTile.tsx
@@ -22,7 +22,7 @@ export default function StatusMapTile({ editing, onResize, onRemove, live }: Til
   const issueServices = live.services.filter((s) => s.overallStatus !== 'operational').length;
   const baseHeat = issueServices / totalServices;
 
-  const regions = REGIONS.map((r, i) => ({
+  const regions = REGIONS.map((r) => ({
     ...r,
     hot: Math.min(1, r.hot * (1 + baseHeat) * (activeIncidents > 0 ? 1.2 : 1)),
   }));


### PR DESCRIPTION
## Summary

- **Root cause**: `next build` was failing with ESLint/TypeScript errors introduced alongside the new modular tile-grid dashboard, so Docker never rebuilt the image — the container kept serving the old pre-redesign code
- **Fix**: Resolved all three build-blocking errors across two component files, plus added the missing `midnight` theme entry that caused a TypeScript exhaustiveness error

## Changes

- **`ImportSlideOver.tsx`**: Renamed `usePreset` → `applyPreset` (ESLint `react-hooks/rules-of-hooks` rejects any `use`-prefixed function called inside a callback); fixed unused `kind` destructure (`const [, setKind]`); added `name` to `useEffect` dependency array
- **`StatusMapTile.tsx`**: Removed unused `i` parameter from `REGIONS.map((r, i) => …)` → `REGIONS.map((r) => …)`
- **`SettingsView.tsx`**: Added missing `midnight` entry to `THEME_PREVIEWS` (`Record<Theme, …>` requires all four theme values)

## Test plan

- [ ] `npm run build` (or `next build`) completes with exit code 0 — no ESLint or TypeScript errors
- [ ] `docker compose build` succeeds and produces a new image
- [ ] Running the container shows the new tile-grid dashboard and customization toolbar
- [ ] Midnight theme preview renders correctly in Settings → Appearance

https://claude.ai/code/session_011vAGAK3erCqxBW1J645g8a

---
_Generated by [Claude Code](https://claude.ai/code/session_011vAGAK3erCqxBW1J645g8a)_