### PR TITLE
Fall back to cached image when GHCR pull times out

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,20 @@ deployment) and enable **Re-pull image and redeploy** to pull the latest
 GHCR image and recreate the container. The SQLite volume is preserved
 automatically.
 
-The default compose file sets `pull_policy: always`, so every redeploy
-fetches the latest tag from GHCR even if the local Docker daemon has a
-cached copy.
+The compose file sets `pull_policy: missing`, so a redeploy will use the
+locally cached image when one exists. This keeps redeploys fast and
+resilient: if GHCR is slow or briefly unreachable, the stack still comes
+back up on the cached image instead of failing with a registry timeout
+like:
+
+```
+Get "https://ghcr.io/v2/": ... net/http: request canceled
+(Client.Timeout exceeded while awaiting headers)
+```
+
+To force a refresh to the latest published build, either tick
+**Re-pull image and redeploy** in Portainer or run
+`docker compose pull && docker compose up -d` from a shell.
 
 ## Environment variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,17 @@ services:
     # To build from source instead (offline or development), run
     # `docker compose -f docker-compose.yml -f docker-compose.build.yml up -d`.
     image: ${OUTAGE_MAP_IMAGE:-ghcr.io/tri-lumen/outage-map:latest}
-    pull_policy: always
+    # `missing` (not `always`) so a redeploy uses the cached image when GHCR
+    # is slow or unreachable. With `always`, the daemon blocks every redeploy
+    # on a synchronous registry fetch — if ghcr.io's token endpoint exceeds
+    # the Docker client timeout the whole deploy aborts with:
+    #   Get "https://ghcr.io/v2/": ... net/http: request canceled
+    #   (Client.Timeout exceeded while awaiting headers)
+    # even though a perfectly good cached image is sitting on the host. To
+    # pull updates explicitly, tick Portainer's "Re-pull image and redeploy"
+    # checkbox (runs `docker compose pull` first, then recreates), or run
+    # `docker compose pull && docker compose up -d` from a shell.
+    pull_policy: missing
     container_name: outage-map
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

Fixes the GHCR timeout that was killing redeploys:

```
Error response from daemon: Get "https://ghcr.io/v2/": Get "https://ghcr.io/token?account=Tri-Lumen&client_id=docker&offline_token=true&service=ghcr.io": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

`pull_policy: always` made every redeploy block on a synchronous fetch from `ghcr.io`. When the registry's token endpoint was slow or briefly unreachable, the Docker client timed out and the whole deploy aborted — even though a perfectly good cached image was sitting on the host.

Switching to `pull_policy: missing` lets the daemon use the cached image, so redeploys stay fast and resilient to GHCR hiccups. Updates still flow through Portainer's **Re-pull image and redeploy** checkbox (which runs `docker compose pull` separately before recreating), or via `docker compose pull && docker compose up -d` from a shell.

## Changes

- `docker-compose.yml`: `pull_policy: always` → `pull_policy: missing`, with a comment explaining the timeout failure mode it avoids.
- `README.md`: update the Portainer "Updating" section to describe the new pull behavior and show the timeout symptom this guards against.

## Test plan

- [ ] Redeploy the stack while GHCR is reachable with no local image — daemon pulls once, stack starts.
- [ ] Redeploy the stack with a cached image and a flaky/unreachable GHCR — stack comes back up on the cached image instead of failing with the timeout above.
- [ ] Tick Portainer's **Re-pull image and redeploy** — confirm the new `:latest` image is pulled and the container is recreated.
- [ ] `docker compose pull && docker compose up -d` from a shell — confirm it still updates to the newest image.

https://claude.ai/code/session_01W4ggBpqfdRk2P8qB2UsbDB

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4ggBpqfdRk2P8qB2UsbDB)_