### PR TITLE
Fix Portainer infinite loading after redeploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ USER nextjs
 EXPOSE 3100
 VOLUME ["/app/data"]
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD wget -qO- http://127.0.0.1:3100/api/status >/dev/null 2>&1 || exit 1
 
 CMD ["node", "server.js"]

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  // better-sqlite3 is a native module and must not be bundled — it needs to be
+  // traced and copied into the standalone output as-is. In Next.js 14+ this
+  // option lives at the top level (it was promoted out of experimental in 14.0).
+  serverComponentsExternalPackages: ['better-sqlite3'],
   experimental: {
     instrumentationHook: true,
-    serverComponentsExternalPackages: ['better-sqlite3'],
   },
 };
 


### PR DESCRIPTION
## Summary

- **Root cause**: `serverComponentsExternalPackages: ['better-sqlite3']` was nested under `experimental` in `next.config.mjs`. In Next.js 14+, this option is a stable top-level config. Placing it under `experimental` causes it to be silently ignored, so webpack bundles `better-sqlite3` instead of treating it as an external native module. The standalone output then contains a broken server bundle that can't load the `.node` binary at runtime — crashing the server on startup and triggering a Portainer restart loop (visible as "stuck loading").
- **Secondary issue**: The `HEALTHCHECK --start-period=20s` was too short for the Next.js server to initialize SQLite and reach a healthy state. Bumped to 60s start-period and 10s timeout.

## Test plan

- [ ] Rebuild and redeploy the Docker image via Portainer ("Re-pull image and redeploy")
- [ ] Confirm container transitions from "starting" → "healthy" within ~60 seconds
- [ ] Confirm Portainer no longer shows the container stuck in an infinite loading state
- [ ] Verify `/api/status` responds with service data after startup

https://claude.ai/code/session_01EhrT9gKbrEXPnFricEDwRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhrT9gKbrEXPnFricEDwRQ)_