### PR TITLE
Switch to prebuilt Docker images with CI/CD publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,59 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'ROADMAP.md'
+      - '.github/workflows/issue-plan.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase image name
+        id: img
+        run: echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.img.outputs.name }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=ref,event=branch
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,21 @@ FROM base AS deps
 WORKDIR /app
 RUN apk add --no-cache python3 make g++
 COPY package.json package-lock.json ./
-RUN npm ci
+# Cache the npm download cache between builds — saves ~30s on rebuilds when
+# package-lock.json hasn't changed and the layer is being recreated (e.g.
+# Portainer's "re-pull and redeploy" with build context invalidation).
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm ci
 
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
-RUN npm run build
+# Persist Next.js's incremental build cache so unchanged routes don't
+# recompile on every redeploy.
+RUN --mount=type=cache,target=/app/.next/cache,sharing=locked \
+    npm run build
 
 FROM base AS runner
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -97,16 +97,34 @@ Open [http://localhost:3100](http://localhost:3100) to view the dashboard.
 
 ## Docker
 
-Build and run with the bundled `Dockerfile` and `docker-compose.yml`:
+The default `docker-compose.yml` pulls a prebuilt image from GitHub Container
+Registry (`ghcr.io/tri-lumen/outage-map:latest`). Every push to `main`
+publishes a new image via the `Build and publish Docker image` workflow.
 
 ```bash
-docker compose up -d --build
+docker compose up -d
 ```
 
 The SQLite database is persisted in the named volume `outage-map-data`
 (mounted at `/app/data` inside the container). Configure the container by
 creating a `.env` file next to `docker-compose.yml` (the compose file reads
 the same variables as `.env.example`).
+
+To pin a specific build instead of `:latest`, set `OUTAGE_MAP_IMAGE`:
+
+```bash
+OUTAGE_MAP_IMAGE=ghcr.io/tri-lumen/outage-map:sha-1a2b3c4 docker compose up -d
+```
+
+### Building locally (offline / development)
+
+If GHCR is unreachable or you want to test an unpushed change, layer in the
+`docker-compose.build.yml` overlay to switch back to building from the bundled
+`Dockerfile`:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+```
 
 ### Changing the host port
 
@@ -148,32 +166,54 @@ The stack can be deployed as a Portainer Stack in one of two ways:
    - `SMTP_*` and `ALERT_*` if you want email alerts
 6. Click **Deploy the stack**.
 
-Portainer will clone the repo, build the image via the Dockerfile, and
+Portainer will clone the repo, pull the prebuilt image from GHCR, and
 start the container. The `outage-map-data` volume will keep the SQLite
 database across redeploys.
+
+> **Note**: the published GHCR package must be public for Portainer to
+> pull it without credentials. After the first run of the
+> `Build and publish Docker image` workflow, open
+> `https://github.com/orgs/Tri-Lumen/packages/container/outage-map/settings`
+> and set the package visibility to **Public**. If you'd rather keep it
+> private, add a GHCR registry under **Registries** in Portainer with a
+> PAT that has `read:packages`.
 
 ### Option 2 — Web editor
 
 1. In Portainer, go to **Stacks → Add stack**.
 2. Choose **Build method: Web editor**.
 3. Paste the contents of `docker-compose.yml` into the editor.
-4. Because Portainer's web editor cannot build from a local Dockerfile, you
-   will need to point `image:` at a prebuilt image (for example a GHCR or
-   Docker Hub tag you've pushed) and remove the `build:` block.
-5. Add the same environment variables as in Option 1 and deploy.
+4. Add the same environment variables as in Option 1 and deploy.
+
+The compose file references the prebuilt GHCR image directly, so the web
+editor flow works without any further changes — Portainer just pulls and
+runs.
+
+### Option 3 — Local build (offline / air-gapped)
+
+If your Portainer host can't reach GHCR, point the **Compose path** at
+both files, comma-separated:
+
+```
+docker-compose.yml,docker-compose.build.yml
+```
+
+The overlay swaps the image source from GHCR back to a local Dockerfile
+build. Note: this is significantly slower than the prebuilt path (often
+3–7 minutes vs. seconds) and can exceed Portainer's HTTP proxy timeouts,
+leaving the "Saving..." spinner hanging even though the build is still
+running in the background.
 
 ### Updating
 
 From the stack page, click **Update the stack** (repository-based
-deployment) and enable **Re-pull image and redeploy** to rebuild with the
-latest code. The compose file sets `pull_policy: build`, so Portainer
-will build the image from the bundled `Dockerfile` rather than trying to
-pull a prebuilt image from a registry — this avoids "image not found"
-errors during re-pull. The SQLite volume is preserved automatically.
+deployment) and enable **Re-pull image and redeploy** to pull the latest
+GHCR image and recreate the container. The SQLite volume is preserved
+automatically.
 
-If you host your own prebuilt image in a registry (e.g. GHCR, Docker
-Hub), change the `image:` tag in `docker-compose.yml` to point at it and
-remove `pull_policy: build` (and optionally the `build:` block).
+The default compose file sets `pull_policy: always`, so every redeploy
+fetches the latest tag from GHCR even if the local Docker daemon has a
+cached copy.
 
 ## Environment variables
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,18 @@
+# Overlay that switches docker-compose.yml from pulling the prebuilt GHCR
+# image to building from the local Dockerfile. Use this when you can't reach
+# GHCR (offline / air-gapped environments) or when you want to test a local
+# code change without pushing it through CI.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+#
+# In Portainer (Repository deploy), set the Compose path to both files
+# separated by a comma:
+#   docker-compose.yml,docker-compose.build.yml
+services:
+  outage-map:
+    image: outage-map:local
+    pull_policy: build
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,15 @@
 services:
   outage-map:
-    image: outage-map:local
-    pull_policy: build
-    build:
-      context: .
-      dockerfile: Dockerfile
+    # Prebuilt image published by .github/workflows/docker-publish.yml on every
+    # push to main. Using a prebuilt image instead of `pull_policy: build` keeps
+    # Portainer redeploys fast (seconds, not minutes), which avoids the
+    # "Saving..." spinner hanging past Portainer's HTTP/proxy timeout while a
+    # local Dockerfile build is still running in the background.
+    #
+    # To build from source instead (offline or development), run
+    # `docker compose -f docker-compose.yml -f docker-compose.build.yml up -d`.
+    image: ${OUTAGE_MAP_IMAGE:-ghcr.io/tri-lumen/outage-map:latest}
+    pull_policy: always
     container_name: outage-map
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

This PR transitions the project from building Docker images locally to publishing prebuilt images via GitHub Actions, significantly improving deployment speed and simplifying the deployment process across different environments.

## Key Changes

- **New GitHub Actions workflow** (`.github/workflows/docker-publish.yml`): Automatically builds and publishes Docker images to GHCR on every push to `main`, tagging with `latest`, short SHA, and branch name
- **Updated `docker-compose.yml`**: Now pulls the prebuilt image from GHCR (`ghcr.io/tri-lumen/outage-map:latest`) instead of building locally, with support for pinning specific builds via the `OUTAGE_MAP_IMAGE` environment variable
- **New `docker-compose.build.yml` overlay**: Provides a way to switch back to local builds for offline/air-gapped environments or development without pushing changes
- **Dockerfile optimizations**: Added build cache mounts for npm and Next.js to speed up rebuilds when dependencies or source code haven't changed
- **Updated documentation**: Comprehensive README updates explaining the new prebuilt image approach, local build fallback, and Portainer deployment options (including a new Option 3 for offline deployments)

## Notable Implementation Details

- The prebuilt image approach reduces Portainer redeploys from 3–7 minutes to seconds, avoiding HTTP proxy timeouts
- `pull_policy: always` ensures the latest GHCR image is fetched on every redeploy
- Build cache mounts in the Dockerfile persist npm and Next.js caches between builds, saving ~30s on rebuilds when dependencies haven't changed
- The overlay pattern allows seamless switching between prebuilt and local builds without modifying the main compose file
- Documentation includes a note about setting the GHCR package to public for Portainer access, or using a PAT for private packages

https://claude.ai/code/session_01GQNs9mfkBQNUDjrowycM4E