### PR TITLE
Fix Docker builds for ARM hosts and non-BuildKit Portainer setups

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # QEMU lets the amd64 GitHub runner cross-build the arm64 image. Without
+      # this, `platforms: linux/arm64` below fails with "exec format error".
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -52,6 +59,10 @@ jobs:
         with:
           context: .
           push: true
+          # Build for both architectures so Portainer hosts on Raspberry Pi,
+          # Apple Silicon, Graviton, etc. can pull the same `:latest` tag.
+          # Without this, ARM hosts hit `no matching manifest for linux/arm64`.
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.6
-
 FROM node:20-alpine AS base
 RUN apk add --no-cache libc6-compat
 
@@ -7,21 +5,18 @@ FROM base AS deps
 WORKDIR /app
 RUN apk add --no-cache python3 make g++
 COPY package.json package-lock.json ./
-# Cache the npm download cache between builds — saves ~30s on rebuilds when
-# package-lock.json hasn't changed and the layer is being recreated (e.g.
-# Portainer's "re-pull and redeploy" with build context invalidation).
-RUN --mount=type=cache,target=/root/.npm,sharing=locked \
-    npm ci
+# Plain RUN (no BuildKit cache mounts) so the Dockerfile builds on Portainer
+# hosts where BuildKit isn't enabled — the legacy builder rejects `--mount`
+# with "unknown flag". Layer caching alone still skips this step on rebuilds
+# when package-lock.json is unchanged.
+RUN npm ci
 
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
-# Persist Next.js's incremental build cache so unchanged routes don't
-# recompile on every redeploy.
-RUN --mount=type=cache,target=/app/.next/cache,sharing=locked \
-    npm run build
+RUN npm run build
 
 FROM base AS runner
 WORKDIR /app


### PR DESCRIPTION
## Summary

Both deployment paths were failing on common Portainer configurations:

- **GHCR pull fails on ARM hosts** — the publish workflow built `linux/amd64` only, so Raspberry Pi, Apple Silicon, Graviton, and Oracle ARM hosts got `no matching manifest for linux/arm64` when pulling `ghcr.io/tri-lumen/outage-map:latest`.
- **Local build fails when BuildKit is off** — the Dockerfile used `# syntax=docker/dockerfile:1.6` and `RUN --mount=type=cache,...`. The legacy builder (still the default in older Docker / some Portainer-managed engines) rejects `--mount` with `unknown flag`, killing the build immediately.

## Changes

**`.github/workflows/docker-publish.yml`**
- Added `docker/setup-qemu-action@v3` (arm64 emulation) before buildx setup.
- Added `platforms: linux/amd64,linux/arm64` to `docker/build-push-action`. Same `:latest` tag now serves both architectures via a manifest list.

**`Dockerfile`**
- Removed `# syntax=docker/dockerfile:1.6` directive.
- Removed both `RUN --mount=type=cache,...` directives, replaced with plain `RUN`. Standard layer caching still skips `npm ci` on rebuilds when `package-lock.json` is unchanged — the cache mounts only sped up the cold-cache case, which isn't worth losing legacy-builder support over.

## Tradeoffs

- CI build time roughly doubles (arm64 cross-compile via QEMU is slow, especially `npm ci` building `better-sqlite3` from source). Acceptable for a once-per-merge publish.
- Cold-cache `npm ci` in local Portainer builds is ~30s slower without the cache mount. Warm rebuilds unchanged.

## Test plan

- [ ] CI workflow run on merge produces a multi-arch manifest — `docker manifest inspect ghcr.io/tri-lumen/outage-map:latest` lists both `linux/amd64` and `linux/arm64`.
- [ ] Pull on an ARM host (`docker pull ghcr.io/tri-lumen/outage-map:latest` on Pi / M1) succeeds without manifest errors.
- [ ] Local build via the overlay (`docker compose -f docker-compose.yml -f docker-compose.build.yml build`) succeeds with `DOCKER_BUILDKIT=0`.
- [ ] Local build via the overlay still succeeds with BuildKit on (default).
- [ ] Container starts healthy and `/api/status` returns 200.

---
_Generated by [Claude Code](https://claude.ai/code/session_015jNH9GqUzEr8QsGPaeidNb)_