### PR TITLE
Fix /app/data ownership on container start via su-exec entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ ENV PORT=3100
 ENV HOSTNAME=0.0.0.0
 ENV DATABASE_PATH=/app/data/outage.db
 
-RUN addgroup --system --gid 1001 nodejs \
+RUN apk add --no-cache su-exec \
+    && addgroup --system --gid 1001 nodejs \
     && adduser --system --uid 1001 nextjs \
     && mkdir -p /app/data \
     && chown -R nextjs:nodejs /app
@@ -32,12 +33,14 @@ RUN addgroup --system --gid 1001 nodejs \
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-USER nextjs
 EXPOSE 3100
 VOLUME ["/app/data"]
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD wget -qO- http://127.0.0.1:3100/api/status >/dev/null 2>&1 || exit 1
 
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+# /app/data is a named docker volume (`outage-map-data`). If the volume was
+# ever populated by a container running as a different uid — or if Portainer
+# pre-creates the mount point as root — the uid 1001 `nextjs` user can't
+# write `outage.db`, getDb() throws, /api/status 500s, the HEALTHCHECK fails,
+# and Portainer keeps the stack in "starting" forever. Fix the ownership on
+# every boot, then drop privileges.
+mkdir -p /app/data
+chown -R nextjs:nodejs /app/data
+
+exec su-exec nextjs:nodejs "$@"


### PR DESCRIPTION
## Summary

Adds a small `docker-entrypoint.sh` that ensures the `/app/data` named volume is owned by `nextjs:nodejs` (uid/gid 1001) on every container start, then drops privileges via `su-exec` before launching `server.js`.

## Why

When the `outage-map-data` volume is owned by a different uid (e.g. root, because Portainer pre-created the mount point or because the volume predates the `USER nextjs` line in the Dockerfile), the runtime user can't write `outage.db`. `getDb()` throws, `/api/status` 500s, the `HEALTHCHECK` fails, and Portainer keeps the stack in `starting` — visible as a never-completing redeploy.

Fixing ownership in an entrypoint is the standard pattern for this — running as root briefly is contained to the chown step.

## Caveat / what this does NOT fix

The reported symptom is *"Portainer's redeploy page itself hangs and the container is never created"*. That happens **before** any entrypoint runs, so this PR alone may not be the full fix. If the hang is during `docker compose build` (most likely culprit: `better-sqlite3` falling back to a full source compile under Alpine + musl), we'll need a separate change — moving the runtime to `node:20-bookworm-slim`, or pinning a prebuilt better-sqlite3 binary that matches Alpine. Worth confirming once this change is in place whether redeploy still hangs.

## Test plan

- [ ] Redeploy the stack in Portainer ("Re-pull image and redeploy")
- [ ] Container transitions `starting` → `healthy` within ~60s, even on a volume that previously had root-owned files
- [ ] `/api/status` returns 200 with the service list
- [ ] `docker exec outage-map id` shows the running process as `uid=1001(nextjs)` — the entrypoint dropped privileges correctly

---
*Generated by [Claude Code](https://claude.ai/code/session_014szCcSjFcH9nxifvfRBvDR)*

---
_Generated by [Claude Code](https://claude.ai/code/session_014szCcSjFcH9nxifvfRBvDR)_