### PR TITLE
Fix Portainer redeploy: restore serverComponentsExternalPackages under experimental

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,12 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
-  // better-sqlite3 is a native module and must not be bundled — it needs to be
-  // traced and copied into the standalone output as-is. In Next.js 14+ this
-  // option lives at the top level (it was promoted out of experimental in 14.0).
-  serverComponentsExternalPackages: ['better-sqlite3'],
   experimental: {
     instrumentationHook: true,
+    // better-sqlite3 is a native module and must not be bundled — it needs to
+    // be traced and copied into the standalone output as-is. In Next.js 14
+    // this option lives under `experimental`; it was only promoted to the
+    // top level (and renamed `serverExternalPackages`) in Next.js 15.
+    serverComponentsExternalPackages: ['better-sqlite3'],
   },
 };
 


### PR DESCRIPTION
## Summary

PR #27 attempted to fix the "infinite loading after redeploy" by moving `serverComponentsExternalPackages: ['better-sqlite3']` from `experimental` to the top level of `next.config.mjs`, citing "promoted out of experimental in Next.js 14.0". **That premise is wrong** — the promotion (and rename to `serverExternalPackages`) happened in Next.js 15, not 14. This project pins `next@14.2.35`.

On Next 14, a top-level `serverComponentsExternalPackages` is an unrecognized key: Next prints a warning and silently ignores it. Webpack then tries to bundle the native `better-sqlite3` module, producing a standalone server bundle that can't load `better_sqlite3.node` at runtime. The container crashes on startup, and Portainer keeps failing the redeploy.

## Fix

Move `serverComponentsExternalPackages` back under `experimental` where Next 14 expects it.

## Verification

- `npm run build` completes without the "Unrecognized key" warning
- `.next/standalone/node_modules/better-sqlite3/build/Release/better_sqlite3.node` is present in the traced output (the native binary is copied in, not bundled)

## Test plan

- [ ] Redeploy the stack in Portainer ("Re-pull image and redeploy")
- [ ] Container transitions from `starting` → `healthy` within ~60s
- [ ] `/api/status` responds with service data after startup
- [ ] No `Cannot find module '../build/Release/better_sqlite3.node'` errors in container logs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hdzh4chuQ6a19peZCNyTgw)_