### PR TITLE
Use a DB-free /api/health endpoint so Portainer redeploys finish before proxy timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,15 +41,14 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 EXPOSE 3100
 VOLUME ["/app/data"]
 
-# Tight interval + short start-period so docker marks the container healthy
-# within ~5–10s of the Next.js server binding the port. Portainer's redeploy
-# call gates on healthy state (via `docker compose up --wait` semantics); if
-# the first check doesn't fire until 30s in and start-period is 60s, a stack
-# update can run past the default HTTP/proxy timeout (~60s) and the "Saving…"
-# spinner hangs even though the deploy itself succeeded. /api/status is a
-# cheap SELECT against a small SQLite db, so a 5s interval is fine.
-HEALTHCHECK --interval=5s --timeout=5s --start-period=15s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:3100/api/status >/dev/null 2>&1 || exit 1
+# /api/health is a static 200 OK that doesn't touch the database — so the
+# first probe succeeds the moment the Next.js server binds the port, even on
+# a fresh volume where SQLite still needs to run its CREATE TABLE migrations.
+# Combined with the short start-period this lets the container reach
+# `healthy` within a couple of seconds, well inside the upstream HTTP/proxy
+# timeout that Portainer's stack-update call rides on.
+HEALTHCHECK --interval=3s --timeout=3s --start-period=5s --retries=5 \
+  CMD wget -qO- http://127.0.0.1:3100/api/health >/dev/null 2>&1 || exit 1
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,7 +7,9 @@ set -e
 # write `outage.db`, getDb() throws, /api/status 500s, the HEALTHCHECK fails,
 # and Portainer keeps the stack in "starting" forever. Fix the ownership on
 # every boot, then drop privileges.
+echo "[entrypoint] preparing /app/data"
 mkdir -p /app/data
 chown -R nextjs:nodejs /app/data
 
+echo "[entrypoint] starting: $*"
 exec su-exec nextjs:nodejs "$@"

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+// Liveness probe target for the container HEALTHCHECK. Intentionally does NOT
+// touch the database, the filesystem, or any application module — it only
+// confirms that the Next.js HTTP server has bound the port and is serving
+// routes. /api/status was previously used here, but it opens SQLite, runs the
+// initial CREATE TABLE migrations on first boot, and queries two tables, so
+// the first probe on a fresh volume can take several seconds — long enough
+// for `docker compose up --wait` (which Portainer uses on redeploy) to keep
+// the stack-update HTTP call open past upstream proxy timeouts and hang the
+// "Saving…" spinner in the UI.
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export function GET() {
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
## Context

User reports the Portainer **redeploy UI still spins forever** after PR #32. The publish workflow for #32 ran successfully (run #3 on `4234412`) so the tightened healthcheck IS in the published `:latest` image — the previous fix didn't move the needle.

So the bottleneck isn't healthcheck *cadence*; it's the healthcheck *target*. The current `HEALTHCHECK` hits `/api/status`, which calls `getDb()` → opens SQLite, runs `CREATE TABLE IF NOT EXISTS` for 6 tables + indexes, runs an `ALTER TABLE` migration check, then queries two tables. On a freshly-created `outage-map-data` volume, the first probe also pays Next.js's lazy route-compilation cost for `/api/status`. Easily a few seconds of wall time.

While the container sits in `starting`, `docker compose up --wait` (Portainer's redeploy gate) keeps the HTTP request from the Portainer UI open. If the user's Portainer is behind a reverse proxy with a typical 60s timeout, the spinner can hang even though the container eventually comes up.

## Change

- **New `src/app/api/health/route.ts`** — returns `{ ok: true }`, no DB access, no imports beyond `NextResponse`. Compiles fast on first hit and responds instantly thereafter.
- **`Dockerfile` HEALTHCHECK** — switch target from `/api/status` to `/api/health`; drop `start-period` from 15s → 5s and bump `retries` 3 → 5 (cheaper probe, can afford more attempts).
- **`docker-entrypoint.sh`** — two extra `echo` lines so `docker logs outage-map` clearly shows the chown step and the exec into `node server.js`. Useful for telling apart "slow GHCR pull" vs "slow app boot" vs "slow healthcheck" without another guessing round if this doesn't fully resolve it.

## What this fixes vs. what it doesn't

**Fixes:** the case where the healthcheck itself is slow on first boot because `/api/status` does real work. Container will now be marked `healthy` within a couple of seconds of Node binding the port.

**Doesn't fix:**
- A slow `docker pull` from GHCR (image size / user's connection). `pull_policy: always` means every redeploy re-pulls; on a slow link this dominates the total time.
- Portainer's own UI/proxy timeout if it's set unusually low.
- The image not actually getting refreshed (cached `:latest` digest unchanged). The image hash *does* change with this PR, so the next "Re-pull image and redeploy" will fetch a fresh layer.

If the spinner still hangs after this is merged and the image is republished, grab `docker logs outage-map` during a failing redeploy — the new entrypoint echoes will make it obvious where time is being spent.

## Test plan

- [ ] Wait for `docker-publish.yml` to publish a new `:latest` after merge
- [ ] In Portainer: Stacks → outage-map → "Re-pull image and redeploy"
- [ ] UI returns to the stack page within ~30s (no infinite "Saving..." spinner)
- [ ] `docker ps` shows `(healthy)` within ~5–10s of container start
- [ ] `wget -qO- http://localhost:3100/api/health` returns `{"ok":true}`
- [ ] `wget -qO- http://localhost:3100/api/status` still returns the service list (unchanged behavior)
- [ ] `docker logs outage-map` shows the two `[entrypoint]` lines at boot

---
_Generated by [Claude Code](https://claude.ai/code/session_011SvjCRTEkR7xXQ6GWu42u4)_