### PR TITLE
Split docker build across native runners with per-arch GHA cache scope

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,8 +14,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  # One build job per architecture on a native runner. QEMU emulation made
+  # `next/font/google` fetches from fonts.gstatic.com hang during `next build`
+  # on the arm64 leg, and shared a single GHA cache scope across both arches.
+  # Native runners avoid emulation entirely and per-arch scopes let each
+  # platform's cache populate independently.
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -23,12 +38,67 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # QEMU lets the amd64 GitHub runner cross-build the arm64 image. Without
-      # this, `platforms: linux/arm64` below fails with "exec format error".
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          platforms: arm64
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase image name
+        id: img
+        run: echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.img.outputs.name }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Push the per-arch image by digest only; the merge job below
+          # attaches the human-readable tags once both digests exist.
+          outputs: type=image,name=${{ steps.img.outputs.name }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=build-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
+          provenance: false
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -54,17 +124,12 @@ jobs:
             type=sha,prefix=sha-,format=short
             type=ref,event=branch
 
-      - name: Build and push image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          # Build for both architectures so Portainer hosts on Raspberry Pi,
-          # Apple Silicon, Graviton, etc. can pull the same `:latest` tag.
-          # Without this, ARM hosts hit `no matching manifest for linux/arm64`.
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: false
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ steps.img.outputs.name }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ steps.img.outputs.name }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Summary

- Replace the single emulated `linux/amd64,linux/arm64` build with a matrix that runs each platform on a native runner (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64), then merge digests into a manifest list in a follow-up job.
- Give each platform its own GHA cache scope (`scope=build-amd64` / `scope=build-arm64`) so cache writes from one arch no longer evict the other's.

## Why

The previous build hung the arm64 leg on `next/font/google` requests to `fonts.gstatic.com` during `next build`:

```
#25 67.62 request to https://fonts.gstatic.com/s/lato/v25/S6uyw4BMUTPHjxAwXiWtFCfQ7A.woff2 failed, reason:
#25 67.62 Retrying 1/3...
```

`src/app/layout.tsx` pulls Noto Sans, Noto Sans Mono, Inter, Roboto, Source Sans 3, and Lato via `next/font/google`, and those downloads are unreliable under QEMU emulation on a GHA runner. Running arm64 natively eliminates the emulation entirely. As a side benefit, native arm64 builds are significantly faster and per-arch cache scopes let the two legs populate the GHA cache independently.

## Test plan

- [ ] First push after merge populates both `build-amd64` and `build-arm64` GHA cache scopes.
- [ ] Second push hits cache for unchanged layers on both arches.
- [ ] `docker buildx imagetools inspect ghcr.io/tri-lumen/outage-map:latest` shows both `linux/amd64` and `linux/arm64` entries.
- [ ] Pull and run `ghcr.io/tri-lumen/outage-map:latest` on an arm64 host (Pi / Apple Silicon) and confirm the app starts.

https://claude.ai/code/session_016pPWXV3PrC2N8Yap6kB6fs

---
_Generated by [Claude Code](https://claude.ai/code/session_016pPWXV3PrC2N8Yap6kB6fs)_