### PR TITLE
Speed up container healthcheck so Portainer redeploys don't hang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,14 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 EXPOSE 3100
 VOLUME ["/app/data"]
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+# Tight interval + short start-period so docker marks the container healthy
+# within ~5–10s of the Next.js server binding the port. Portainer's redeploy
+# call gates on healthy state (via `docker compose up --wait` semantics); if
+# the first check doesn't fire until 30s in and start-period is 60s, a stack
+# update can run past the default HTTP/proxy timeout (~60s) and the "Saving…"
+# spinner hangs even though the deploy itself succeeded. /api/status is a
+# cheap SELECT against a small SQLite db, so a 5s interval is fine.
+HEALTHCHECK --interval=5s --timeout=5s --start-period=15s --retries=3 \
   CMD wget -qO- http://127.0.0.1:3100/api/status >/dev/null 2>&1 || exit 1
 
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
## Context

After PR #30 (prebuilt GHCR images) and PR #31 (multi-arch + non-BuildKit support), the user reports the Portainer redeploy UI still **"spins forever"** on an amd64 host pulling the public `ghcr.io/tri-lumen/outage-map:latest`. Image pull and image arch aren't the bottleneck — both are correct now. The most likely remaining cause is the healthcheck timing.

## Root cause hypothesis

Portainer's stack-update flow waits for the new container to reach `healthy` before returning the HTTP response (it uses `docker compose up --wait` semantics in recent versions). With the previous settings:

```
HEALTHCHECK --interval=30s --start-period=60s ...
```

…docker doesn't fire the first probe until **30 seconds** after the container starts, and the container cannot become healthy until that first successful probe — even though the Next.js server actually binds the port within 1–2s. Stacked on top of GHCR pull time (5–30s) and Portainer's own request overhead, total deploy time runs past a typical 60s nginx/proxy timeout and the UI spinner hangs even though the container came up fine.

## Change

Tighten the healthcheck:

```diff
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+HEALTHCHECK --interval=5s --timeout=5s --start-period=15s --retries=3 \
   CMD wget -qO- http://127.0.0.1:3100/api/status >/dev/null 2>&1 || exit 1
```

- First probe fires at **t=5s** instead of t=30s.
- `start-period=15s` still gives the SQLite init + Next.js cold start ample slack to fail a probe without being marked unhealthy.
- `/api/status` is a small `SELECT` against an empty-on-first-boot db, so a 5s cadence is negligible runtime cost.

Expected end-to-end deploy time (amd64 host, public GHCR pull): ~10–40s total, well inside a 60s proxy timeout.

## Caveats / what this does NOT fix

- If the user's host has a *much* lower proxy timeout (e.g. 15–30s), or if their connection to ghcr.io is the bottleneck, this won't be enough on its own — they'd need to either pre-pull the image (`docker pull ghcr.io/tri-lumen/outage-map:latest` from a shell on the host before clicking Redeploy in Portainer) or raise Portainer's proxy timeout.
- I don't have access to the Portainer logs or docker daemon logs for this specific deploy, so this is a high-likelihood guess based on the symptoms ("spins forever", amd64, GHCR pull, image is public + multi-arch confirmed). If it still hangs after this change, the next step is to grab `docker events` output and the Portainer container's stderr during a failing redeploy.

## Test plan

- [ ] Redeploy the stack in Portainer (Stacks → outage-map → "Re-pull image and redeploy")
- [ ] UI returns to the stack page within ~30s, no infinite "Saving…" spinner
- [ ] `docker ps` shows the container in `(healthy)` state within ~15s of start
- [ ] `/api/status` returns 200 from the host
- [ ] If it STILL hangs: capture `docker logs outage-map` + the Portainer container's logs during the redeploy and share — we'll need them to dig further

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqbsWh7jWFEDqugF4YbiJj)_