### PR TITLE
Dashboard customization: Waves 1 and 2

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1046,3 +1046,79 @@ select.twk-field {
 .board-btn-icon { padding: 7px 9px; }
 .board-btn:disabled,
 .board-btn[aria-disabled="true"] { opacity: 0.35; cursor: not-allowed; pointer-events: none; }
+
+/* ============================================================
+   SHORTCUTS OVERLAY
+   ============================================================ */
+
+.sc-overlay {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 60;
+  width: min(520px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  overflow: auto;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  box-shadow: 0 24px 60px -12px rgba(0, 0, 0, 0.6);
+  font-family: inherit;
+  color: var(--foreground);
+}
+
+.sc-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.sc-body {
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.sc-section-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--muted-strong);
+  margin-bottom: 6px;
+}
+
+.sc-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sc-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+}
+
+.sc-keys {
+  display: inline-flex;
+  gap: 4px;
+  min-width: 140px;
+}
+
+.sc-kbd {
+  display: inline-block;
+  padding: 2px 6px;
+  font-size: 11px;
+  border-radius: 5px;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  color: var(--foreground);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.sc-desc { color: var(--muted); }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1162,3 +1162,117 @@ select.twk-field {
 }
 
 .sc-desc { color: var(--muted); }
+
+/* ============================================================
+   BOARD TABS
+   ============================================================ */
+
+.board-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 6px;
+  flex-wrap: wrap;
+}
+
+.board-tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 2px 2px 2px 8px;
+  color: var(--muted);
+  font-size: 12.5px;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.board-tab-on {
+  background: var(--surface-elevated);
+  border-color: var(--accent);
+  color: var(--foreground);
+}
+
+.board-tab-label {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 5px 6px 5px 0;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.board-tab-star { color: var(--accent); font-size: 11px; }
+
+.board-tab-input {
+  background: var(--surface-elevated);
+  border: 1px solid var(--accent);
+  border-radius: 5px;
+  padding: 2px 6px;
+  font: inherit;
+  color: var(--foreground);
+  outline: none;
+  min-width: 80px;
+}
+
+.board-tab-more {
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 3px 6px;
+  font-size: 14px;
+  line-height: 1;
+  border-radius: 5px;
+  font-family: inherit;
+}
+.board-tab-more:hover { background: var(--surface); color: var(--foreground); }
+
+.board-tab-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 20;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 140px;
+  box-shadow: 0 12px 32px -8px rgba(0, 0, 0, 0.5);
+}
+.board-tab-menu button {
+  text-align: left;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-family: inherit;
+  color: var(--foreground);
+  padding: 6px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 12px;
+}
+.board-tab-menu button:hover { background: var(--surface); }
+.board-tab-menu-danger { color: #ef5350 !important; }
+
+.board-tab-add {
+  background: transparent;
+  border: 1px dashed var(--border-strong);
+  color: var(--muted);
+  border-radius: 8px;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-size: 16px;
+  font-family: inherit;
+  line-height: 1;
+}
+.board-tab-add:hover { color: var(--foreground); border-color: var(--accent); }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1382,3 +1382,24 @@ select.twk-field {
   font-weight: 700;
   margin-right: 2px;
 }
+
+/* ============================================================
+   TILE CONFIG DRAWER
+   ============================================================ */
+
+.tile-config-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(360px, 100vw);
+  z-index: 70;
+  background: var(--surface);
+  border-left: 1px solid var(--border-strong);
+  display: flex;
+  flex-direction: column;
+  box-shadow: -8px 0 24px -8px rgba(0, 0, 0, 0.4);
+  animation: slide-from-right 240ms ease;
+  overflow-y: auto;
+  font-family: inherit;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1403,3 +1403,27 @@ select.twk-field {
   overflow-y: auto;
   font-family: inherit;
 }
+
+.tile-selected {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.tile-selected.tile-edit-mode { border-style: solid; }
+
+.bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--surface);
+  border: 1px solid var(--accent);
+  border-radius: 9px;
+  font-size: 12px;
+  color: var(--foreground);
+  flex-wrap: wrap;
+}
+.bulk-bar-hint {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--muted);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1303,3 +1303,34 @@ select.twk-field {
   line-height: 1;
 }
 .board-tab-add:hover { color: var(--foreground); border-color: var(--accent); }
+
+/* ============================================================
+   PRESENT MODE
+   ============================================================ */
+
+.present-controls {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 40;
+  display: flex;
+  gap: 6px;
+  background: var(--surface-glass);
+  border: 1px solid var(--border-strong);
+  border-radius: 9px;
+  padding: 4px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 8px 20px -8px rgba(0, 0, 0, 0.5);
+}
+.present-controls button {
+  background: transparent;
+  border: 0;
+  color: var(--foreground);
+  font: inherit;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+.present-controls button:hover { background: var(--surface-elevated); }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1043,3 +1043,6 @@ select.twk-field {
 .board-btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
 .board-btn-edit-on { background: var(--accent-cyan); color: #001f1d; border-color: transparent; font-weight: 600; }
 .board-btn-edit-on:hover { filter: brightness(1.08); }
+.board-btn-icon { padding: 7px 9px; }
+.board-btn:disabled,
+.board-btn[aria-disabled="true"] { opacity: 0.35; cursor: not-allowed; pointer-events: none; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1437,3 +1437,26 @@ select.twk-field {
   background: transparent;
   cursor: pointer;
 }
+
+.tile-icon-text {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.tile-tag {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--accent-soft, rgba(38,139,210,0.18));
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  margin-left: 4px;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -783,6 +783,33 @@ html[data-density="compact"] .tile-inner {
 
 .add-tile-card:hover { border-color: var(--accent); transform: translateY(-1px); }
 
+.add-popover-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 12px;
+  padding: 3px;
+  background: var(--surface-elevated);
+  border-radius: 7px;
+}
+.add-popover-tabs button {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  font: inherit;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 8px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+.add-popover-tabs button[data-on="true"] {
+  background: var(--surface);
+  color: var(--foreground);
+}
+
 .import-cta {
   margin-top: 10px;
   width: 100%;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1334,3 +1334,27 @@ select.twk-field {
   cursor: pointer;
 }
 .present-controls button:hover { background: var(--surface-elevated); }
+
+.tile-refresh-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px dashed var(--border-subtle);
+  font-size: 10px;
+  color: var(--muted-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.tile-refresh-label { font-weight: 600; }
+.tile-refresh-select {
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  color: var(--foreground);
+  font: inherit;
+  font-family: inherit;
+  font-size: 11px;
+  padding: 1px 4px;
+  border-radius: 4px;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -248,6 +248,34 @@ html[data-grid-lines="on"] .tile-grid-edit {
   pointer-events: none;
 }
 
+.tile-resize-handle {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  width: 14px;
+  height: 14px;
+  z-index: 3;
+  cursor: nwse-resize;
+  border-radius: 3px;
+  background:
+    linear-gradient(135deg, transparent 60%, var(--muted) 60%, var(--muted) 70%, transparent 70%,
+                    transparent 80%, var(--muted) 80%, var(--muted) 90%, transparent 90%);
+  opacity: 0.6;
+  transition: opacity 120ms ease, background 120ms ease;
+}
+
+.tile-resize-handle:hover {
+  opacity: 1;
+  background:
+    linear-gradient(135deg, transparent 60%, var(--accent) 60%, var(--accent) 70%, transparent 70%,
+                    transparent 80%, var(--accent) 80%, var(--accent) 90%, transparent 90%);
+}
+
+.tile-resizing {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 .tile-inner {
   padding: 14px 14px 12px;
   height: 100%;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1427,3 +1427,13 @@ select.twk-field {
   font-size: 11px;
   color: var(--muted);
 }
+
+.twk-color {
+  width: 36px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1358,3 +1358,27 @@ select.twk-field {
   padding: 1px 4px;
   border-radius: 4px;
 }
+
+.tile-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px dashed var(--border-subtle);
+}
+.tile-filter-group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 3px;
+  margin-right: 6px;
+}
+.tile-filter-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--muted-strong);
+  font-weight: 700;
+  margin-right: 2px;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -289,6 +289,18 @@ html[data-density="compact"] .tile-inner {
   min-width: 0;
 }
 
+.tile-title-input {
+  flex: 1;
+  min-width: 0;
+  font: inherit;
+  color: var(--foreground);
+  background: var(--surface-elevated);
+  border: 1px solid var(--accent);
+  border-radius: 5px;
+  padding: 1px 5px;
+  outline: none;
+}
+
 .tile-actions { display: flex; gap: 2px; }
 
 .tile-btn {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -197,7 +197,7 @@ html[data-grid-lines="on"] .tile-grid-edit {
   background-image:
     linear-gradient(var(--border-subtle) 1px, transparent 1px),
     linear-gradient(90deg, var(--border-subtle) 1px, transparent 1px);
-  background-size: calc((100% - 80px) / 6) 88px;
+  background-size: calc((100% - 80px) / var(--grid-cols, 6)) 88px;
   border-radius: 8px;
 }
 

--- a/src/components/AddTilePopover.tsx
+++ b/src/components/AddTilePopover.tsx
@@ -1,12 +1,22 @@
 'use client';
 
-import type { TileType } from '@/hooks/useBoard';
+import { useEffect, useState } from 'react';
+import type { TileType, TileConfig } from '@/hooks/useBoard';
+import {
+  BUILTIN_TEMPLATES,
+  readUserTemplates,
+  saveUserTemplate,
+  deleteUserTemplate,
+  type Template,
+} from '@/lib/board/templates';
 
 interface Props {
   open: boolean;
   onClose: () => void;
   onAdd: (type: TileType) => void;
   onOpenImport: () => void;
+  onApplyTemplate?: (name: string, tiles: TileConfig[]) => void;
+  currentTiles?: TileConfig[];
 }
 
 const TILES: { type: TileType; name: string; desc: string }[] = [
@@ -19,8 +29,31 @@ const TILES: { type: TileType; name: string; desc: string }[] = [
   { type: 'rss',           name: 'RSS Feed',       desc: 'Engineering blogs, release notes' },
 ];
 
-export default function AddTilePopover({ open, onClose, onAdd, onOpenImport }: Props) {
+type Tab = 'tiles' | 'templates';
+
+export default function AddTilePopover({ open, onClose, onAdd, onOpenImport, onApplyTemplate, currentTiles }: Props) {
+  const [tab, setTab] = useState<Tab>('tiles');
+  const [userTemplates, setUserTemplates] = useState<Template[]>([]);
+  const [saveName, setSaveName] = useState('');
+
+  useEffect(() => {
+    if (open) setUserTemplates(readUserTemplates());
+  }, [open]);
+
   if (!open) return null;
+
+  const applyTemplate = (tpl: Template) => {
+    if (!onApplyTemplate) return;
+    onApplyTemplate(tpl.name, JSON.parse(JSON.stringify(tpl.tiles)));
+    onClose();
+  };
+
+  const handleSave = () => {
+    if (!saveName.trim() || !currentTiles) return;
+    saveUserTemplate(saveName.trim(), currentTiles);
+    setUserTemplates(readUserTemplates());
+    setSaveName('');
+  };
 
   return (
     <>
@@ -38,29 +71,101 @@ export default function AddTilePopover({ open, onClose, onAdd, onOpenImport }: P
           </button>
         </div>
 
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
-          {TILES.map((t) => (
-            <button
-              key={t.type}
-              className="add-tile-card"
-              onClick={() => { onAdd(t.type); onClose(); }}
-            >
-              <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--foreground)' }}>{t.name}</div>
-              <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 4 }}>{t.desc}</div>
-            </button>
-          ))}
+        <div className="add-popover-tabs">
+          <button data-on={tab === 'tiles'}     onClick={() => setTab('tiles')}>Tiles</button>
+          <button data-on={tab === 'templates'} onClick={() => setTab('templates')}>Templates</button>
         </div>
 
-        <button
-          className="import-cta"
-          onClick={() => { onClose(); onOpenImport(); }}
-        >
-          <span style={{ fontSize: 18 }}>＋</span>
-          <div style={{ textAlign: 'left' }}>
-            <div style={{ fontSize: 13, fontWeight: 600 }}>Import a custom service</div>
-            <div style={{ fontSize: 11, opacity: 0.8 }}>Paste an RSS feed, Statuspage, or HTTP endpoint</div>
+        {tab === 'tiles' && (
+          <>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+              {TILES.map((t) => (
+                <button
+                  key={t.type}
+                  className="add-tile-card"
+                  onClick={() => { onAdd(t.type); onClose(); }}
+                >
+                  <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--foreground)' }}>{t.name}</div>
+                  <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 4 }}>{t.desc}</div>
+                </button>
+              ))}
+            </div>
+
+            <button className="import-cta" onClick={() => { onClose(); onOpenImport(); }}>
+              <span style={{ fontSize: 18 }}>＋</span>
+              <div style={{ textAlign: 'left' }}>
+                <div style={{ fontSize: 13, fontWeight: 600 }}>Import a custom service</div>
+                <div style={{ fontSize: 11, opacity: 0.8 }}>Paste an RSS feed, Statuspage, or HTTP endpoint</div>
+              </div>
+            </button>
+          </>
+        )}
+
+        {tab === 'templates' && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div style={{ fontSize: 11, color: 'var(--muted-strong)', textTransform: 'uppercase', letterSpacing: 1 }}>Built-in</div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+              {BUILTIN_TEMPLATES.map((t) => (
+                <button key={t.id} className="add-tile-card" onClick={() => applyTemplate(t)}>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--foreground)' }}>{t.name}</div>
+                  <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 4 }}>{t.description}</div>
+                </button>
+              ))}
+            </div>
+
+            {userTemplates.length > 0 && (
+              <>
+                <div style={{ fontSize: 11, color: 'var(--muted-strong)', textTransform: 'uppercase', letterSpacing: 1, marginTop: 4 }}>
+                  Saved
+                </div>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+                  {userTemplates.map((t) => (
+                    <div key={t.id} className="add-tile-card" style={{ position: 'relative' }}>
+                      <button
+                        style={{ position: 'absolute', top: 4, right: 4, background: 'transparent', border: 0, color: 'var(--muted)', cursor: 'pointer', fontSize: 11 }}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          deleteUserTemplate(t.id);
+                          setUserTemplates(readUserTemplates());
+                        }}
+                        aria-label="Delete template"
+                        title="Delete"
+                      >✕</button>
+                      <button
+                        style={{ all: 'unset', cursor: 'pointer', display: 'block', width: '100%' }}
+                        onClick={() => applyTemplate(t)}
+                      >
+                        <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--foreground)' }}>{t.name}</div>
+                        <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 4 }}>{t.description}</div>
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+
+            {currentTiles && currentTiles.length > 0 && (
+              <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginTop: 4 }}>
+                <input
+                  type="text"
+                  placeholder="Save current as template…"
+                  value={saveName}
+                  onChange={(e) => setSaveName(e.target.value)}
+                  className="twk-field"
+                  style={{ flex: 1, fontSize: 12 }}
+                />
+                <button
+                  type="button"
+                  className="board-btn board-btn-primary"
+                  onClick={handleSave}
+                  disabled={!saveName.trim()}
+                >
+                  Save
+                </button>
+              </div>
+            )}
           </div>
-        </button>
+        )}
       </div>
     </>
   );

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -4,9 +4,20 @@ import { ReactNode } from 'react';
 import Sidebar from './Sidebar';
 import MobileNav from './MobileNav';
 import { SidebarProvider, useSidebar } from './SidebarContext';
+import { usePresentMode } from '@/hooks/usePresentMode';
 
 function ShellInner({ children }: { children: ReactNode }) {
   const { collapsed } = useSidebar();
+  const { present } = usePresentMode();
+
+  if (present) {
+    return (
+      <div className="min-h-screen bg-background text-foreground">
+        <main className="px-4 py-4">{children}</main>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen flex bg-background text-foreground">
       <Sidebar />

--- a/src/components/BoardTabs.tsx
+++ b/src/components/BoardTabs.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { UseBoardSet } from '@/hooks/useBoardSet';
+
+interface Props {
+  boardSet: UseBoardSet;
+}
+
+export default function BoardTabs({ boardSet }: Props) {
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [menuId, setMenuId] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (renamingId) inputRef.current?.select();
+  }, [renamingId]);
+
+  useEffect(() => {
+    if (!menuId) return;
+    const close = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuId(null);
+    };
+    window.addEventListener('mousedown', close);
+    return () => window.removeEventListener('mousedown', close);
+  }, [menuId]);
+
+  const commit = (id: string, value: string) => {
+    const trimmed = value.trim();
+    if (trimmed !== '') boardSet.renameBoard(id, trimmed);
+    setRenamingId(null);
+  };
+
+  return (
+    <div className="board-tabs">
+      {boardSet.boards.map((b) => {
+        const isActive = b.id === boardSet.activeId;
+        const isRenaming = renamingId === b.id;
+        return (
+          <div key={b.id} className={`board-tab ${isActive ? 'board-tab-on' : ''}`}>
+            {isRenaming ? (
+              <input
+                ref={inputRef}
+                className="board-tab-input"
+                defaultValue={b.name}
+                aria-label="Rename board"
+                onBlur={(e) => commit(b.id, e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commit(b.id, (e.target as HTMLInputElement).value);
+                  else if (e.key === 'Escape') setRenamingId(null);
+                }}
+              />
+            ) : (
+              <button
+                type="button"
+                className="board-tab-label"
+                onClick={() => boardSet.setActive(b.id)}
+                onDoubleClick={() => setRenamingId(b.id)}
+                title={b.starred ? `${b.name} (default)` : b.name}
+              >
+                {b.starred && <span className="board-tab-star" aria-hidden="true">★</span>}
+                {b.name}
+              </button>
+            )}
+            <button
+              type="button"
+              className="board-tab-more"
+              aria-label="Board options"
+              onClick={(e) => { e.stopPropagation(); setMenuId(menuId === b.id ? null : b.id); }}
+            >
+              ⋯
+            </button>
+            {menuId === b.id && (
+              <div className="board-tab-menu" ref={menuRef}>
+                <button onClick={() => { setRenamingId(b.id); setMenuId(null); }}>Rename</button>
+                <button onClick={() => { boardSet.duplicateBoard(b.id); setMenuId(null); }}>Duplicate</button>
+                <button onClick={() => { boardSet.starBoard(b.id); setMenuId(null); }}>
+                  {b.starred ? 'Default ✓' : 'Set as default'}
+                </button>
+                {boardSet.boards.length > 1 && (
+                  <button
+                    className="board-tab-menu-danger"
+                    onClick={() => { boardSet.deleteBoard(b.id); setMenuId(null); }}
+                  >
+                    Delete
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        className="board-tab-add"
+        aria-label="Add board"
+        onClick={() => boardSet.addBoard('Untitled', [])}
+        title="Add board"
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -20,6 +20,7 @@ import AddTilePopover from './AddTilePopover';
 import TweaksPanel from './TweaksPanel';
 import ShortcutsOverlay from './ShortcutsOverlay';
 import PresentControls from './PresentControls';
+import TileConfigDrawer from './TileConfigDrawer';
 
 export default function Dashboard() {
   const { theme, setTheme } = useTheme();
@@ -41,6 +42,8 @@ export default function Dashboard() {
   const [addOpen, setAddOpen]             = useState(false);
   const [tweaksOpen, setTweaksOpen]       = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [configTileId, setConfigTileId]   = useState<string | null>(null);
+  const configTile = configTileId ? board.find((t) => t.id === configTileId) ?? null : null;
 
   // Force-disable edit + overlays in present mode.
   useEffect(() => {
@@ -79,6 +82,7 @@ export default function Dashboard() {
     setAddOpen(false);
     setTweaksOpen(false);
     setShortcutsOpen(false);
+    setConfigTileId(null);
     if (present.present) exitPresent();
   };
 
@@ -299,6 +303,7 @@ export default function Dashboard() {
           onRenameTile={actions.renameTile}
           onMoveTile={actions.moveTile}
           onResizeTile={actions.resizeTile}
+          onConfigureTile={(id) => setConfigTileId(id)}
           onAddClick={() => setAddOpen(true)}
         />
       )}
@@ -334,6 +339,15 @@ export default function Dashboard() {
         setBoard={actions.setBoard}
         theme={theme}
         setTheme={setTheme}
+      />
+
+      <TileConfigDrawer
+        tile={configTile}
+        live={live}
+        onClose={() => setConfigTileId(null)}
+        onUpdate={actions.updateTile}
+        onRemove={actions.removeTile}
+        onDuplicate={actions.duplicateTile}
       />
 
       {present.present && <PresentControls />}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -23,7 +23,7 @@ import PresentControls from './PresentControls';
 import TileConfigDrawer from './TileConfigDrawer';
 
 export default function Dashboard() {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, customTheme, setCustomTheme } = useTheme();
   const [tweaks, tweaksApi] = useTweaks();
   const { setTweak, setTweaks } = tweaksApi;
   const breakpoint         = useBreakpoint();
@@ -390,6 +390,8 @@ export default function Dashboard() {
         setBoard={actions.setBoard}
         theme={theme}
         setTheme={setTheme}
+        customTheme={customTheme}
+        setCustomTheme={setCustomTheme}
       />
 
       <TileConfigDrawer

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -16,7 +16,8 @@ import TweaksPanel from './TweaksPanel';
 
 export default function Dashboard() {
   const { theme, setTheme } = useTheme();
-  const [tweaks, setTweak] = useTweaks();
+  const [tweaks, tweaksApi] = useTweaks();
+  const { setTweak, setTweaks } = tweaksApi;
   const [board, actions]   = useBoard();
   const prefs              = usePreferences();
 
@@ -216,6 +217,9 @@ export default function Dashboard() {
         onClose={() => setTweaksOpen(false)}
         tweaks={tweaks}
         setTweak={setTweak}
+        setTweaks={setTweaks}
+        board={board}
+        setBoard={actions.setBoard}
         theme={theme}
         setTheme={setTheme}
       />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -218,6 +218,7 @@ export default function Dashboard() {
           onSwapTiles={actions.swapTiles}
           onDuplicateTile={actions.duplicateTile}
           onRenameTile={actions.renameTile}
+          onMoveTile={actions.moveTile}
           onAddClick={() => setAddOpen(true)}
         />
       )}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -44,6 +44,23 @@ export default function Dashboard() {
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [configTileId, setConfigTileId]   = useState<string | null>(null);
   const configTile = configTileId ? board.find((t) => t.id === configTileId) ?? null : null;
+  const [selectedIds, setSelectedIds]     = useState<Set<string>>(new Set());
+  const selectedArr = useMemo(() => Array.from(selectedIds), [selectedIds]);
+
+  // Clear selection when leaving edit mode.
+  useEffect(() => {
+    if (!editing && selectedIds.size > 0) setSelectedIds(new Set());
+  }, [editing, selectedIds.size]);
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+  const clearSelection = () => setSelectedIds(new Set());
 
   // Force-disable edit + overlays in present mode.
   useEffect(() => {
@@ -66,6 +83,19 @@ export default function Dashboard() {
     return () => clearInterval(id);
   }, [present.present, present.rotateMs, boardSet]);
 
+  // Bulk-action shortcuts when tiles are selected.
+  useShortcuts(
+    {
+      'ArrowLeft':  () => actions.bulkMove(selectedArr, -1, 0),
+      'ArrowRight': () => actions.bulkMove(selectedArr,  1, 0),
+      'ArrowUp':    () => actions.bulkMove(selectedArr,  0, -1),
+      'ArrowDown':  () => actions.bulkMove(selectedArr,  0,  1),
+      'Backspace':  () => { actions.bulkDelete(selectedArr); clearSelection(); },
+      'mod+d':      () => actions.bulkDuplicate(selectedArr),
+    },
+    { enabled: editing && selectedIds.size > 0 },
+  );
+
   // Fullscreen shortcut (F) in present mode.
   useShortcuts(
     {
@@ -83,6 +113,7 @@ export default function Dashboard() {
     setTweaksOpen(false);
     setShortcutsOpen(false);
     setConfigTileId(null);
+    if (selectedIds.size > 0) setSelectedIds(new Set());
     if (present.present) exitPresent();
   };
 
@@ -268,6 +299,23 @@ export default function Dashboard() {
       </div>
       )}
 
+      {!present.present && editing && selectedIds.size > 0 && (
+        <div className="bulk-bar">
+          <span><b>{selectedIds.size}</b> selected</span>
+          <button
+            className="board-btn"
+            onClick={() => actions.bulkDuplicate(selectedArr)}
+          >Duplicate</button>
+          <button
+            className="board-btn"
+            style={{ color: '#ef5350' }}
+            onClick={() => { actions.bulkDelete(selectedArr); clearSelection(); }}
+          >Delete</button>
+          <span className="bulk-bar-hint">Arrow keys move · ⇧Click toggle · Esc clear</span>
+          <button className="board-btn" onClick={clearSelection}>Done</button>
+        </div>
+      )}
+
       {/* ── Tile grid ── */}
       {isLoading && board.length === 0 ? (
         <div
@@ -294,6 +342,9 @@ export default function Dashboard() {
           cols={COLS_FOR[breakpoint]}
           editing={editing}
           live={live}
+          selectedIds={selectedIds}
+          onToggleSelect={toggleSelect}
+          onClearSelection={clearSelection}
           onUpdateTile={actions.updateTile}
           onRemoveTile={actions.removeTile}
           onCycleResize={actions.cycleResize}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import { useServiceStatus, useIncidents, useHistory } from '@/hooks/useStatus';
 import { usePreferences } from '@/hooks/usePreferences';
 import { useBoard } from '@/hooks/useBoard';
+import { useBoardSet } from '@/hooks/useBoardSet';
 import { useBreakpoint, COLS_FOR } from '@/hooks/useBreakpoint';
 import { useTweaks } from '@/hooks/useTweaks';
 import { useShortcuts } from '@/hooks/useShortcuts';
@@ -12,6 +13,7 @@ import { formatRelativeTime } from '@/lib/format';
 import type { LiveData } from './tiles/types';
 import type { TileType } from '@/hooks/useBoard';
 import TileGrid from './TileGrid';
+import BoardTabs from './BoardTabs';
 import ImportSlideOver from './ImportSlideOver';
 import AddTilePopover from './AddTilePopover';
 import TweaksPanel from './TweaksPanel';
@@ -22,7 +24,13 @@ export default function Dashboard() {
   const [tweaks, tweaksApi] = useTweaks();
   const { setTweak, setTweaks } = tweaksApi;
   const breakpoint         = useBreakpoint();
-  const [board, actions]   = useBoard(breakpoint);
+  const boardSet           = useBoardSet();
+  const [board, actions]   = useBoard({
+    bp: breakpoint,
+    boardId: boardSet.activeId,
+    tiles: boardSet.active.tiles,
+    onCommit: boardSet.setActiveTiles,
+  });
   const prefs              = usePreferences();
 
   const [editing, setEditing]             = useState(false);
@@ -82,6 +90,9 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-6">
+      {/* ── Board tabs ── */}
+      <BoardTabs boardSet={boardSet} />
+
       {/* ── Board toolbar ── */}
       <div className="flex flex-col sm:flex-row sm:items-center gap-4">
         {/* Left: headline */}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useServiceStatus, useIncidents, useHistory } from '@/hooks/useStatus';
 import { usePreferences } from '@/hooks/usePreferences';
 import { useBoard } from '@/hooks/useBoard';
@@ -8,6 +8,7 @@ import { useBoardSet } from '@/hooks/useBoardSet';
 import { useBreakpoint, COLS_FOR } from '@/hooks/useBreakpoint';
 import { useTweaks } from '@/hooks/useTweaks';
 import { useShortcuts } from '@/hooks/useShortcuts';
+import { usePresentMode, enterPresent, exitPresent } from '@/hooks/usePresentMode';
 import { useTheme } from './ThemeProvider';
 import { formatRelativeTime } from '@/lib/format';
 import type { LiveData } from './tiles/types';
@@ -18,6 +19,7 @@ import ImportSlideOver from './ImportSlideOver';
 import AddTilePopover from './AddTilePopover';
 import TweaksPanel from './TweaksPanel';
 import ShortcutsOverlay from './ShortcutsOverlay';
+import PresentControls from './PresentControls';
 
 export default function Dashboard() {
   const { theme, setTheme } = useTheme();
@@ -32,6 +34,7 @@ export default function Dashboard() {
     onCommit: boardSet.setActiveTiles,
   });
   const prefs              = usePreferences();
+  const present            = usePresentMode();
 
   const [editing, setEditing]             = useState(false);
   const [importOpen, setImportOpen]       = useState(false);
@@ -39,11 +42,44 @@ export default function Dashboard() {
   const [tweaksOpen, setTweaksOpen]       = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
+  // Force-disable edit + overlays in present mode.
+  useEffect(() => {
+    if (!present.present) return;
+    setEditing(false);
+    setImportOpen(false);
+    setAddOpen(false);
+    setTweaksOpen(false);
+    setShortcutsOpen(false);
+  }, [present.present]);
+
+  // Auto-rotate active board in present mode.
+  useEffect(() => {
+    if (!present.present || !present.rotateMs || boardSet.boards.length <= 1) return;
+    const id = setInterval(() => {
+      const i = boardSet.boards.findIndex((b) => b.id === boardSet.activeId);
+      const next = boardSet.boards[(i + 1) % boardSet.boards.length];
+      if (next) boardSet.setActive(next.id);
+    }, present.rotateMs);
+    return () => clearInterval(id);
+  }, [present.present, present.rotateMs, boardSet]);
+
+  // Fullscreen shortcut (F) in present mode.
+  useShortcuts(
+    {
+      'f': () => {
+        if (document.fullscreenElement) document.exitFullscreen().catch(() => { /* ignore */ });
+        else document.documentElement.requestFullscreen().catch(() => { /* ignore */ });
+      },
+    },
+    { enabled: present.present },
+  );
+
   const closeAllOverlays = () => {
     setImportOpen(false);
     setAddOpen(false);
     setTweaksOpen(false);
     setShortcutsOpen(false);
+    if (present.present) exitPresent();
   };
 
   useShortcuts({
@@ -90,10 +126,11 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-6">
-      {/* ── Board tabs ── */}
-      <BoardTabs boardSet={boardSet} />
+      {/* ── Board tabs (hidden in present mode) ── */}
+      {!present.present && <BoardTabs boardSet={boardSet} />}
 
-      {/* ── Board toolbar ── */}
+      {/* ── Board toolbar (hidden in present mode) ── */}
+      {!present.present && (
       <div className="flex flex-col sm:flex-row sm:items-center gap-4">
         {/* Left: headline */}
         <div className="flex-1 min-w-0">
@@ -215,8 +252,17 @@ export default function Dashboard() {
             </svg>
             Tweaks
           </button>
+
+          <button className="board-btn" onClick={enterPresent} title="Presentation mode">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <rect x="2" y="3" width="20" height="14" rx="2" />
+              <path d="M8 21h8M12 17v4" />
+            </svg>
+            Present
+          </button>
         </div>
       </div>
+      )}
 
       {/* ── Tile grid ── */}
       {isLoading && board.length === 0 ? (
@@ -289,6 +335,8 @@ export default function Dashboard() {
         theme={theme}
         setTheme={setTheme}
       />
+
+      {present.present && <PresentControls />}
     </div>
   );
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useServiceStatus, useIncidents, useHistory } from '@/hooks/useStatus';
 import { usePreferences } from '@/hooks/usePreferences';
 import { useBoard } from '@/hooks/useBoard';
@@ -24,6 +24,21 @@ export default function Dashboard() {
   const [importOpen, setImportOpen] = useState(false);
   const [addOpen, setAddOpen]       = useState(false);
   const [tweaksOpen, setTweaksOpen] = useState(false);
+
+  // Undo / redo via Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z (or Cmd/Ctrl+Y).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+      const k = e.key.toLowerCase();
+      if (k === 'z' && !e.shiftKey) { e.preventDefault(); actions.undo(); }
+      else if ((k === 'z' && e.shiftKey) || k === 'y') { e.preventDefault(); actions.redo(); }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [actions]);
 
   const refreshMs = prefs.refreshInterval * 1000;
   const { data: statusData, isLoading } = useServiceStatus(refreshMs);
@@ -81,6 +96,34 @@ export default function Dashboard() {
             <span className="live-dot" />
             <span>Auto-refresh · {prefs.refreshInterval < 60 ? `${prefs.refreshInterval}s` : `${prefs.refreshInterval / 60}m`}</span>
           </div>
+
+          <button
+            className="board-btn board-btn-icon"
+            onClick={actions.undo}
+            disabled={!actions.canUndo}
+            aria-disabled={!actions.canUndo}
+            title="Undo (Ctrl/Cmd+Z)"
+            aria-label="Undo"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M3 7v6h6" />
+              <path d="M3 13a9 9 0 1 0 3-7.7L3 8" />
+            </svg>
+          </button>
+
+          <button
+            className="board-btn board-btn-icon"
+            onClick={actions.redo}
+            disabled={!actions.canRedo}
+            aria-disabled={!actions.canRedo}
+            title="Redo (Ctrl/Cmd+Shift+Z)"
+            aria-label="Redo"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M21 7v6h-6" />
+              <path d="M21 13a9 9 0 1 1-3-7.7L21 8" />
+            </svg>
+          </button>
 
           <button
             className={`board-btn ${editing ? 'board-btn-edit-on' : ''}`}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useServiceStatus, useIncidents, useHistory } from '@/hooks/useStatus';
 import { usePreferences } from '@/hooks/usePreferences';
 import { useBoard } from '@/hooks/useBoard';
 import { useTweaks } from '@/hooks/useTweaks';
+import { useShortcuts } from '@/hooks/useShortcuts';
 import { useTheme } from './ThemeProvider';
 import { formatRelativeTime } from '@/lib/format';
 import type { LiveData } from './tiles/types';
@@ -13,6 +14,7 @@ import TileGrid from './TileGrid';
 import ImportSlideOver from './ImportSlideOver';
 import AddTilePopover from './AddTilePopover';
 import TweaksPanel from './TweaksPanel';
+import ShortcutsOverlay from './ShortcutsOverlay';
 
 export default function Dashboard() {
   const { theme, setTheme } = useTheme();
@@ -21,25 +23,32 @@ export default function Dashboard() {
   const [board, actions]   = useBoard();
   const prefs              = usePreferences();
 
-  const [editing, setEditing]       = useState(false);
-  const [importOpen, setImportOpen] = useState(false);
-  const [addOpen, setAddOpen]       = useState(false);
-  const [tweaksOpen, setTweaksOpen] = useState(false);
+  const [editing, setEditing]             = useState(false);
+  const [importOpen, setImportOpen]       = useState(false);
+  const [addOpen, setAddOpen]             = useState(false);
+  const [tweaksOpen, setTweaksOpen]       = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
-  // Undo / redo via Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z (or Cmd/Ctrl+Y).
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement | null;
-      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
-      const mod = e.metaKey || e.ctrlKey;
-      if (!mod) return;
-      const k = e.key.toLowerCase();
-      if (k === 'z' && !e.shiftKey) { e.preventDefault(); actions.undo(); }
-      else if ((k === 'z' && e.shiftKey) || k === 'y') { e.preventDefault(); actions.redo(); }
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [actions]);
+  const closeAllOverlays = () => {
+    setImportOpen(false);
+    setAddOpen(false);
+    setTweaksOpen(false);
+    setShortcutsOpen(false);
+  };
+
+  useShortcuts({
+    'e':                 () => setEditing((v) => !v),
+    'a':                 () => setAddOpen((v) => !v),
+    'i':                 () => setImportOpen((v) => !v),
+    't':                 () => setTweaksOpen((v) => !v),
+    '?':                 () => setShortcutsOpen((v) => !v),
+    'shift+?':           () => setShortcutsOpen((v) => !v),
+    'shift+/':           () => setShortcutsOpen((v) => !v),
+    'Escape':            closeAllOverlays,
+    'mod+z':             () => actions.undo(),
+    'mod+shift+z':       () => actions.redo(),
+    'mod+y':             () => actions.redo(),
+  });
 
   const refreshMs = prefs.refreshInterval * 1000;
   const { data: statusData, isLoading } = useServiceStatus(refreshMs);
@@ -151,10 +160,23 @@ export default function Dashboard() {
           </button>
 
           <button
+            className="board-btn board-btn-icon"
+            onClick={() => setShortcutsOpen((o) => !o)}
+            title="Keyboard shortcuts (?)"
+            aria-label="Keyboard shortcuts"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="12" cy="12" r="10" />
+              <path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3" />
+              <line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+          </button>
+
+          <button
             className="board-btn"
             onClick={() => setTweaksOpen((o) => !o)}
             style={tweaksOpen ? { borderColor: 'var(--accent)', color: 'var(--accent)' } : {}}
-            title="Tweaks"
+            title="Tweaks (T)"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M10.5 6h9.75M10.5 6a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M3.75 6H7.5M4.5 12h9.75M4.5 12a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M14.25 12h5.25M4.5 18h9.75M4.5 18a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M14.25 18h5.25" />
@@ -210,6 +232,11 @@ export default function Dashboard() {
         onClose={() => setAddOpen(false)}
         onAdd={(type: TileType) => actions.addTile(type)}
         onOpenImport={() => { setAddOpen(false); setImportOpen(true); }}
+      />
+
+      <ShortcutsOverlay
+        open={shortcutsOpen}
+        onClose={() => setShortcutsOpen(false)}
       />
 
       <TweaksPanel

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import { useServiceStatus, useIncidents, useHistory } from '@/hooks/useStatus';
 import { usePreferences } from '@/hooks/usePreferences';
 import { useBoard } from '@/hooks/useBoard';
+import { useBreakpoint, COLS_FOR } from '@/hooks/useBreakpoint';
 import { useTweaks } from '@/hooks/useTweaks';
 import { useShortcuts } from '@/hooks/useShortcuts';
 import { useTheme } from './ThemeProvider';
@@ -20,7 +21,8 @@ export default function Dashboard() {
   const { theme, setTheme } = useTheme();
   const [tweaks, tweaksApi] = useTweaks();
   const { setTweak, setTweaks } = tweaksApi;
-  const [board, actions]   = useBoard();
+  const breakpoint         = useBreakpoint();
+  const [board, actions]   = useBoard(breakpoint);
   const prefs              = usePreferences();
 
   const [editing, setEditing]             = useState(false);
@@ -209,7 +211,7 @@ export default function Dashboard() {
       {isLoading && board.length === 0 ? (
         <div
           className="tile-grid"
-          style={{ gridTemplateColumns: 'repeat(6,1fr)' }}
+          style={{ gridTemplateColumns: `repeat(${COLS_FOR[breakpoint]},1fr)` }}
         >
           {[
             { col: 1, row: 2 }, { col: 1, row: 2 }, { col: 1, row: 2 }, { col: 1, row: 2 },
@@ -228,6 +230,7 @@ export default function Dashboard() {
       ) : (
         <TileGrid
           board={board}
+          cols={COLS_FOR[breakpoint]}
           editing={editing}
           live={live}
           onUpdateTile={actions.updateTile}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -145,6 +145,25 @@ export default function Dashboard() {
             {editing ? 'Done editing' : 'Edit board'}
           </button>
 
+          {editing && (
+            <button
+              className="board-btn"
+              onClick={actions.tidy}
+              title={
+                actions.lastTidyDelta === null
+                  ? 'Auto-arrange tiles'
+                  : actions.lastTidyDelta === 0
+                  ? 'Already tidy'
+                  : `Saved ${actions.lastTidyDelta} row${actions.lastTidyDelta === 1 ? '' : 's'}`
+              }
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M3 3h7v7H3zM14 3h7v7h-7zM3 14h7v7H3zM14 14h7v7h-7z" />
+              </svg>
+              Tidy
+            </button>
+          )}
+
           <button className="board-btn" onClick={() => setAddOpen(true)}>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M12 5v14M5 12h14" />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -269,6 +269,8 @@ export default function Dashboard() {
         onClose={() => setAddOpen(false)}
         onAdd={(type: TileType) => actions.addTile(type)}
         onOpenImport={() => { setAddOpen(false); setImportOpen(true); }}
+        onApplyTemplate={(name, tiles) => boardSet.addBoard(name, tiles)}
+        currentTiles={board}
       />
 
       <ShortcutsOverlay

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -216,6 +216,8 @@ export default function Dashboard() {
           onCycleResize={actions.cycleResize}
           onToggleDataPoint={actions.toggleDataPoint}
           onSwapTiles={actions.swapTiles}
+          onDuplicateTile={actions.duplicateTile}
+          onRenameTile={actions.renameTile}
           onAddClick={() => setAddOpen(true)}
         />
       )}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -219,6 +219,7 @@ export default function Dashboard() {
           onDuplicateTile={actions.duplicateTile}
           onRenameTile={actions.renameTile}
           onMoveTile={actions.moveTile}
+          onResizeTile={actions.resizeTile}
           onAddClick={() => setAddOpen(true)}
         />
       )}

--- a/src/components/PresentControls.tsx
+++ b/src/components/PresentControls.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { exitPresent } from '@/hooks/usePresentMode';
+
+export default function PresentControls() {
+  const [fullscreen, setFullscreen] = useState(false);
+
+  useEffect(() => {
+    const onChange = () => setFullscreen(!!document.fullscreenElement);
+    document.addEventListener('fullscreenchange', onChange);
+    return () => document.removeEventListener('fullscreenchange', onChange);
+  }, []);
+
+  const toggleFullscreen = () => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => { /* ignore */ });
+    } else {
+      document.documentElement.requestFullscreen().catch(() => { /* ignore */ });
+    }
+  };
+
+  return (
+    <div className="present-controls" role="toolbar" aria-label="Presentation controls">
+      <button onClick={toggleFullscreen} title="Toggle fullscreen (F)">
+        {fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+      </button>
+      <button onClick={exitPresent} title="Exit presentation (Esc)">
+        Exit
+      </button>
+    </div>
+  );
+}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -43,6 +43,18 @@ const THEME_PREVIEWS: Record<Theme, {
     secondaryBar: 'bg-[#64748b]',
     accentBar: 'bg-[#38bdf8]',
   },
+  'auto': {
+    wrapper: 'bg-gradient-to-br from-[#0a0a0a] to-[#fdf6e3] border-neutral-500',
+    primaryBar: 'bg-neutral-300',
+    secondaryBar: 'bg-neutral-500',
+    accentBar: 'bg-[#268bd2]',
+  },
+  'custom': {
+    wrapper: 'bg-[var(--surface)] border-[var(--border-strong)]',
+    primaryBar: 'bg-[var(--foreground)]',
+    secondaryBar: 'bg-[var(--muted)]',
+    accentBar: 'bg-[var(--accent)]',
+  },
 };
 
 export default function SettingsView() {

--- a/src/components/ShortcutsOverlay.tsx
+++ b/src/components/ShortcutsOverlay.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface ShortcutRow {
+  keys: string[];
+  desc: string;
+}
+
+const GLOBAL: ShortcutRow[] = [
+  { keys: ['E'],       desc: 'Toggle edit mode' },
+  { keys: ['A'],       desc: 'Add tile' },
+  { keys: ['I'],       desc: 'Import' },
+  { keys: ['T'],       desc: 'Tweaks' },
+  { keys: ['?'],       desc: 'This cheat-sheet' },
+  { keys: ['Esc'],     desc: 'Close overlays' },
+];
+
+const HISTORY: ShortcutRow[] = [
+  { keys: ['Ctrl', 'Z'],        desc: 'Undo' },
+  { keys: ['Ctrl', 'Shift', 'Z'], desc: 'Redo' },
+];
+
+const EDIT: ShortcutRow[] = [
+  { keys: ['←', '↑', '→', '↓'], desc: 'Move focused tile' },
+  { keys: ['Backspace'],        desc: 'Remove focused tile' },
+  { keys: ['Ctrl', 'D'],        desc: 'Duplicate focused tile' },
+  { keys: ['Shift', 'Drag'],    desc: 'Swap (instead of reflow)' },
+];
+
+function Section({ title, rows }: { title: string; rows: ShortcutRow[] }) {
+  return (
+    <div className="sc-section">
+      <div className="sc-section-title">{title}</div>
+      <div className="sc-rows">
+        {rows.map((r, i) => (
+          <div className="sc-row" key={i}>
+            <div className="sc-keys">
+              {r.keys.map((k, j) => (
+                <kbd key={j} className="sc-kbd">{k}</kbd>
+              ))}
+            </div>
+            <div className="sc-desc">{r.desc}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function ShortcutsOverlay({ open, onClose }: Props) {
+  if (!open) return null;
+  return (
+    <>
+      <div className="slideover-backdrop" onClick={onClose} />
+      <div className="sc-overlay" role="dialog" aria-label="Keyboard shortcuts">
+        <div className="sc-head">
+          <b>Keyboard shortcuts</b>
+          <button className="twk-x" onClick={onClose} aria-label="Close">✕</button>
+        </div>
+        <div className="sc-body">
+          <Section title="Global" rows={GLOBAL} />
+          <Section title="History" rows={HISTORY} />
+          <Section title="Edit mode" rows={EDIT} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,44 +1,58 @@
 'use client';
 
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useState, ReactNode } from 'react';
 
-export type Theme = 'solarized-dark' | 'solarized-light' | 'black-grey' | 'midnight';
+export type Theme = 'solarized-dark' | 'solarized-light' | 'black-grey' | 'midnight' | 'auto' | 'custom';
 
 export const THEMES: { value: Theme; label: string; description: string }[] = [
-  {
-    value: 'solarized-dark',
-    label: 'Solarized Dark',
-    description: 'Warm cyan-on-teal palette from Ethan Schoonover.',
-  },
-  {
-    value: 'solarized-light',
-    label: 'Solarized Light',
-    description: 'Cream-and-ink variant of the Solarized palette.',
-  },
-  {
-    value: 'black-grey',
-    label: 'Classic Dark',
-    description: 'Traditional near-black background with neutral greys.',
-  },
-  {
-    value: 'midnight',
-    label: 'Midnight',
-    description: 'Deep navy blue with slate accents.',
-  },
+  { value: 'auto',            label: 'Auto (system)',  description: 'Follows your OS light/dark preference.' },
+  { value: 'solarized-dark',  label: 'Solarized Dark', description: 'Warm cyan-on-teal palette from Ethan Schoonover.' },
+  { value: 'solarized-light', label: 'Solarized Light', description: 'Cream-and-ink variant of the Solarized palette.' },
+  { value: 'black-grey',      label: 'Classic Dark',   description: 'Traditional near-black background with neutral greys.' },
+  { value: 'midnight',        label: 'Midnight',        description: 'Deep navy blue with slate accents.' },
+  { value: 'custom',          label: 'Custom…',        description: 'Pick your own background / surface / foreground / muted.' },
 ];
 
+const CONCRETE_THEMES: Theme[] = ['solarized-dark', 'solarized-light', 'black-grey', 'midnight', 'custom'];
 const VALID_THEMES: Theme[] = THEMES.map((t) => t.value);
 const DEFAULT_THEME: Theme = 'solarized-dark';
 const STORAGE_KEY = 'outage-map-theme';
+const CUSTOM_STORAGE_KEY = 'outage-map-custom-theme';
 const LEGACY_MAP: Record<string, Theme> = {
   dark: 'solarized-dark',
   light: 'solarized-light',
+};
+
+export interface CustomTheme {
+  background: string;
+  surface: string;
+  surfaceElevated: string;
+  foreground: string;
+  muted: string;
+}
+
+export const DEFAULT_CUSTOM_THEME: CustomTheme = {
+  background: '#0a0a0a',
+  surface: '#141414',
+  surfaceElevated: '#1f1f1f',
+  foreground: '#e5e5e5',
+  muted: '#a3a3a3',
+};
+
+const CUSTOM_VAR_MAP: Record<keyof CustomTheme, string> = {
+  background:      '--background',
+  surface:         '--surface',
+  surfaceElevated: '--surface-elevated',
+  foreground:      '--foreground',
+  muted:           '--muted',
 };
 
 interface ThemeContextValue {
   theme: Theme;
   setTheme: (theme: Theme) => void;
   toggle: () => void;
+  customTheme: CustomTheme;
+  setCustomTheme: (next: Partial<CustomTheme>) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
@@ -47,46 +61,79 @@ function isTheme(value: string | null): value is Theme {
   return !!value && (VALID_THEMES as string[]).includes(value);
 }
 
-function applyTheme(theme: Theme) {
+function systemPreference(): 'solarized-dark' | 'solarized-light' {
+  if (typeof window === 'undefined') return 'solarized-dark';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'solarized-dark' : 'solarized-light';
+}
+
+function applyTheme(theme: Theme, customTheme: CustomTheme) {
   const root = document.documentElement;
-  // Remove all theme classes and set the new one
-  root.classList.remove(...VALID_THEMES);
-  root.classList.add(theme);
-  // Also set data-theme attribute for CSS selectors in the new design
-  root.dataset.theme = theme;
+  const concrete = theme === 'auto' ? systemPreference() : theme;
+  root.classList.remove(...CONCRETE_THEMES);
+  root.classList.add(concrete);
+  root.dataset.theme = concrete;
+
+  // Clear inline custom vars; re-apply only when theme is 'custom'.
+  for (const cssVar of Object.values(CUSTOM_VAR_MAP)) {
+    root.style.removeProperty(cssVar);
+  }
+  if (theme === 'custom') {
+    for (const [k, cssVar] of Object.entries(CUSTOM_VAR_MAP) as [keyof CustomTheme, string][]) {
+      root.style.setProperty(cssVar, customTheme[k]);
+    }
+  }
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<Theme>(DEFAULT_THEME);
+  const [customTheme, setCustomThemeState] = useState<CustomTheme>(DEFAULT_CUSTOM_THEME);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (isTheme(stored)) {
-      setThemeState(stored);
-    } else if (stored && stored in LEGACY_MAP) {
-      setThemeState(LEGACY_MAP[stored]);
-    }
+    if (isTheme(stored)) setThemeState(stored);
+    else if (stored && stored in LEGACY_MAP) setThemeState(LEGACY_MAP[stored]);
+
+    try {
+      const customRaw = localStorage.getItem(CUSTOM_STORAGE_KEY);
+      if (customRaw) {
+        const parsed = JSON.parse(customRaw) as Partial<CustomTheme>;
+        setCustomThemeState({ ...DEFAULT_CUSTOM_THEME, ...parsed });
+      }
+    } catch { /* ignore */ }
   }, []);
 
   useEffect(() => {
-    applyTheme(theme);
-    try {
-      localStorage.setItem(STORAGE_KEY, theme);
-    } catch {
-      // ignore storage errors
-    }
-  }, [theme]);
+    applyTheme(theme, customTheme);
+    try { localStorage.setItem(STORAGE_KEY, theme); } catch { /* ignore */ }
+  }, [theme, customTheme]);
 
-  const setTheme = (next: Theme) => setThemeState(next);
-  const toggle = () =>
+  // Auto-follow OS light/dark while theme === 'auto'.
+  useEffect(() => {
+    if (theme !== 'auto' || typeof window === 'undefined') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = () => applyTheme('auto', customTheme);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, [theme, customTheme]);
+
+  const setTheme = useCallback((next: Theme) => setThemeState(next), []);
+  const toggle = useCallback(() =>
     setThemeState((t) => {
       const idx = VALID_THEMES.indexOf(t);
       return VALID_THEMES[(idx + 1) % VALID_THEMES.length];
+    }), []);
+
+  const setCustomTheme = useCallback((patch: Partial<CustomTheme>) => {
+    setCustomThemeState((prev) => {
+      const next = { ...prev, ...patch };
+      try { localStorage.setItem(CUSTOM_STORAGE_KEY, JSON.stringify(next)); } catch { /* ignore */ }
+      return next;
     });
+  }, []);
 
   return (
-    <ThemeContext.Provider value={{ theme, setTheme, toggle }}>
+    <ThemeContext.Provider value={{ theme, setTheme, toggle, customTheme, setCustomTheme }}>
       {children}
     </ThemeContext.Provider>
   );
@@ -95,7 +142,13 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 export function useTheme(): ThemeContextValue {
   const ctx = useContext(ThemeContext);
   if (!ctx) {
-    return { theme: DEFAULT_THEME, setTheme: () => {}, toggle: () => {} };
+    return {
+      theme: DEFAULT_THEME,
+      setTheme: () => {},
+      toggle: () => {},
+      customTheme: DEFAULT_CUSTOM_THEME,
+      setCustomTheme: () => {},
+    };
   }
   return ctx;
 }

--- a/src/components/TileConfigDrawer.tsx
+++ b/src/components/TileConfigDrawer.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import type { TileConfig } from '@/hooks/useBoard';
+import type { LiveData } from './tiles/types';
+import { TILE_CONFIG_FORMS } from './tiles/configs';
+
+interface Props {
+  tile: TileConfig | null;
+  live: LiveData;
+  onClose: () => void;
+  onUpdate: (id: string, patch: Partial<TileConfig>) => void;
+  onRemove: (id: string) => void;
+  onDuplicate: (id: string) => void;
+}
+
+export default function TileConfigDrawer({ tile, live, onClose, onUpdate, onRemove, onDuplicate }: Props) {
+  if (!tile) return null;
+  const Form = TILE_CONFIG_FORMS[tile.type];
+  const title =
+    (typeof tile.config.label === 'string' && tile.config.label) || tile.type.replace(/-/g, ' ');
+
+  return (
+    <>
+      <div className="slideover-backdrop" onClick={onClose} />
+      <div className="tile-config-drawer" role="dialog" aria-label={`Configure ${title}`}>
+        <div className="twk-hd">
+          <b style={{ textTransform: 'capitalize' }}>{title}</b>
+          <button className="twk-x" onClick={onClose} aria-label="Close">✕</button>
+        </div>
+        <div className="twk-body">
+          {Form ? <Form tile={tile} live={live} onUpdate={(patch) => onUpdate(tile.id, patch)} /> : null}
+
+          <div className="twk-sect">Actions</div>
+          <div className="twk-row twk-row-h">
+            <div className="twk-lbl"><span>Duplicate</span></div>
+            <button className="board-btn" onClick={() => onDuplicate(tile.id)}>Duplicate</button>
+          </div>
+          <div className="twk-row twk-row-h">
+            <div className="twk-lbl"><span>Remove</span></div>
+            <button
+              className="board-btn"
+              style={{ color: '#ef5350', borderColor: '#ef5350' }}
+              onClick={() => { onRemove(tile.id); onClose(); }}
+            >
+              Remove tile
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/TileGrid.tsx
+++ b/src/components/TileGrid.tsx
@@ -31,10 +31,11 @@ interface TileGridProps {
   onRenameTile: (id: string, label: string | null) => void;
   onMoveTile: (id: string, x: number, y: number) => void;
   onResizeTile: (id: string, w: number, h: number) => void;
+  onConfigureTile: (id: string) => void;
   onAddClick: () => void;
 }
 
-function TileComponent({ tile, editing, live, onUpdate, onRemove, onResize, onToggleDataPoint, onDuplicate, onRename }: {
+function TileComponent({ tile, editing, live, onUpdate, onRemove, onResize, onToggleDataPoint, onDuplicate, onRename, onConfigure }: {
   tile: TileConfig;
   editing: boolean;
   live: LiveData;
@@ -44,6 +45,7 @@ function TileComponent({ tile, editing, live, onUpdate, onRemove, onResize, onTo
   onToggleDataPoint: (key: string) => void;
   onDuplicate: () => void;
   onRename: (label: string | null) => void;
+  onConfigure: () => void;
 }) {
   const common = {
     config: tile.config,
@@ -55,6 +57,7 @@ function TileComponent({ tile, editing, live, onUpdate, onRemove, onResize, onTo
     onRemove,
     onDuplicate,
     onRename,
+    onConfigure,
     live,
   };
 
@@ -85,6 +88,7 @@ export default function TileGrid({
   onRenameTile,
   onMoveTile,
   onResizeTile,
+  onConfigureTile,
   onAddClick,
 }: TileGridProps) {
   const [dragId, setDragId] = useState<string | null>(null);
@@ -241,6 +245,7 @@ export default function TileGrid({
             onToggleDataPoint={(key) => onToggleDataPoint(tile.id, key)}
             onDuplicate={() => onDuplicateTile(tile.id)}
             onRename={(label) => onRenameTile(tile.id, label)}
+            onConfigure={() => onConfigureTile(tile.id)}
           />
         </div>
         );

--- a/src/components/TileGrid.tsx
+++ b/src/components/TileGrid.tsx
@@ -22,6 +22,9 @@ interface TileGridProps {
   cols: number;
   editing: boolean;
   live: LiveData;
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string) => void;
+  onClearSelection: () => void;
   onUpdateTile: (id: string, patch: Partial<TileConfig>) => void;
   onRemoveTile: (id: string) => void;
   onCycleResize: (id: string) => void;
@@ -79,6 +82,9 @@ export default function TileGrid({
   cols,
   editing,
   live,
+  selectedIds,
+  onToggleSelect,
+  onClearSelection,
   onUpdateTile,
   onRemoveTile,
   onCycleResize,
@@ -198,6 +204,7 @@ export default function TileGrid({
             dragId === tile.id ? 'tile-dragging' : '',
             dragOverId === tile.id && dragId !== tile.id ? 'tile-drag-over' : '',
             resizePreview?.id === tile.id ? 'tile-resizing' : '',
+            selectedIds.has(tile.id) ? 'tile-selected' : '',
           ]
             .filter(Boolean)
             .join(' ')}
@@ -212,6 +219,19 @@ export default function TileGrid({
           onDragOver={(e) => { e.preventDefault(); setDragOverId(tile.id); }}
           onDragLeave={() => setDragOverId(null)}
           onDragEnd={() => { setDragId(null); setDragOverId(null); dropTargetRef.current = null; }}
+          onClickCapture={(e) => {
+            if (!editing) return;
+            // Don't hijack clicks on action buttons / inputs inside the tile.
+            const target = e.target as HTMLElement;
+            if (target.closest('button, input, select, textarea, a, .tile-resize-handle')) return;
+            if (e.shiftKey) {
+              e.preventDefault();
+              e.stopPropagation();
+              onToggleSelect(tile.id);
+            } else if (selectedIds.size > 0) {
+              onClearSelection();
+            }
+          }}
         >
           {editing && (
             <div className="drag-handle" aria-hidden="true">

--- a/src/components/TileGrid.tsx
+++ b/src/components/TileGrid.tsx
@@ -23,10 +23,12 @@ interface TileGridProps {
   onCycleResize: (id: string) => void;
   onToggleDataPoint: (id: string, key: string) => void;
   onSwapTiles: (srcId: string, tgtId: string) => void;
+  onDuplicateTile: (id: string) => void;
+  onRenameTile: (id: string, label: string | null) => void;
   onAddClick: () => void;
 }
 
-function TileComponent({ tile, editing, live, onUpdate, onRemove, onResize, onToggleDataPoint }: {
+function TileComponent({ tile, editing, live, onUpdate, onRemove, onResize, onToggleDataPoint, onDuplicate, onRename }: {
   tile: TileConfig;
   editing: boolean;
   live: LiveData;
@@ -34,6 +36,8 @@ function TileComponent({ tile, editing, live, onUpdate, onRemove, onResize, onTo
   onRemove: () => void;
   onResize: () => void;
   onToggleDataPoint: (key: string) => void;
+  onDuplicate: () => void;
+  onRename: (label: string | null) => void;
 }) {
   const common = {
     config: tile.config,
@@ -43,6 +47,8 @@ function TileComponent({ tile, editing, live, onUpdate, onRemove, onResize, onTo
     onConfigChange: (patch: Record<string, unknown>) => onUpdate({ config: patch }),
     onResize,
     onRemove,
+    onDuplicate,
+    onRename,
     live,
   };
 
@@ -68,6 +74,8 @@ export default function TileGrid({
   onCycleResize,
   onToggleDataPoint,
   onSwapTiles,
+  onDuplicateTile,
+  onRenameTile,
   onAddClick,
 }: TileGridProps) {
   const [dragId, setDragId] = useState<string | null>(null);
@@ -126,6 +134,8 @@ export default function TileGrid({
             onRemove={() => onRemoveTile(tile.id)}
             onResize={() => onCycleResize(tile.id)}
             onToggleDataPoint={(key) => onToggleDataPoint(tile.id, key)}
+            onDuplicate={() => onDuplicateTile(tile.id)}
+            onRename={(label) => onRenameTile(tile.id, label)}
           />
         </div>
       ))}

--- a/src/components/TileGrid.tsx
+++ b/src/components/TileGrid.tsx
@@ -2,7 +2,6 @@
 
 import { useRef, useState } from 'react';
 import type { TileConfig } from '@/hooks/useBoard';
-import { DEFAULT_COLS } from '@/lib/board/layout';
 import type { LiveData } from './tiles/types';
 import ServiceWatchTile from './tiles/ServiceWatchTile';
 import ServiceGridTile from './tiles/ServiceGridTile';
@@ -13,7 +12,6 @@ import UptimeChartTile from './tiles/UptimeChartTile';
 import StatusMapTile from './tiles/StatusMapTile';
 import StatusPageTile from './tiles/StatusPageTile';
 
-const GRID_COLS = DEFAULT_COLS;
 const ROW_HEIGHT = 88;            // matches .tile-grid grid-auto-rows in globals.css
 const ROW_HEIGHT_COMPACT = 72;    // ".compact" density override
 const GAP = 16;
@@ -21,6 +19,7 @@ const GAP_COMPACT = 10;
 
 interface TileGridProps {
   board: TileConfig[];
+  cols: number;
   editing: boolean;
   live: LiveData;
   onUpdateTile: (id: string, patch: Partial<TileConfig>) => void;
@@ -74,6 +73,7 @@ function TileComponent({ tile, editing, live, onUpdate, onRemove, onResize, onTo
 
 export default function TileGrid({
   board,
+  cols,
   editing,
   live,
   onUpdateTile,
@@ -99,7 +99,7 @@ export default function TileGrid({
     const compact = typeof document !== 'undefined' && document.documentElement.dataset.density === 'compact';
     const rowH = compact ? ROW_HEIGHT_COMPACT : ROW_HEIGHT;
     const gap = compact ? GAP_COMPACT : GAP;
-    const colW = el ? (el.getBoundingClientRect().width - gap * (GRID_COLS - 1)) / GRID_COLS : 100;
+    const colW = el ? (el.getBoundingClientRect().width - gap * (cols - 1)) / cols : 100;
     return { colW, rowH, gap };
   };
 
@@ -116,7 +116,7 @@ export default function TileGrid({
     const move = (ev: MouseEvent) => {
       const dw = Math.round((ev.clientX - startX) / (colW + gap));
       const dh = Math.round((ev.clientY - startY) / (rowH + gap));
-      const w = Math.max(1, Math.min(GRID_COLS - tile.x, startW + dw));
+      const w = Math.max(1, Math.min(cols - tile.x, startW + dw));
       const h = Math.max(1, startH + dh);
       setResizePreview({ id: tile.id, w, h });
     };
@@ -148,7 +148,7 @@ export default function TileGrid({
     if (!el) return null;
     const r = el.getBoundingClientRect();
     const { colW, rowH, gap } = cellSize();
-    const x = Math.max(0, Math.min(GRID_COLS - 1, Math.floor((clientX - r.left) / (colW + gap))));
+    const x = Math.max(0, Math.min(cols - 1, Math.floor((clientX - r.left) / (colW + gap))));
     const y = Math.max(0, Math.floor((clientY - r.top) / (rowH + gap)));
     return { x, y };
   };
@@ -157,7 +157,10 @@ export default function TileGrid({
     <div
       ref={gridRef}
       className={`tile-grid ${editing ? 'tile-grid-edit' : ''}`}
-      style={{ gridTemplateColumns: `repeat(${GRID_COLS}, 1fr)` }}
+      style={{
+        gridTemplateColumns: `repeat(${cols}, 1fr)`,
+        ['--grid-cols' as string]: cols,
+      } as React.CSSProperties}
       onDragOver={(e) => {
         if (!dragId) return;
         e.preventDefault();
@@ -196,7 +199,7 @@ export default function TileGrid({
             .join(' ')}
           style={{
             gridColumnStart: tile.x + 1,
-            gridColumnEnd: `span ${Math.min(previewSize.w, GRID_COLS - tile.x)}`,
+            gridColumnEnd: `span ${Math.min(previewSize.w, cols - tile.x)}`,
             gridRowStart: tile.y + 1,
             gridRowEnd: `span ${previewSize.h}`,
           }}
@@ -246,7 +249,7 @@ export default function TileGrid({
       {editing && (
         <button
           className="add-tile-slot"
-          style={{ gridColumn: 'span 2', gridRow: 'span 2' }}
+          style={{ gridColumn: `span ${Math.min(2, cols)}`, gridRow: 'span 2' }}
           onClick={onAddClick}
         >
           <div style={{ fontSize: 36, fontWeight: 200, color: 'var(--muted)' }}>＋</div>

--- a/src/components/TileGrid.tsx
+++ b/src/components/TileGrid.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { TileConfig } from '@/hooks/useBoard';
+import { DEFAULT_COLS } from '@/lib/board/layout';
 import type { LiveData } from './tiles/types';
 import ServiceWatchTile from './tiles/ServiceWatchTile';
 import ServiceGridTile from './tiles/ServiceGridTile';
@@ -12,7 +13,11 @@ import UptimeChartTile from './tiles/UptimeChartTile';
 import StatusMapTile from './tiles/StatusMapTile';
 import StatusPageTile from './tiles/StatusPageTile';
 
-const GRID_COLS = 6;
+const GRID_COLS = DEFAULT_COLS;
+const ROW_HEIGHT = 88;            // matches .tile-grid grid-auto-rows in globals.css
+const ROW_HEIGHT_COMPACT = 72;    // ".compact" density override
+const GAP = 16;
+const GAP_COMPACT = 10;
 
 interface TileGridProps {
   board: TileConfig[];
@@ -25,6 +30,7 @@ interface TileGridProps {
   onSwapTiles: (srcId: string, tgtId: string) => void;
   onDuplicateTile: (id: string) => void;
   onRenameTile: (id: string, label: string | null) => void;
+  onMoveTile: (id: string, x: number, y: number) => void;
   onAddClick: () => void;
 }
 
@@ -76,19 +82,54 @@ export default function TileGrid({
   onSwapTiles,
   onDuplicateTile,
   onRenameTile,
+  onMoveTile,
   onAddClick,
 }: TileGridProps) {
   const [dragId, setDragId] = useState<string | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const dropTargetRef = useRef<{ x: number; y: number } | null>(null);
+  const shiftRef = useRef(false);
 
-  const sorted = [...board].sort((a, b) => a.y - b.y || a.x - b.x);
+  const pointerToCell = (clientX: number, clientY: number): { x: number; y: number } | null => {
+    const el = gridRef.current;
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    const compact = document.documentElement.dataset.density === 'compact';
+    const rowH = compact ? ROW_HEIGHT_COMPACT : ROW_HEIGHT;
+    const gap = compact ? GAP_COMPACT : GAP;
+    const colW = (r.width - gap * (GRID_COLS - 1)) / GRID_COLS;
+    const x = Math.max(0, Math.min(GRID_COLS - 1, Math.floor((clientX - r.left) / (colW + gap))));
+    const y = Math.max(0, Math.floor((clientY - r.top) / (rowH + gap)));
+    return { x, y };
+  };
 
   return (
     <div
+      ref={gridRef}
       className={`tile-grid ${editing ? 'tile-grid-edit' : ''}`}
       style={{ gridTemplateColumns: `repeat(${GRID_COLS}, 1fr)` }}
+      onDragOver={(e) => {
+        if (!dragId) return;
+        e.preventDefault();
+        shiftRef.current = e.shiftKey;
+        dropTargetRef.current = pointerToCell(e.clientX, e.clientY);
+      }}
+      onDrop={(e) => {
+        if (!dragId) return;
+        e.preventDefault();
+        if (shiftRef.current && dragOverId) {
+          onSwapTiles(dragId, dragOverId);
+        } else if (dropTargetRef.current) {
+          const { x, y } = dropTargetRef.current;
+          onMoveTile(dragId, x, y);
+        }
+        setDragId(null);
+        setDragOverId(null);
+        dropTargetRef.current = null;
+      }}
     >
-      {sorted.map((tile) => (
+      {board.map((tile) => (
         <div
           key={tile.id}
           className={[
@@ -100,19 +141,16 @@ export default function TileGrid({
             .filter(Boolean)
             .join(' ')}
           style={{
-            gridColumn: `span ${Math.min(tile.w, GRID_COLS)}`,
-            gridRow: `span ${tile.h}`,
+            gridColumnStart: tile.x + 1,
+            gridColumnEnd: `span ${Math.min(tile.w, GRID_COLS)}`,
+            gridRowStart: tile.y + 1,
+            gridRowEnd: `span ${tile.h}`,
           }}
           draggable={editing}
           onDragStart={() => { setDragId(tile.id); setDragOverId(null); }}
           onDragOver={(e) => { e.preventDefault(); setDragOverId(tile.id); }}
           onDragLeave={() => setDragOverId(null)}
-          onDrop={() => {
-            if (dragId) onSwapTiles(dragId, tile.id);
-            setDragId(null);
-            setDragOverId(null);
-          }}
-          onDragEnd={() => { setDragId(null); setDragOverId(null); }}
+          onDragEnd={() => { setDragId(null); setDragOverId(null); dropTargetRef.current = null; }}
         >
           {editing && (
             <div className="drag-handle" aria-hidden="true">

--- a/src/components/TileGrid.tsx
+++ b/src/components/TileGrid.tsx
@@ -213,7 +213,10 @@ export default function TileGrid({
             gridColumnEnd: `span ${Math.min(previewSize.w, cols - tile.x)}`,
             gridRowStart: tile.y + 1,
             gridRowEnd: `span ${previewSize.h}`,
-          }}
+            ...(typeof tile.config.accent === 'string'
+              ? { ['--accent' as string]: tile.config.accent } as React.CSSProperties
+              : {}),
+          } as React.CSSProperties}
           draggable={editing && resizePreview?.id !== tile.id}
           onDragStart={() => { setDragId(tile.id); setDragOverId(null); }}
           onDragOver={(e) => { e.preventDefault(); setDragOverId(tile.id); }}

--- a/src/components/TileGrid.tsx
+++ b/src/components/TileGrid.tsx
@@ -31,6 +31,7 @@ interface TileGridProps {
   onDuplicateTile: (id: string) => void;
   onRenameTile: (id: string, label: string | null) => void;
   onMoveTile: (id: string, x: number, y: number) => void;
+  onResizeTile: (id: string, w: number, h: number) => void;
   onAddClick: () => void;
 }
 
@@ -83,22 +84,70 @@ export default function TileGrid({
   onDuplicateTile,
   onRenameTile,
   onMoveTile,
+  onResizeTile,
   onAddClick,
 }: TileGridProps) {
   const [dragId, setDragId] = useState<string | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
+  const [resizePreview, setResizePreview] = useState<{ id: string; w: number; h: number } | null>(null);
   const gridRef = useRef<HTMLDivElement>(null);
   const dropTargetRef = useRef<{ x: number; y: number } | null>(null);
   const shiftRef = useRef(false);
+
+  const cellSize = (): { colW: number; rowH: number; gap: number } => {
+    const el = gridRef.current;
+    const compact = typeof document !== 'undefined' && document.documentElement.dataset.density === 'compact';
+    const rowH = compact ? ROW_HEIGHT_COMPACT : ROW_HEIGHT;
+    const gap = compact ? GAP_COMPACT : GAP;
+    const colW = el ? (el.getBoundingClientRect().width - gap * (GRID_COLS - 1)) / GRID_COLS : 100;
+    return { colW, rowH, gap };
+  };
+
+  const startResize = (tile: TileConfig, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const { colW, rowH, gap } = cellSize();
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const startW = tile.w;
+    const startH = tile.h;
+    setResizePreview({ id: tile.id, w: startW, h: startH });
+
+    const move = (ev: MouseEvent) => {
+      const dw = Math.round((ev.clientX - startX) / (colW + gap));
+      const dh = Math.round((ev.clientY - startY) / (rowH + gap));
+      const w = Math.max(1, Math.min(GRID_COLS - tile.x, startW + dw));
+      const h = Math.max(1, startH + dh);
+      setResizePreview({ id: tile.id, w, h });
+    };
+    const cancel = (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape') {
+        cleanup();
+        setResizePreview(null);
+      }
+    };
+    const up = () => {
+      cleanup();
+      setResizePreview((p) => {
+        if (p && (p.w !== startW || p.h !== startH)) onResizeTile(tile.id, p.w, p.h);
+        return null;
+      });
+    };
+    const cleanup = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+      window.removeEventListener('keydown', cancel);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+    window.addEventListener('keydown', cancel);
+  };
 
   const pointerToCell = (clientX: number, clientY: number): { x: number; y: number } | null => {
     const el = gridRef.current;
     if (!el) return null;
     const r = el.getBoundingClientRect();
-    const compact = document.documentElement.dataset.density === 'compact';
-    const rowH = compact ? ROW_HEIGHT_COMPACT : ROW_HEIGHT;
-    const gap = compact ? GAP_COMPACT : GAP;
-    const colW = (r.width - gap * (GRID_COLS - 1)) / GRID_COLS;
+    const { colW, rowH, gap } = cellSize();
     const x = Math.max(0, Math.min(GRID_COLS - 1, Math.floor((clientX - r.left) / (colW + gap))));
     const y = Math.max(0, Math.floor((clientY - r.top) / (rowH + gap)));
     return { x, y };
@@ -129,7 +178,11 @@ export default function TileGrid({
         dropTargetRef.current = null;
       }}
     >
-      {board.map((tile) => (
+      {board.map((tile) => {
+        const previewSize = resizePreview && resizePreview.id === tile.id
+          ? { w: resizePreview.w, h: resizePreview.h }
+          : { w: tile.w, h: tile.h };
+        return (
         <div
           key={tile.id}
           className={[
@@ -137,16 +190,17 @@ export default function TileGrid({
             editing ? 'tile-edit-mode' : '',
             dragId === tile.id ? 'tile-dragging' : '',
             dragOverId === tile.id && dragId !== tile.id ? 'tile-drag-over' : '',
+            resizePreview?.id === tile.id ? 'tile-resizing' : '',
           ]
             .filter(Boolean)
             .join(' ')}
           style={{
             gridColumnStart: tile.x + 1,
-            gridColumnEnd: `span ${Math.min(tile.w, GRID_COLS)}`,
+            gridColumnEnd: `span ${Math.min(previewSize.w, GRID_COLS - tile.x)}`,
             gridRowStart: tile.y + 1,
-            gridRowEnd: `span ${tile.h}`,
+            gridRowEnd: `span ${previewSize.h}`,
           }}
-          draggable={editing}
+          draggable={editing && resizePreview?.id !== tile.id}
           onDragStart={() => { setDragId(tile.id); setDragOverId(null); }}
           onDragOver={(e) => { e.preventDefault(); setDragOverId(tile.id); }}
           onDragLeave={() => setDragOverId(null)}
@@ -164,6 +218,16 @@ export default function TileGrid({
               </svg>
             </div>
           )}
+          {editing && (
+            <div
+              className="tile-resize-handle"
+              role="separator"
+              aria-label="Resize tile"
+              onMouseDown={(e) => startResize(tile, e)}
+              onContextMenu={(e) => { e.preventDefault(); onCycleResize(tile.id); }}
+              title="Drag to resize · right-click to cycle preset sizes"
+            />
+          )}
           <TileComponent
             tile={tile}
             editing={editing}
@@ -176,7 +240,8 @@ export default function TileGrid({
             onRename={(label) => onRenameTile(tile.id, label)}
           />
         </div>
-      ))}
+        );
+      })}
 
       {editing && (
         <button

--- a/src/components/TweaksPanel.tsx
+++ b/src/components/TweaksPanel.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from 'react';
 import type { Tweaks } from '@/hooks/useTweaks';
 import type { TileConfig } from '@/hooks/useBoard';
 import { serializeBoard, parseBoardFile } from '@/lib/board/io';
-import { THEMES, type Theme } from './ThemeProvider';
+import { THEMES, type Theme, type CustomTheme } from './ThemeProvider';
 
 interface Props {
   open: boolean;
@@ -16,11 +16,21 @@ interface Props {
   setBoard: (next: TileConfig[]) => void;
   theme: Theme;
   setTheme: (t: Theme) => void;
+  customTheme: CustomTheme;
+  setCustomTheme: (patch: Partial<CustomTheme>) => void;
 }
+
+const CUSTOM_FIELDS: { key: keyof CustomTheme; label: string }[] = [
+  { key: 'background',      label: 'Background' },
+  { key: 'surface',         label: 'Surface' },
+  { key: 'surfaceElevated', label: 'Surface (elevated)' },
+  { key: 'foreground',      label: 'Foreground' },
+  { key: 'muted',           label: 'Muted' },
+];
 
 const ACCENT_OPTIONS = ['#268bd2', '#2aa198', '#b58900', '#d33682', '#859900', '#3b82f6'];
 
-export default function TweaksPanel({ open, onClose, tweaks, setTweak, setTweaks, board, setBoard, theme, setTheme }: Props) {
+export default function TweaksPanel({ open, onClose, tweaks, setTweak, setTweaks, board, setBoard, theme, setTheme, customTheme, setCustomTheme }: Props) {
   const panelRef = useRef<HTMLDivElement>(null);
   const offsetRef = useRef({ x: 16, y: 16 });
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -165,6 +175,33 @@ export default function TweaksPanel({ open, onClose, tweaks, setTweak, setTweaks
             ))}
           </select>
         </div>
+
+        {theme === 'custom' && (
+          <>
+            {CUSTOM_FIELDS.map((f) => (
+              <div className="twk-row twk-row-h" key={f.key}>
+                <div className="twk-lbl"><span>{f.label}</span></div>
+                <div style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+                  <input
+                    type="color"
+                    className="twk-color"
+                    value={customTheme[f.key]}
+                    onChange={(e) => setCustomTheme({ [f.key]: e.target.value })}
+                    aria-label={`Pick ${f.label}`}
+                  />
+                  <input
+                    type="text"
+                    className="twk-field"
+                    style={{ width: 90, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize: 11 }}
+                    value={customTheme[f.key]}
+                    onChange={(e) => setCustomTheme({ [f.key]: e.target.value })}
+                    spellCheck={false}
+                  />
+                </div>
+              </div>
+            ))}
+          </>
+        )}
 
         {/* Accent */}
         <div className="twk-row">

--- a/src/components/TweaksPanel.tsx
+++ b/src/components/TweaksPanel.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import type { Tweaks } from '@/hooks/useTweaks';
+import type { TileConfig } from '@/hooks/useBoard';
+import { serializeBoard, parseBoardFile } from '@/lib/board/io';
 import { THEMES, type Theme } from './ThemeProvider';
 
 interface Props {
@@ -9,15 +11,22 @@ interface Props {
   onClose: () => void;
   tweaks: Tweaks;
   setTweak: (key: keyof Tweaks, value: unknown) => void;
+  setTweaks: (next: Tweaks) => void;
+  board: TileConfig[];
+  setBoard: (next: TileConfig[]) => void;
   theme: Theme;
   setTheme: (t: Theme) => void;
 }
 
 const ACCENT_OPTIONS = ['#268bd2', '#2aa198', '#b58900', '#d33682', '#859900', '#3b82f6'];
 
-export default function TweaksPanel({ open, onClose, tweaks, setTweak, theme, setTheme }: Props) {
+export default function TweaksPanel({ open, onClose, tweaks, setTweak, setTweaks, board, setBoard, theme, setTheme }: Props) {
   const panelRef = useRef<HTMLDivElement>(null);
   const offsetRef = useRef({ x: 16, y: 16 });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [pasting, setPasting] = useState(false);
+  const [pasteValue, setPasteValue] = useState('');
+  const [importError, setImportError] = useState<string | null>(null);
 
   const onDragStart = (e: React.MouseEvent) => {
     const panel = panelRef.current;
@@ -43,6 +52,39 @@ export default function TweaksPanel({ open, onClose, tweaks, setTweak, theme, se
     };
     window.addEventListener('mousemove', move);
     window.addEventListener('mouseup', up);
+  };
+
+  const handleExport = () => {
+    const json = serializeBoard({ board, tweaks });
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'outage-board.json';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const applyImport = (raw: string) => {
+    const parsed = parseBoardFile(raw);
+    if (!parsed) {
+      setImportError('That doesn’t look like an outage-board export.');
+      return false;
+    }
+    setBoard(parsed.board);
+    if (parsed.tweaks) setTweaks(parsed.tweaks);
+    setImportError(null);
+    setPasting(false);
+    setPasteValue('');
+    onClose();
+    return true;
+  };
+
+  const handleFile = async (file: File) => {
+    const text = await file.text();
+    applyImport(text);
   };
 
   if (!open) return null;
@@ -140,6 +182,81 @@ export default function TweaksPanel({ open, onClose, tweaks, setTweak, theme, se
             ))}
           </div>
         </div>
+
+        {/* Backup section */}
+        <div className="twk-sect">Backup</div>
+
+        <div className="twk-row twk-row-h">
+          <div className="twk-lbl"><span>Export &amp; import</span></div>
+          <div className="twk-seg">
+            <button onClick={handleExport} title="Download outage-board.json">Export</button>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              title="Import from a file"
+            >
+              Import
+            </button>
+          </div>
+        </div>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json"
+          style={{ display: 'none' }}
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) handleFile(f);
+            e.target.value = '';
+          }}
+        />
+
+        <div className="twk-row" style={{ marginTop: -4 }}>
+          <button
+            type="button"
+            onClick={() => { setPasting((p) => !p); setImportError(null); }}
+            style={{
+              background: 'transparent',
+              border: 0,
+              color: 'var(--muted)',
+              fontSize: 11,
+              textDecoration: 'underline',
+              cursor: 'pointer',
+              padding: 0,
+              alignSelf: 'flex-start',
+              fontFamily: 'inherit',
+            }}
+          >
+            {pasting ? 'Cancel paste' : 'Or paste JSON…'}
+          </button>
+        </div>
+
+        {pasting && (
+          <div className="twk-row">
+            <textarea
+              className="twk-field"
+              rows={4}
+              placeholder="Paste exported JSON here"
+              value={pasteValue}
+              onChange={(e) => setPasteValue(e.target.value)}
+              style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize: 11 }}
+            />
+            <button
+              type="button"
+              className="board-btn board-btn-primary"
+              style={{ marginTop: 6 }}
+              onClick={() => applyImport(pasteValue)}
+            >
+              Apply
+            </button>
+          </div>
+        )}
+
+        {importError && (
+          <div className="twk-row" role="alert" style={{ fontSize: 11, color: 'var(--accent-rose, #f87171)' }}>
+            {importError}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/TweaksPanel.tsx
+++ b/src/components/TweaksPanel.tsx
@@ -183,6 +183,69 @@ export default function TweaksPanel({ open, onClose, tweaks, setTweak, setTweaks
           </div>
         </div>
 
+        <div className="twk-row twk-row-h">
+          <div className="twk-lbl"><span>Custom hex</span></div>
+          <div style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+            <input
+              type="color"
+              value={tweaks.accent}
+              onChange={(e) => setTweak('accent', e.target.value)}
+              className="twk-color"
+              aria-label="Pick accent color"
+            />
+            <input
+              type="text"
+              className="twk-field"
+              style={{ width: 90, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize: 11 }}
+              value={tweaks.accent}
+              onChange={(e) => {
+                const v = e.target.value.trim();
+                if (/^#[0-9a-f]{6}$/i.test(v)) setTweak('accent', v);
+                else if (v.startsWith('#')) setTweak('accent', v);
+              }}
+              placeholder="#268bd2"
+              spellCheck={false}
+            />
+            {typeof window !== 'undefined' && 'EyeDropper' in window && (
+              <button
+                type="button"
+                className="board-btn board-btn-icon"
+                title="Eye-dropper"
+                onClick={async () => {
+                  try {
+                    const Picker = (window as unknown as { EyeDropper: new () => { open: () => Promise<{ sRGBHex: string }> } }).EyeDropper;
+                    const result = await new Picker().open();
+                    if (result?.sRGBHex) setTweak('accent', result.sRGBHex);
+                  } catch { /* user cancelled */ }
+                }}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M2 22l3-1 11-11-2-2L3 19l-1 3z" />
+                  <path d="M14 8l4-4a2.83 2.83 0 014 4l-4 4" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+
+        {tweaks.accentRecents && tweaks.accentRecents.length > 0 && (
+          <div className="twk-row">
+            <div className="twk-lbl"><span>Recents</span></div>
+            <div className="twk-chips">
+              {tweaks.accentRecents.map((color) => (
+                <button
+                  key={color}
+                  className="twk-chip"
+                  data-on={tweaks.accent === color}
+                  style={{ background: color }}
+                  onClick={() => setTweak('accent', color)}
+                  title={color}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Backup section */}
         <div className="twk-sect">Backup</div>
 

--- a/src/components/tiles/BoardStatTile.tsx
+++ b/src/components/tiles/BoardStatTile.tsx
@@ -3,7 +3,7 @@ import type { TileProps } from './types';
 
 type MetricKey = 'uptime' | 'incidents' | 'dd' | 'mttr';
 
-export default function BoardStatTile({ config, editing, onResize, onRemove, onConfigChange, live }: TileProps) {
+export default function BoardStatTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigChange, live }: TileProps) {
   const metric = (config.metric as MetricKey) || 'uptime';
   const { services, incidents } = live;
 
@@ -23,7 +23,15 @@ export default function BoardStatTile({ config, editing, onResize, onRemove, onC
   const m = metrics[metric] ?? metrics.uptime;
 
   return (
-    <TileChrome title={m.label} editing={editing} onResize={onResize} onRemove={onRemove}>
+    <TileChrome
+      title={m.label}
+      label={typeof config.label === 'string' ? config.label : null}
+      editing={editing}
+      onResize={onResize}
+      onRemove={onRemove}
+      onDuplicate={onDuplicate}
+      onRename={onRename}
+    >
       <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100%', gap: 4 }}>
         <div
           style={{

--- a/src/components/tiles/BoardStatTile.tsx
+++ b/src/components/tiles/BoardStatTile.tsx
@@ -3,7 +3,7 @@ import type { TileProps } from './types';
 
 type MetricKey = 'uptime' | 'incidents' | 'dd' | 'mttr';
 
-export default function BoardStatTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigChange, live }: TileProps) {
+export default function BoardStatTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure, live }: TileProps) {
   const metric = (config.metric as MetricKey) || 'uptime';
   const { services, incidents } = live;
 
@@ -31,6 +31,7 @@ export default function BoardStatTile({ config, editing, onResize, onRemove, onD
       onRemove={onRemove}
       onDuplicate={onDuplicate}
       onRename={onRename}
+      onConfigure={onConfigure}
     >
       <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100%', gap: 4 }}>
         <div
@@ -48,19 +49,6 @@ export default function BoardStatTile({ config, editing, onResize, onRemove, onD
         <div style={{ fontSize: 11, color: 'var(--muted)' }}>{m.sub}</div>
       </div>
 
-      {editing && (
-        <div className="datapoint-chips" style={{ marginTop: 8 }}>
-          {(Object.keys(metrics) as MetricKey[]).map((k) => (
-            <button
-              key={k}
-              onClick={() => onConfigChange({ metric: k })}
-              className={`chip ${metric === k ? 'chip-on' : ''}`}
-            >
-              {metrics[k].label}
-            </button>
-          ))}
-        </div>
-      )}
     </TileChrome>
   );
 }

--- a/src/components/tiles/BoardStatTile.tsx
+++ b/src/components/tiles/BoardStatTile.tsx
@@ -26,6 +26,8 @@ export default function BoardStatTile({ config, editing, onResize, onRemove, onD
     <TileChrome
       title={m.label}
       label={typeof config.label === 'string' ? config.label : null}
+      iconText={typeof config.icon === 'string' ? config.icon : null}
+      tag={typeof config.tag === 'string' ? config.tag : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}

--- a/src/components/tiles/IncidentFeedTile.tsx
+++ b/src/components/tiles/IncidentFeedTile.tsx
@@ -47,6 +47,8 @@ export default function IncidentFeedTile({ config, editing, onResize, onRemove, 
         </span>
       }
       label={typeof config.label === 'string' ? config.label : null}
+      iconText={typeof config.icon === 'string' ? config.icon : null}
+      tag={typeof config.tag === 'string' ? config.tag : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}

--- a/src/components/tiles/IncidentFeedTile.tsx
+++ b/src/components/tiles/IncidentFeedTile.tsx
@@ -10,7 +10,7 @@ const SEV_COLOR: Record<string, string> = {
   resolved: '#7CB342',
 };
 
-export default function IncidentFeedTile({ editing, onResize, onRemove, live }: TileProps) {
+export default function IncidentFeedTile({ config, editing, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
   const { incidents, services } = live;
   const activeCount = incidents.filter((i) => i.status !== 'resolved').length;
 
@@ -30,9 +30,12 @@ export default function IncidentFeedTile({ editing, onResize, onRemove, live }: 
           {activeCount} active
         </span>
       }
+      label={typeof config.label === 'string' ? config.label : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}
+      onDuplicate={onDuplicate}
+      onRename={onRename}
     >
       <div style={{ display: 'flex', flexDirection: 'column', overflowY: 'auto', flex: 1 }}>
         {incidents.length === 0 ? (

--- a/src/components/tiles/IncidentFeedTile.tsx
+++ b/src/components/tiles/IncidentFeedTile.tsx
@@ -12,12 +12,35 @@ const SEV_COLOR: Record<string, string> = {
   resolved: '#7CB342',
 };
 
+const SEVERITIES = ['critical', 'major', 'minor'] as const;
+const STATUSES = ['investigating', 'identified', 'monitoring', 'resolved'] as const;
+
 export default function IncidentFeedTile({ config, editing, onConfigChange, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
   const refreshMs = typeof config.refreshMs === 'number' ? config.refreshMs : undefined;
   const override = useIncidents(7, refreshMs);
-  const incidents = refreshMs && override.data ? override.data.incidents : live.incidents;
+  const allIncidents = refreshMs && override.data ? override.data.incidents : live.incidents;
   const services = live.services;
+
+  const filters = (config.filters ?? {}) as {
+    severity?: string[];
+    statuses?: string[];
+    services?: string[];
+  };
+  const incidents = allIncidents.filter((i) => {
+    if (filters.severity && filters.severity.length && !filters.severity.includes(i.severity)) return false;
+    if (filters.statuses && filters.statuses.length && !filters.statuses.includes(i.status)) return false;
+    if (filters.services && filters.services.length && !filters.services.includes(i.service)) return false;
+    return true;
+  });
   const activeCount = incidents.filter((i) => i.status !== 'resolved').length;
+
+  const toggleFilter = (key: 'severity' | 'statuses' | 'services', value: string) => {
+    const current = filters[key] ?? [];
+    const next = current.includes(value)
+      ? current.filter((v) => v !== value)
+      : [...current, value];
+    onConfigChange({ filters: { ...filters, [key]: next.length ? next : undefined } });
+  };
 
   return (
     <TileChrome
@@ -71,6 +94,34 @@ export default function IncidentFeedTile({ config, editing, onConfigChange, onRe
           })
         )}
       </div>
+      {editing && (
+        <div className="tile-filters">
+          <div className="tile-filter-group">
+            <span className="tile-filter-label">Severity</span>
+            {SEVERITIES.map((s) => (
+              <button
+                key={s}
+                className={`chip ${filters.severity?.includes(s) ? 'chip-on' : ''}`}
+                onClick={() => toggleFilter('severity', s)}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+          <div className="tile-filter-group">
+            <span className="tile-filter-label">Status</span>
+            {STATUSES.map((s) => (
+              <button
+                key={s}
+                className={`chip ${filters.statuses?.includes(s) ? 'chip-on' : ''}`}
+                onClick={() => toggleFilter('statuses', s)}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
       {editing && (
         <RefreshSelect
           value={refreshMs}

--- a/src/components/tiles/IncidentFeedTile.tsx
+++ b/src/components/tiles/IncidentFeedTile.tsx
@@ -1,6 +1,8 @@
 import TileChrome from './TileChrome';
 import { relTime } from '@/lib/boardColors';
+import { useIncidents } from '@/hooks/useStatus';
 import type { TileProps } from './types';
+import RefreshSelect from './RefreshSelect';
 
 const SEV_COLOR: Record<string, string> = {
   critical: '#EF5350',
@@ -10,8 +12,11 @@ const SEV_COLOR: Record<string, string> = {
   resolved: '#7CB342',
 };
 
-export default function IncidentFeedTile({ config, editing, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
-  const { incidents, services } = live;
+export default function IncidentFeedTile({ config, editing, onConfigChange, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
+  const refreshMs = typeof config.refreshMs === 'number' ? config.refreshMs : undefined;
+  const override = useIncidents(7, refreshMs);
+  const incidents = refreshMs && override.data ? override.data.incidents : live.incidents;
+  const services = live.services;
   const activeCount = incidents.filter((i) => i.status !== 'resolved').length;
 
   return (
@@ -66,6 +71,12 @@ export default function IncidentFeedTile({ config, editing, onResize, onRemove, 
           })
         )}
       </div>
+      {editing && (
+        <RefreshSelect
+          value={refreshMs}
+          onChange={(ms) => onConfigChange({ refreshMs: ms })}
+        />
+      )}
     </TileChrome>
   );
 }

--- a/src/components/tiles/IncidentFeedTile.tsx
+++ b/src/components/tiles/IncidentFeedTile.tsx
@@ -2,7 +2,6 @@ import TileChrome from './TileChrome';
 import { relTime } from '@/lib/boardColors';
 import { useIncidents } from '@/hooks/useStatus';
 import type { TileProps } from './types';
-import RefreshSelect from './RefreshSelect';
 
 const SEV_COLOR: Record<string, string> = {
   critical: '#EF5350',
@@ -12,10 +11,7 @@ const SEV_COLOR: Record<string, string> = {
   resolved: '#7CB342',
 };
 
-const SEVERITIES = ['critical', 'major', 'minor'] as const;
-const STATUSES = ['investigating', 'identified', 'monitoring', 'resolved'] as const;
-
-export default function IncidentFeedTile({ config, editing, onConfigChange, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
+export default function IncidentFeedTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure, live }: TileProps) {
   const refreshMs = typeof config.refreshMs === 'number' ? config.refreshMs : undefined;
   const override = useIncidents(7, refreshMs);
   const allIncidents = refreshMs && override.data ? override.data.incidents : live.incidents;
@@ -33,14 +29,6 @@ export default function IncidentFeedTile({ config, editing, onConfigChange, onRe
     return true;
   });
   const activeCount = incidents.filter((i) => i.status !== 'resolved').length;
-
-  const toggleFilter = (key: 'severity' | 'statuses' | 'services', value: string) => {
-    const current = filters[key] ?? [];
-    const next = current.includes(value)
-      ? current.filter((v) => v !== value)
-      : [...current, value];
-    onConfigChange({ filters: { ...filters, [key]: next.length ? next : undefined } });
-  };
 
   return (
     <TileChrome
@@ -64,6 +52,7 @@ export default function IncidentFeedTile({ config, editing, onConfigChange, onRe
       onRemove={onRemove}
       onDuplicate={onDuplicate}
       onRename={onRename}
+      onConfigure={onConfigure}
     >
       <div style={{ display: 'flex', flexDirection: 'column', overflowY: 'auto', flex: 1 }}>
         {incidents.length === 0 ? (
@@ -94,40 +83,6 @@ export default function IncidentFeedTile({ config, editing, onConfigChange, onRe
           })
         )}
       </div>
-      {editing && (
-        <div className="tile-filters">
-          <div className="tile-filter-group">
-            <span className="tile-filter-label">Severity</span>
-            {SEVERITIES.map((s) => (
-              <button
-                key={s}
-                className={`chip ${filters.severity?.includes(s) ? 'chip-on' : ''}`}
-                onClick={() => toggleFilter('severity', s)}
-              >
-                {s}
-              </button>
-            ))}
-          </div>
-          <div className="tile-filter-group">
-            <span className="tile-filter-label">Status</span>
-            {STATUSES.map((s) => (
-              <button
-                key={s}
-                className={`chip ${filters.statuses?.includes(s) ? 'chip-on' : ''}`}
-                onClick={() => toggleFilter('statuses', s)}
-              >
-                {s}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
-      {editing && (
-        <RefreshSelect
-          value={refreshMs}
-          onChange={(ms) => onConfigChange({ refreshMs: ms })}
-        />
-      )}
     </TileChrome>
   );
 }

--- a/src/components/tiles/RefreshSelect.tsx
+++ b/src/components/tiles/RefreshSelect.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+const OPTIONS: { label: string; value: number | undefined }[] = [
+  { label: 'Inherit', value: undefined },
+  { label: '5s',      value:  5000 },
+  { label: '15s',     value: 15000 },
+  { label: '30s',     value: 30000 },
+  { label: '1m',      value: 60000 },
+  { label: '5m',      value: 300000 },
+];
+
+interface Props {
+  value: number | undefined;
+  onChange: (ms: number | undefined) => void;
+}
+
+export default function RefreshSelect({ value, onChange }: Props) {
+  return (
+    <div className="tile-refresh-row">
+      <span className="tile-refresh-label">Refresh</span>
+      <select
+        className="tile-refresh-select"
+        value={value ?? ''}
+        onChange={(e) => onChange(e.target.value === '' ? undefined : Number(e.target.value))}
+      >
+        {OPTIONS.map((o) => (
+          <option key={o.label} value={o.value ?? ''}>{o.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/tiles/RssFeedTile.tsx
+++ b/src/components/tiles/RssFeedTile.tsx
@@ -36,6 +36,8 @@ export default function RssFeedTile({ config, editing, onResize, onRemove, onDup
       }
       badge={<span className="count-pill">RSS</span>}
       label={typeof config.label === 'string' ? config.label : null}
+      iconText={typeof config.icon === 'string' ? config.icon : null}
+      tag={typeof config.tag === 'string' ? config.tag : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}

--- a/src/components/tiles/RssFeedTile.tsx
+++ b/src/components/tiles/RssFeedTile.tsx
@@ -21,7 +21,7 @@ const FEEDS = [
   },
 ];
 
-export default function RssFeedTile({ config, editing, onResize, onRemove }: TileProps) {
+export default function RssFeedTile({ config, editing, onResize, onRemove, onDuplicate, onRename }: TileProps) {
   const feedId = (config.feed as string) || 'aws-blog';
   const feed = FEEDS.find((f) => f.id === feedId) ?? FEEDS[0];
 
@@ -35,9 +35,12 @@ export default function RssFeedTile({ config, editing, onResize, onRemove }: Til
         </svg>
       }
       badge={<span className="count-pill">RSS</span>}
+      label={typeof config.label === 'string' ? config.label : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}
+      onDuplicate={onDuplicate}
+      onRename={onRename}
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8, overflowY: 'auto', flex: 1 }}>
         {feed.items.map((item, i) => (

--- a/src/components/tiles/RssFeedTile.tsx
+++ b/src/components/tiles/RssFeedTile.tsx
@@ -21,7 +21,7 @@ const FEEDS = [
   },
 ];
 
-export default function RssFeedTile({ config, editing, onResize, onRemove, onDuplicate, onRename }: TileProps) {
+export default function RssFeedTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure }: TileProps) {
   const feedId = (config.feed as string) || 'aws-blog';
   const feed = FEEDS.find((f) => f.id === feedId) ?? FEEDS[0];
 
@@ -41,6 +41,7 @@ export default function RssFeedTile({ config, editing, onResize, onRemove, onDup
       onRemove={onRemove}
       onDuplicate={onDuplicate}
       onRename={onRename}
+      onConfigure={onConfigure}
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8, overflowY: 'auto', flex: 1 }}>
         {feed.items.map((item, i) => (

--- a/src/components/tiles/ServiceGridTile.tsx
+++ b/src/components/tiles/ServiceGridTile.tsx
@@ -2,7 +2,7 @@ import TileChrome from './TileChrome';
 import { getStatusColor } from '@/lib/boardColors';
 import type { TileProps } from './types';
 
-export default function ServiceGridTile({ config, editing, onConfigChange, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
+export default function ServiceGridTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure, live }: TileProps) {
   const filterSlugs = config.services as string[] | undefined;
   const filters = (config.filters ?? {}) as { hideOperational?: boolean };
   let shown = filterSlugs?.length
@@ -32,6 +32,7 @@ export default function ServiceGridTile({ config, editing, onConfigChange, onRes
       onRemove={onRemove}
       onDuplicate={onDuplicate}
       onRename={onRename}
+      onConfigure={onConfigure}
     >
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))', gap: 8, overflowY: 'auto', flex: 1 }}>
         {shown.map((s) => {
@@ -68,16 +69,6 @@ export default function ServiceGridTile({ config, editing, onConfigChange, onRes
           );
         })}
       </div>
-      {editing && (
-        <div className="tile-filters">
-          <button
-            className={`chip ${filters.hideOperational ? 'chip-on' : ''}`}
-            onClick={() => onConfigChange({ filters: { ...filters, hideOperational: !filters.hideOperational } })}
-          >
-            {filters.hideOperational ? '●' : '○'} Hide healthy
-          </button>
-        </div>
-      )}
     </TileChrome>
   );
 }

--- a/src/components/tiles/ServiceGridTile.tsx
+++ b/src/components/tiles/ServiceGridTile.tsx
@@ -27,6 +27,8 @@ export default function ServiceGridTile({ config, editing, onResize, onRemove, o
         <span className="count-pill">{shown.length}</span>
       }
       label={typeof config.label === 'string' ? config.label : null}
+      iconText={typeof config.icon === 'string' ? config.icon : null}
+      tag={typeof config.tag === 'string' ? config.tag : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}

--- a/src/components/tiles/ServiceGridTile.tsx
+++ b/src/components/tiles/ServiceGridTile.tsx
@@ -2,11 +2,15 @@ import TileChrome from './TileChrome';
 import { getStatusColor } from '@/lib/boardColors';
 import type { TileProps } from './types';
 
-export default function ServiceGridTile({ config, editing, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
+export default function ServiceGridTile({ config, editing, onConfigChange, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
   const filterSlugs = config.services as string[] | undefined;
-  const shown = filterSlugs?.length
+  const filters = (config.filters ?? {}) as { hideOperational?: boolean };
+  let shown = filterSlugs?.length
     ? live.services.filter((s) => filterSlugs.includes(s.slug))
     : live.services;
+  if (filters.hideOperational) {
+    shown = shown.filter((s) => s.overallStatus !== 'operational');
+  }
 
   return (
     <TileChrome
@@ -64,6 +68,16 @@ export default function ServiceGridTile({ config, editing, onResize, onRemove, o
           );
         })}
       </div>
+      {editing && (
+        <div className="tile-filters">
+          <button
+            className={`chip ${filters.hideOperational ? 'chip-on' : ''}`}
+            onClick={() => onConfigChange({ filters: { ...filters, hideOperational: !filters.hideOperational } })}
+          >
+            {filters.hideOperational ? '●' : '○'} Hide healthy
+          </button>
+        </div>
+      )}
     </TileChrome>
   );
 }

--- a/src/components/tiles/ServiceGridTile.tsx
+++ b/src/components/tiles/ServiceGridTile.tsx
@@ -2,7 +2,7 @@ import TileChrome from './TileChrome';
 import { getStatusColor } from '@/lib/boardColors';
 import type { TileProps } from './types';
 
-export default function ServiceGridTile({ config, editing, onResize, onRemove, live }: TileProps) {
+export default function ServiceGridTile({ config, editing, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
   const filterSlugs = config.services as string[] | undefined;
   const shown = filterSlugs?.length
     ? live.services.filter((s) => filterSlugs.includes(s.slug))
@@ -22,9 +22,12 @@ export default function ServiceGridTile({ config, editing, onResize, onRemove, l
       badge={
         <span className="count-pill">{shown.length}</span>
       }
+      label={typeof config.label === 'string' ? config.label : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}
+      onDuplicate={onDuplicate}
+      onRename={onRename}
     >
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))', gap: 8, overflowY: 'auto', flex: 1 }}>
         {shown.map((s) => {

--- a/src/components/tiles/ServiceWatchTile.tsx
+++ b/src/components/tiles/ServiceWatchTile.tsx
@@ -1,10 +1,12 @@
 import TileChrome from './TileChrome';
 import Sparkline from '../Sparkline';
+import RefreshSelect from './RefreshSelect';
 import { getStatusColor, historyToSparkline } from '@/lib/boardColors';
+import { useServiceStatus } from '@/hooks/useStatus';
 import type { LiveData } from './types';
 
 interface Props {
-  config: { service?: string; label?: string };
+  config: { service?: string; label?: string; refreshMs?: number };
   editing?: boolean;
   dataPoints: string[];
   toggleDataPoint: (key: string) => void;
@@ -70,8 +72,11 @@ export default function ServiceWatchTile({
   onRename,
   live,
 }: Props) {
+  const refreshMs = config.refreshMs;
+  const override = useServiceStatus(refreshMs);
+  const services = refreshMs && override.data ? override.data.services : live.services;
   const slug = (config.service as string) || '';
-  const svc = live.services.find((s) => s.slug === slug) || live.services[0];
+  const svc = services.find((s) => s.slug === slug) || services[0];
 
   if (!svc) {
     return (
@@ -133,7 +138,7 @@ export default function ServiceWatchTile({
       onDuplicate={onDuplicate}
       onRename={onRename}
       onConfigure={() => {
-        const next = live.services[(live.services.findIndex((s) => s.slug === svc.slug) + 1) % live.services.length];
+        const next = services[(services.findIndex((s) => s.slug === svc.slug) + 1) % services.length];
         if (next) onConfigChange({ service: next.slug });
       }}
     >
@@ -226,6 +231,12 @@ export default function ServiceWatchTile({
               </button>
             ))}
           </div>
+        )}
+        {editing && (
+          <RefreshSelect
+            value={refreshMs}
+            onChange={(ms) => onConfigChange({ refreshMs: ms })}
+          />
         )}
       </div>
     </TileChrome>

--- a/src/components/tiles/ServiceWatchTile.tsx
+++ b/src/components/tiles/ServiceWatchTile.tsx
@@ -5,7 +5,14 @@ import { useServiceStatus } from '@/hooks/useStatus';
 import type { LiveData } from './types';
 
 interface Props {
-  config: { service?: string; label?: string; refreshMs?: number };
+  config: {
+    service?: string;
+    label?: string;
+    refreshMs?: number;
+    icon?: string;
+    tag?: string;
+    accent?: string;
+  };
   editing?: boolean;
   dataPoints: string[];
   toggleDataPoint: (key: string) => void;
@@ -88,6 +95,8 @@ export default function ServiceWatchTile({
       <TileChrome
         title="Service Watch"
         label={config.label ?? null}
+        iconText={typeof config.icon === 'string' ? config.icon : null}
+        tag={typeof config.tag === 'string' ? config.tag : null}
         editing={editing}
         onResize={onResize}
         onRemove={onRemove}
@@ -138,6 +147,8 @@ export default function ServiceWatchTile({
         </div>
       }
       label={config.label ?? null}
+      iconText={typeof config.icon === 'string' ? config.icon : null}
+      tag={typeof config.tag === 'string' ? config.tag : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}

--- a/src/components/tiles/ServiceWatchTile.tsx
+++ b/src/components/tiles/ServiceWatchTile.tsx
@@ -4,13 +4,15 @@ import { getStatusColor, historyToSparkline } from '@/lib/boardColors';
 import type { LiveData } from './types';
 
 interface Props {
-  config: { service?: string };
+  config: { service?: string; label?: string };
   editing?: boolean;
   dataPoints: string[];
   toggleDataPoint: (key: string) => void;
   onConfigChange: (patch: Record<string, unknown>) => void;
   onResize?: () => void;
   onRemove?: () => void;
+  onDuplicate?: () => void;
+  onRename?: (label: string | null) => void;
   live: LiveData;
 }
 
@@ -64,6 +66,8 @@ export default function ServiceWatchTile({
   onConfigChange,
   onResize,
   onRemove,
+  onDuplicate,
+  onRename,
   live,
 }: Props) {
   const slug = (config.service as string) || '';
@@ -71,7 +75,15 @@ export default function ServiceWatchTile({
 
   if (!svc) {
     return (
-      <TileChrome title="Service Watch" editing={editing} onResize={onResize} onRemove={onRemove}>
+      <TileChrome
+        title="Service Watch"
+        label={config.label ?? null}
+        editing={editing}
+        onResize={onResize}
+        onRemove={onRemove}
+        onDuplicate={onDuplicate}
+        onRename={onRename}
+      >
         <div style={{ color: 'var(--muted)', fontSize: 12 }}>No service data</div>
       </TileChrome>
     );
@@ -114,9 +126,12 @@ export default function ServiceWatchTile({
           {svc.name.substring(0, 2).toUpperCase()}
         </div>
       }
+      label={config.label ?? null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}
+      onDuplicate={onDuplicate}
+      onRename={onRename}
       onConfigure={() => {
         const next = live.services[(live.services.findIndex((s) => s.slug === svc.slug) + 1) % live.services.length];
         if (next) onConfigChange({ service: next.slug });

--- a/src/components/tiles/ServiceWatchTile.tsx
+++ b/src/components/tiles/ServiceWatchTile.tsx
@@ -1,6 +1,5 @@
 import TileChrome from './TileChrome';
 import Sparkline from '../Sparkline';
-import RefreshSelect from './RefreshSelect';
 import { getStatusColor, historyToSparkline } from '@/lib/boardColors';
 import { useServiceStatus } from '@/hooks/useStatus';
 import type { LiveData } from './types';
@@ -15,6 +14,7 @@ interface Props {
   onRemove?: () => void;
   onDuplicate?: () => void;
   onRename?: (label: string | null) => void;
+  onConfigure?: () => void;
   live: LiveData;
 }
 
@@ -70,13 +70,18 @@ export default function ServiceWatchTile({
   onRemove,
   onDuplicate,
   onRename,
+  onConfigure,
   live,
 }: Props) {
+  void onConfigChange;
   const refreshMs = config.refreshMs;
   const override = useServiceStatus(refreshMs);
   const services = refreshMs && override.data ? override.data.services : live.services;
   const slug = (config.service as string) || '';
   const svc = services.find((s) => s.slug === slug) || services[0];
+  // toggleDataPoint kept for the parent's onConfigChange API symmetry, but
+  // the inline chip UI has moved to the config drawer.
+  void toggleDataPoint;
 
   if (!svc) {
     return (
@@ -88,6 +93,7 @@ export default function ServiceWatchTile({
         onRemove={onRemove}
         onDuplicate={onDuplicate}
         onRename={onRename}
+        onConfigure={onConfigure}
       >
         <div style={{ color: 'var(--muted)', fontSize: 12 }}>No service data</div>
       </TileChrome>
@@ -137,10 +143,7 @@ export default function ServiceWatchTile({
       onRemove={onRemove}
       onDuplicate={onDuplicate}
       onRename={onRename}
-      onConfigure={() => {
-        const next = services[(services.findIndex((s) => s.slug === svc.slug) + 1) % services.length];
-        if (next) onConfigChange({ service: next.slug });
-      }}
+      onConfigure={onConfigure}
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12, height: '100%' }}>
         <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
@@ -214,30 +217,6 @@ export default function ServiceWatchTile({
           </div>
         )}
 
-        {editing && (
-          <div className="datapoint-chips">
-            {[
-              ['sparkline', '30d chart'],
-              ['uptime', 'Uptime %'],
-              ['official', 'Official'],
-              ['downdetector', 'DD reports'],
-            ].map(([k, label]) => (
-              <button
-                key={k}
-                onClick={() => toggleDataPoint(k)}
-                className={`chip ${dataPoints.includes(k) ? 'chip-on' : ''}`}
-              >
-                {dataPoints.includes(k) ? '●' : '○'} {label}
-              </button>
-            ))}
-          </div>
-        )}
-        {editing && (
-          <RefreshSelect
-            value={refreshMs}
-            onChange={(ms) => onConfigChange({ refreshMs: ms })}
-          />
-        )}
       </div>
     </TileChrome>
   );

--- a/src/components/tiles/StatusMapTile.tsx
+++ b/src/components/tiles/StatusMapTile.tsx
@@ -37,6 +37,8 @@ export default function StatusMapTile({ config, editing, onResize, onRemove, onD
         </svg>
       }
       label={typeof config.label === 'string' ? config.label : null}
+      iconText={typeof config.icon === 'string' ? config.icon : null}
+      tag={typeof config.tag === 'string' ? config.tag : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}

--- a/src/components/tiles/StatusMapTile.tsx
+++ b/src/components/tiles/StatusMapTile.tsx
@@ -15,7 +15,7 @@ function regionColor(hot: number): string {
   return '#7CB342';
 }
 
-export default function StatusMapTile({ config, editing, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
+export default function StatusMapTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure, live }: TileProps) {
   // Compute a rough "heat" per region based on active incidents
   const activeIncidents = live.incidents.filter((i) => i.status !== 'resolved').length;
   const totalServices = live.services.length || 1;
@@ -42,6 +42,7 @@ export default function StatusMapTile({ config, editing, onResize, onRemove, onD
       onRemove={onRemove}
       onDuplicate={onDuplicate}
       onRename={onRename}
+      onConfigure={onConfigure}
     >
       <div
         style={{

--- a/src/components/tiles/StatusMapTile.tsx
+++ b/src/components/tiles/StatusMapTile.tsx
@@ -15,7 +15,7 @@ function regionColor(hot: number): string {
   return '#7CB342';
 }
 
-export default function StatusMapTile({ editing, onResize, onRemove, live }: TileProps) {
+export default function StatusMapTile({ config, editing, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
   // Compute a rough "heat" per region based on active incidents
   const activeIncidents = live.incidents.filter((i) => i.status !== 'resolved').length;
   const totalServices = live.services.length || 1;
@@ -36,9 +36,12 @@ export default function StatusMapTile({ editing, onResize, onRemove, live }: Til
           <path d="M12 2a8 8 0 018 8c0 6-8 12-8 12s-8-6-8-12a8 8 0 018-8z" />
         </svg>
       }
+      label={typeof config.label === 'string' ? config.label : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}
+      onDuplicate={onDuplicate}
+      onRename={onRename}
     >
       <div
         style={{

--- a/src/components/tiles/StatusPageTile.tsx
+++ b/src/components/tiles/StatusPageTile.tsx
@@ -14,7 +14,7 @@ const DEFAULT_COMPONENTS: Component[] = [
   { name: 'Search',    status: 'operational' },
 ];
 
-export default function StatusPageTile({ config, editing, onResize, onRemove }: TileProps) {
+export default function StatusPageTile({ config, editing, onResize, onRemove, onDuplicate, onRename }: TileProps) {
   const components = (config.components as Component[]) ?? DEFAULT_COMPONENTS;
   const name = (config.name as string) || 'Imported Status Page';
   const color = (config.color as string) || '#635BFF';
@@ -41,9 +41,12 @@ export default function StatusPageTile({ config, editing, onResize, onRemove }: 
           Statuspage
         </span>
       }
+      label={typeof config.label === 'string' ? config.label : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}
+      onDuplicate={onDuplicate}
+      onRename={onRename}
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 6, overflowY: 'auto', flex: 1 }}>
         {components.map((c, i) => {

--- a/src/components/tiles/StatusPageTile.tsx
+++ b/src/components/tiles/StatusPageTile.tsx
@@ -14,7 +14,7 @@ const DEFAULT_COMPONENTS: Component[] = [
   { name: 'Search',    status: 'operational' },
 ];
 
-export default function StatusPageTile({ config, editing, onResize, onRemove, onDuplicate, onRename }: TileProps) {
+export default function StatusPageTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure }: TileProps) {
   const components = (config.components as Component[]) ?? DEFAULT_COMPONENTS;
   const name = (config.name as string) || 'Imported Status Page';
   const color = (config.color as string) || '#635BFF';
@@ -47,6 +47,7 @@ export default function StatusPageTile({ config, editing, onResize, onRemove, on
       onRemove={onRemove}
       onDuplicate={onDuplicate}
       onRename={onRename}
+      onConfigure={onConfigure}
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 6, overflowY: 'auto', flex: 1 }}>
         {components.map((c, i) => {

--- a/src/components/tiles/StatusPageTile.tsx
+++ b/src/components/tiles/StatusPageTile.tsx
@@ -42,6 +42,8 @@ export default function StatusPageTile({ config, editing, onResize, onRemove, on
         </span>
       }
       label={typeof config.label === 'string' ? config.label : null}
+      iconText={typeof config.icon === 'string' ? config.icon : null}
+      tag={typeof config.tag === 'string' ? config.tag : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}

--- a/src/components/tiles/TileChrome.tsx
+++ b/src/components/tiles/TileChrome.tsx
@@ -6,6 +6,8 @@ interface TileChromeProps {
   title: string;
   label?: string | null;
   icon?: ReactNode;
+  iconText?: string | null;
+  tag?: string | null;
   badge?: ReactNode;
   children: ReactNode;
   editing?: boolean;
@@ -20,6 +22,8 @@ export default function TileChrome({
   title,
   label,
   icon,
+  iconText,
+  tag,
   badge,
   children,
   editing,
@@ -54,7 +58,9 @@ export default function TileChrome({
     <div className="tile-inner">
       <div className="tile-header">
         <div className="tile-title">
-          {icon}
+          {iconText
+            ? <span className="tile-icon-text" aria-hidden="true">{iconText}</span>
+            : icon}
           {renaming ? (
             <input
               ref={inputRef}
@@ -78,6 +84,7 @@ export default function TileChrome({
               {displayed}
             </span>
           )}
+          {tag && <span className="tile-tag">{tag.slice(0, 12)}</span>}
           {badge}
         </div>
         <div className="tile-actions">

--- a/src/components/tiles/TileChrome.tsx
+++ b/src/components/tiles/TileChrome.tsx
@@ -1,7 +1,10 @@
-import { ReactNode } from 'react';
+'use client';
+
+import { ReactNode, useEffect, useRef, useState } from 'react';
 
 interface TileChromeProps {
   title: string;
+  label?: string | null;
   icon?: ReactNode;
   badge?: ReactNode;
   children: ReactNode;
@@ -9,10 +12,13 @@ interface TileChromeProps {
   onResize?: () => void;
   onRemove?: () => void;
   onConfigure?: () => void;
+  onDuplicate?: () => void;
+  onRename?: (label: string | null) => void;
 }
 
 export default function TileChrome({
   title,
+  label,
   icon,
   badge,
   children,
@@ -20,13 +26,58 @@ export default function TileChrome({
   onResize,
   onRemove,
   onConfigure,
+  onDuplicate,
+  onRename,
 }: TileChromeProps) {
+  const [renaming, setRenaming] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const displayed = label && label.trim() !== '' ? label : title;
+
+  useEffect(() => {
+    if (renaming) inputRef.current?.select();
+  }, [renaming]);
+
+  // Cancel rename if edit mode flips off.
+  useEffect(() => {
+    if (!editing && renaming) setRenaming(false);
+  }, [editing, renaming]);
+
+  const commit = (value: string) => {
+    if (!onRename) { setRenaming(false); return; }
+    const trimmed = value.trim();
+    if (trimmed === '' || trimmed === title) onRename(null);
+    else onRename(trimmed);
+    setRenaming(false);
+  };
+
   return (
     <div className="tile-inner">
       <div className="tile-header">
         <div className="tile-title">
           {icon}
-          <span>{title}</span>
+          {renaming ? (
+            <input
+              ref={inputRef}
+              type="text"
+              defaultValue={displayed}
+              aria-label="Rename tile"
+              className="tile-title-input"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') commit((e.target as HTMLInputElement).value);
+                else if (e.key === 'Escape') setRenaming(false);
+              }}
+              onBlur={(e) => commit(e.target.value)}
+              onClick={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <span
+              onDoubleClick={() => editing && onRename && setRenaming(true)}
+              title={editing && onRename ? 'Double-click to rename' : undefined}
+            >
+              {displayed}
+            </span>
+          )}
           {badge}
         </div>
         <div className="tile-actions">
@@ -38,6 +89,14 @@ export default function TileChrome({
                   <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 11-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 11-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 11-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 110-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 112.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 114 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 112.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 110 4h-.09a1.65 1.65 0 00-1.51 1z" />
                 </svg>
               </button>
+              {onDuplicate && (
+                <button className="tile-btn" onClick={onDuplicate} title="Duplicate">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <rect x="9" y="9" width="11" height="11" rx="2" />
+                    <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                  </svg>
+                </button>
+              )}
               <button className="tile-btn" onClick={onResize} title="Resize">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                   <path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" />

--- a/src/components/tiles/UptimeChartTile.tsx
+++ b/src/components/tiles/UptimeChartTile.tsx
@@ -16,6 +16,8 @@ export default function UptimeChartTile({ config, editing, onResize, onRemove, o
       <TileChrome
         title="Uptime Chart"
         label={typeof config.label === 'string' ? config.label : null}
+        iconText={typeof config.icon === 'string' ? config.icon : null}
+        tag={typeof config.tag === 'string' ? config.tag : null}
         editing={editing}
         onResize={onResize}
         onRemove={onRemove}
@@ -64,6 +66,8 @@ export default function UptimeChartTile({ config, editing, onResize, onRemove, o
         </div>
       }
       label={typeof config.label === 'string' ? config.label : null}
+      iconText={typeof config.icon === 'string' ? config.icon : null}
+      tag={typeof config.tag === 'string' ? config.tag : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}

--- a/src/components/tiles/UptimeChartTile.tsx
+++ b/src/components/tiles/UptimeChartTile.tsx
@@ -3,9 +3,14 @@ import Sparkline from '../Sparkline';
 import { getStatusColor, historyToSparkline } from '@/lib/boardColors';
 import type { TileProps } from './types';
 
-export default function UptimeChartTile({ config, editing, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
+const RANGE_OPTIONS = [7, 30, 90] as const;
+type RangeDays = typeof RANGE_OPTIONS[number];
+
+export default function UptimeChartTile({ config, editing, onConfigChange, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
   const slug = (config.service as string) || '';
   const svc = live.services.find((s) => s.slug === slug) ?? live.services[0];
+  const filters = (config.filters ?? {}) as { rangeDays?: RangeDays };
+  const rangeDays: RangeDays = filters.rangeDays ?? 30;
 
   if (!svc) {
     return (
@@ -23,7 +28,8 @@ export default function UptimeChartTile({ config, editing, onResize, onRemove, o
     );
   }
 
-  const hist = live.history[svc.slug] ?? [];
+  const fullHist = live.history[svc.slug] ?? [];
+  const hist = fullHist.slice(-rangeDays);
   const sparkData = historyToSparkline(hist as Parameters<typeof historyToSparkline>[0]);
   const c = getStatusColor(svc.overallStatus);
   const uptimePct =
@@ -32,13 +38,13 @@ export default function UptimeChartTile({ config, editing, onResize, onRemove, o
       : '—';
 
   const today = new Date();
-  const thirtyAgo = new Date(today);
-  thirtyAgo.setDate(today.getDate() - 30);
+  const rangeAgo = new Date(today);
+  rangeAgo.setDate(today.getDate() - rangeDays);
   const fmt = (d: Date) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 
   return (
     <TileChrome
-      title={`${svc.name} — 30 day`}
+      title={`${svc.name} — ${rangeDays} day`}
       icon={
         <div
           style={{
@@ -70,7 +76,7 @@ export default function UptimeChartTile({ config, editing, onResize, onRemove, o
           <div style={{ fontSize: 24, fontWeight: 700, color: 'var(--foreground)', fontVariantNumeric: 'tabular-nums' }}>
             {uptimePct}%
           </div>
-          <div style={{ fontSize: 11, color: 'var(--muted-strong)' }}>uptime over 30 days</div>
+          <div style={{ fontSize: 11, color: 'var(--muted-strong)' }}>uptime over {rangeDays} days</div>
         </div>
         <div style={{ flex: 1, minHeight: 60 }}>
           {sparkData.length > 0 ? (
@@ -80,9 +86,23 @@ export default function UptimeChartTile({ config, editing, onResize, onRemove, o
           )}
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 9, color: 'var(--muted-strong)' }}>
-          <span>{fmt(thirtyAgo)}</span>
+          <span>{fmt(rangeAgo)}</span>
           <span>{fmt(today)}</span>
         </div>
+        {editing && (
+          <div className="tile-filters">
+            <span className="tile-filter-label">Range</span>
+            {RANGE_OPTIONS.map((d) => (
+              <button
+                key={d}
+                className={`chip ${rangeDays === d ? 'chip-on' : ''}`}
+                onClick={() => onConfigChange({ filters: { ...filters, rangeDays: d } })}
+              >
+                {d}d
+              </button>
+            ))}
+          </div>
+        )}
       </div>
     </TileChrome>
   );

--- a/src/components/tiles/UptimeChartTile.tsx
+++ b/src/components/tiles/UptimeChartTile.tsx
@@ -3,10 +3,9 @@ import Sparkline from '../Sparkline';
 import { getStatusColor, historyToSparkline } from '@/lib/boardColors';
 import type { TileProps } from './types';
 
-const RANGE_OPTIONS = [7, 30, 90] as const;
-type RangeDays = typeof RANGE_OPTIONS[number];
+type RangeDays = 7 | 30 | 90;
 
-export default function UptimeChartTile({ config, editing, onConfigChange, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
+export default function UptimeChartTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure, live }: TileProps) {
   const slug = (config.service as string) || '';
   const svc = live.services.find((s) => s.slug === slug) ?? live.services[0];
   const filters = (config.filters ?? {}) as { rangeDays?: RangeDays };
@@ -70,6 +69,7 @@ export default function UptimeChartTile({ config, editing, onConfigChange, onRes
       onRemove={onRemove}
       onDuplicate={onDuplicate}
       onRename={onRename}
+      onConfigure={onConfigure}
     >
       <div style={{ display: 'flex', flexDirection: 'column', height: '100%', gap: 8 }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
@@ -89,20 +89,6 @@ export default function UptimeChartTile({ config, editing, onConfigChange, onRes
           <span>{fmt(rangeAgo)}</span>
           <span>{fmt(today)}</span>
         </div>
-        {editing && (
-          <div className="tile-filters">
-            <span className="tile-filter-label">Range</span>
-            {RANGE_OPTIONS.map((d) => (
-              <button
-                key={d}
-                className={`chip ${rangeDays === d ? 'chip-on' : ''}`}
-                onClick={() => onConfigChange({ filters: { ...filters, rangeDays: d } })}
-              >
-                {d}d
-              </button>
-            ))}
-          </div>
-        )}
       </div>
     </TileChrome>
   );

--- a/src/components/tiles/UptimeChartTile.tsx
+++ b/src/components/tiles/UptimeChartTile.tsx
@@ -3,13 +3,21 @@ import Sparkline from '../Sparkline';
 import { getStatusColor, historyToSparkline } from '@/lib/boardColors';
 import type { TileProps } from './types';
 
-export default function UptimeChartTile({ config, editing, onResize, onRemove, live }: TileProps) {
+export default function UptimeChartTile({ config, editing, onResize, onRemove, onDuplicate, onRename, live }: TileProps) {
   const slug = (config.service as string) || '';
   const svc = live.services.find((s) => s.slug === slug) ?? live.services[0];
 
   if (!svc) {
     return (
-      <TileChrome title="Uptime Chart" editing={editing} onResize={onResize} onRemove={onRemove}>
+      <TileChrome
+        title="Uptime Chart"
+        label={typeof config.label === 'string' ? config.label : null}
+        editing={editing}
+        onResize={onResize}
+        onRemove={onRemove}
+        onDuplicate={onDuplicate}
+        onRename={onRename}
+      >
         <div style={{ color: 'var(--muted)', fontSize: 12 }}>No service data</div>
       </TileChrome>
     );
@@ -50,9 +58,12 @@ export default function UptimeChartTile({ config, editing, onResize, onRemove, l
           {svc.name.substring(0, 2).toUpperCase()}
         </div>
       }
+      label={typeof config.label === 'string' ? config.label : null}
       editing={editing}
       onResize={onResize}
       onRemove={onRemove}
+      onDuplicate={onDuplicate}
+      onRename={onRename}
     >
       <div style={{ display: 'flex', flexDirection: 'column', height: '100%', gap: 8 }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>

--- a/src/components/tiles/configs/CommonFields.tsx
+++ b/src/components/tiles/configs/CommonFields.tsx
@@ -6,13 +6,31 @@ interface Props {
   tileType: string;
   label: string | undefined;
   refreshMs: number | undefined;
+  accent: string | undefined;
+  icon: string | undefined;
+  tag: string | undefined;
   onLabelChange: (v: string | null) => void;
   onRefreshChange: (ms: number | undefined) => void;
+  onAccentChange: (v: string | null) => void;
+  onIconChange: (v: string | null) => void;
+  onTagChange: (v: string | null) => void;
   /** If true, hide the refresh selector — tile doesn't poll live data. */
   hideRefresh?: boolean;
 }
 
-export default function CommonFields({ label, refreshMs, onLabelChange, onRefreshChange, hideRefresh }: Props) {
+export default function CommonFields({
+  label,
+  refreshMs,
+  accent,
+  icon,
+  tag,
+  onLabelChange,
+  onRefreshChange,
+  onAccentChange,
+  onIconChange,
+  onTagChange,
+  hideRefresh,
+}: Props) {
   return (
     <>
       <div className="twk-row">
@@ -24,6 +42,54 @@ export default function CommonFields({ label, refreshMs, onLabelChange, onRefres
           value={label ?? ''}
           onChange={(e) => onLabelChange(e.target.value === '' ? null : e.target.value)}
         />
+      </div>
+
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Icon / emoji</span></div>
+        <input
+          type="text"
+          className="twk-field"
+          placeholder="(default icon)"
+          maxLength={4}
+          value={icon ?? ''}
+          onChange={(e) => onIconChange(e.target.value === '' ? null : e.target.value)}
+        />
+      </div>
+
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Tag</span></div>
+        <input
+          type="text"
+          className="twk-field"
+          placeholder="(none)"
+          maxLength={12}
+          value={tag ?? ''}
+          onChange={(e) => onTagChange(e.target.value === '' ? null : e.target.value)}
+        />
+      </div>
+
+      <div className="twk-row twk-row-h">
+        <div className="twk-lbl"><span>Accent</span></div>
+        <div style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+          <input
+            type="color"
+            className="twk-color"
+            value={accent ?? '#268bd2'}
+            onChange={(e) => onAccentChange(e.target.value)}
+            aria-label="Tile accent"
+          />
+          {accent && (
+            <button
+              type="button"
+              className="board-btn board-btn-icon"
+              onClick={() => onAccentChange(null)}
+              title="Use global accent"
+              aria-label="Clear accent"
+            >
+              ✕
+            </button>
+          )}
+        </div>
       </div>
 
       {!hideRefresh && (

--- a/src/components/tiles/configs/CommonFields.tsx
+++ b/src/components/tiles/configs/CommonFields.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import RefreshSelect from '../RefreshSelect';
+
+interface Props {
+  tileType: string;
+  label: string | undefined;
+  refreshMs: number | undefined;
+  onLabelChange: (v: string | null) => void;
+  onRefreshChange: (ms: number | undefined) => void;
+  /** If true, hide the refresh selector — tile doesn't poll live data. */
+  hideRefresh?: boolean;
+}
+
+export default function CommonFields({ label, refreshMs, onLabelChange, onRefreshChange, hideRefresh }: Props) {
+  return (
+    <>
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Title</span></div>
+        <input
+          type="text"
+          className="twk-field"
+          placeholder="(default)"
+          value={label ?? ''}
+          onChange={(e) => onLabelChange(e.target.value === '' ? null : e.target.value)}
+        />
+      </div>
+
+      {!hideRefresh && (
+        <div className="twk-row">
+          <div className="twk-lbl"><span>Refresh</span></div>
+          <RefreshSelect value={refreshMs} onChange={onRefreshChange} />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/tiles/configs/index.tsx
+++ b/src/components/tiles/configs/index.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import type { TileConfig, TileType } from '@/hooks/useBoard';
+import type { LiveData } from '../types';
+import CommonFields from './CommonFields';
+
+export interface ConfigFormProps {
+  tile: TileConfig;
+  live: LiveData;
+  onUpdate: (patch: Partial<TileConfig>) => void;
+}
+
+type ConfigForm = (props: ConfigFormProps) => ReactNode;
+
+function update(tile: TileConfig, onUpdate: ConfigFormProps['onUpdate'], patch: Record<string, unknown>) {
+  onUpdate({ config: patch });
+}
+
+function common(tile: TileConfig, onUpdate: ConfigFormProps['onUpdate'], opts: { hideRefresh?: boolean } = {}) {
+  const cfg = tile.config as Record<string, unknown>;
+  return (
+    <CommonFields
+      tileType={tile.type}
+      label={typeof cfg.label === 'string' ? cfg.label : undefined}
+      refreshMs={typeof cfg.refreshMs === 'number' ? cfg.refreshMs : undefined}
+      hideRefresh={opts.hideRefresh}
+      onLabelChange={(v) => update(tile, onUpdate, { label: v ?? undefined })}
+      onRefreshChange={(ms) => update(tile, onUpdate, { refreshMs: ms })}
+    />
+  );
+}
+
+const StatForm: ConfigForm = ({ tile, onUpdate }) => {
+  const metric = (tile.config.metric as string) || 'uptime';
+  return (
+    <>
+      {common(tile, onUpdate, { hideRefresh: true })}
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Metric</span></div>
+        <select
+          className="twk-field"
+          value={metric}
+          onChange={(e) => update(tile, onUpdate, { metric: e.target.value })}
+        >
+          <option value="uptime">Fleet uptime</option>
+          <option value="incidents">Active incidents</option>
+          <option value="dd">DD reports</option>
+          <option value="mttr">MTTR (30d)</option>
+        </select>
+      </div>
+    </>
+  );
+};
+
+const DATA_POINTS: { key: string; label: string }[] = [
+  { key: 'sparkline',    label: '30d chart' },
+  { key: 'uptime',       label: 'Uptime %' },
+  { key: 'official',     label: 'Official' },
+  { key: 'downdetector', label: 'DD reports' },
+];
+
+const ServiceWatchForm: ConfigForm = ({ tile, live, onUpdate }) => {
+  const service = (tile.config.service as string) || '';
+  const dataPoints = tile.dataPoints ?? [];
+  const toggleDataPoint = (key: string) => {
+    const next = dataPoints.includes(key)
+      ? dataPoints.filter((k) => k !== key)
+      : [...dataPoints, key];
+    onUpdate({ dataPoints: next });
+  };
+  return (
+    <>
+      {common(tile, onUpdate)}
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Service</span></div>
+        <select
+          className="twk-field"
+          value={service}
+          onChange={(e) => update(tile, onUpdate, { service: e.target.value })}
+        >
+          {live.services.map((s) => (
+            <option key={s.slug} value={s.slug}>{s.name}</option>
+          ))}
+        </select>
+      </div>
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Data points</span></div>
+        <div className="twk-chips">
+          {DATA_POINTS.map((dp) => (
+            <button
+              key={dp.key}
+              className={`chip ${dataPoints.includes(dp.key) ? 'chip-on' : ''}`}
+              onClick={() => toggleDataPoint(dp.key)}
+            >
+              {dataPoints.includes(dp.key) ? '●' : '○'} {dp.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+};
+
+const SEVERITIES = ['critical', 'major', 'minor'] as const;
+const STATUSES = ['investigating', 'identified', 'monitoring', 'resolved'] as const;
+
+const IncidentFeedForm: ConfigForm = ({ tile, onUpdate }) => {
+  const filters = (tile.config.filters ?? {}) as { severity?: string[]; statuses?: string[] };
+  const toggle = (key: 'severity' | 'statuses', value: string) => {
+    const current = filters[key] ?? [];
+    const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+    update(tile, onUpdate, { filters: { ...filters, [key]: next.length ? next : undefined } });
+  };
+  return (
+    <>
+      {common(tile, onUpdate)}
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Severity</span></div>
+        <div className="twk-chips">
+          {SEVERITIES.map((s) => (
+            <button
+              key={s}
+              className={`chip ${filters.severity?.includes(s) ? 'chip-on' : ''}`}
+              onClick={() => toggle('severity', s)}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Status</span></div>
+        <div className="twk-chips">
+          {STATUSES.map((s) => (
+            <button
+              key={s}
+              className={`chip ${filters.statuses?.includes(s) ? 'chip-on' : ''}`}
+              onClick={() => toggle('statuses', s)}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+};
+
+const ServiceGridForm: ConfigForm = ({ tile, onUpdate }) => {
+  const filters = (tile.config.filters ?? {}) as { hideOperational?: boolean };
+  return (
+    <>
+      {common(tile, onUpdate, { hideRefresh: true })}
+      <div className="twk-row twk-row-h">
+        <div className="twk-lbl"><span>Hide healthy</span></div>
+        <button
+          type="button"
+          className="twk-toggle"
+          data-on={!!filters.hideOperational}
+          role="switch"
+          aria-checked={!!filters.hideOperational}
+          onClick={() => update(tile, onUpdate, { filters: { ...filters, hideOperational: !filters.hideOperational } })}
+        >
+          <i />
+        </button>
+      </div>
+    </>
+  );
+};
+
+const UptimeChartForm: ConfigForm = ({ tile, live, onUpdate }) => {
+  const service = (tile.config.service as string) || '';
+  const filters = (tile.config.filters ?? {}) as { rangeDays?: number };
+  const rangeDays = filters.rangeDays ?? 30;
+  return (
+    <>
+      {common(tile, onUpdate, { hideRefresh: true })}
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Service</span></div>
+        <select
+          className="twk-field"
+          value={service}
+          onChange={(e) => update(tile, onUpdate, { service: e.target.value })}
+        >
+          {live.services.map((s) => (
+            <option key={s.slug} value={s.slug}>{s.name}</option>
+          ))}
+        </select>
+      </div>
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Range</span></div>
+        <div className="twk-seg">
+          {[7, 30, 90].map((d) => (
+            <button
+              key={d}
+              data-on={rangeDays === d}
+              onClick={() => update(tile, onUpdate, { filters: { ...filters, rangeDays: d } })}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+};
+
+const RssForm: ConfigForm = ({ tile, onUpdate }) => {
+  const feed = (tile.config.feed as string) || 'aws-blog';
+  return (
+    <>
+      {common(tile, onUpdate, { hideRefresh: true })}
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Feed</span></div>
+        <select
+          className="twk-field"
+          value={feed}
+          onChange={(e) => update(tile, onUpdate, { feed: e.target.value })}
+        >
+          <option value="aws-blog">AWS What&apos;s New</option>
+          <option value="gh-blog">GitHub Engineering</option>
+        </select>
+      </div>
+    </>
+  );
+};
+
+const StatusMapForm: ConfigForm = ({ tile, onUpdate }) => common(tile, onUpdate, { hideRefresh: true });
+const StatusPageForm: ConfigForm = ({ tile, onUpdate }) => common(tile, onUpdate, { hideRefresh: true });
+
+export const TILE_CONFIG_FORMS: Record<TileType, ConfigForm> = {
+  'stat':          StatForm,
+  'service-watch': ServiceWatchForm,
+  'service-grid':  ServiceGridForm,
+  'incident-feed': IncidentFeedForm,
+  'rss':           RssForm,
+  'uptime-chart':  UptimeChartForm,
+  'status-map':    StatusMapForm,
+  'statuspage':    StatusPageForm,
+};

--- a/src/components/tiles/configs/index.tsx
+++ b/src/components/tiles/configs/index.tsx
@@ -24,9 +24,15 @@ function common(tile: TileConfig, onUpdate: ConfigFormProps['onUpdate'], opts: {
       tileType={tile.type}
       label={typeof cfg.label === 'string' ? cfg.label : undefined}
       refreshMs={typeof cfg.refreshMs === 'number' ? cfg.refreshMs : undefined}
+      accent={typeof cfg.accent === 'string' ? cfg.accent : undefined}
+      icon={typeof cfg.icon === 'string' ? cfg.icon : undefined}
+      tag={typeof cfg.tag === 'string' ? cfg.tag : undefined}
       hideRefresh={opts.hideRefresh}
       onLabelChange={(v) => update(tile, onUpdate, { label: v ?? undefined })}
       onRefreshChange={(ms) => update(tile, onUpdate, { refreshMs: ms })}
+      onAccentChange={(v) => update(tile, onUpdate, { accent: v ?? undefined })}
+      onIconChange={(v) => update(tile, onUpdate, { icon: v ?? undefined })}
+      onTagChange={(v) => update(tile, onUpdate, { tag: v ?? undefined })}
     />
   );
 }

--- a/src/components/tiles/types.ts
+++ b/src/components/tiles/types.ts
@@ -18,5 +18,6 @@ export interface TileProps {
   onRemove?: () => void;
   onDuplicate?: () => void;
   onRename?: (label: string | null) => void;
+  onConfigure?: () => void;
   live: LiveData;
 }

--- a/src/components/tiles/types.ts
+++ b/src/components/tiles/types.ts
@@ -16,5 +16,7 @@ export interface TileProps {
   onConfigChange: (patch: Record<string, unknown>) => void;
   onResize?: () => void;
   onRemove?: () => void;
+  onDuplicate?: () => void;
+  onRename?: (label: string | null) => void;
   live: LiveData;
 }

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useCallback, useRef } from 'react';
+import * as layout from '@/lib/board/layout';
 
 export type TileType =
   | 'stat'
@@ -85,6 +86,7 @@ export interface BoardActions {
   setBoard: (next: TileConfig[]) => void;
   duplicateTile: (id: string) => void;
   renameTile: (id: string, label: string | null) => void;
+  moveTile: (id: string, x: number, y: number) => void;
   undo: () => void;
   redo: () => void;
   canUndo: boolean;
@@ -95,9 +97,13 @@ export function useBoard(): [TileConfig[], BoardActions] {
   const [history, setHistory] = useState<History>({ past: [], present: DEFAULT_BOARD, future: [] });
   const hydrated = useRef(false);
 
-  // Hydrate from localStorage after mount
+  // Hydrate from localStorage after mount. Compact once on load so any
+  // historical overlaps (the DEFAULT_BOARD relied on grid auto-flow, and
+  // older saves used y=99 as a "place at end" sentinel) collapse into
+  // valid (x, y) positions before we switch to explicit grid placement.
   useEffect(() => {
-    setHistory({ past: [], present: readBoard(), future: [] });
+    const stored = readBoard();
+    setHistory({ past: [], present: layout.compactDown(stored), future: [] });
     hydrated.current = true;
   }, []);
 
@@ -186,19 +192,22 @@ export function useBoard(): [TileConfig[], BoardActions] {
     };
     const id = 't' + Date.now();
     const size = defaultSizes[type];
-    mutate((b) => [
-      ...b,
-      {
-        id,
-        type,
-        x: 0,
-        y: 99,
-        w: size.w,
-        h: size.h,
-        config: { ...defaultConfigs[type], ...extraConfig },
-        dataPoints: defaultDataPoints[type],
-      },
-    ]);
+    mutate((b) => {
+      const bottom = b.reduce((m, t) => Math.max(m, t.y + t.h), 0);
+      return [
+        ...b,
+        {
+          id,
+          type,
+          x: 0,
+          y: bottom,
+          w: size.w,
+          h: size.h,
+          config: { ...defaultConfigs[type], ...extraConfig },
+          dataPoints: defaultDataPoints[type],
+        },
+      ];
+    });
   }, [mutate]);
 
   const swapTiles = useCallback((srcId: string, tgtId: string) => {
@@ -227,16 +236,21 @@ export function useBoard(): [TileConfig[], BoardActions] {
     mutate((b) => {
       const src = b.find((t) => t.id === id);
       if (!src) return b;
+      const bottom = b.reduce((m, t) => Math.max(m, t.y + t.h), 0);
       const clone: TileConfig = {
         ...src,
         id: 't' + Date.now(),
         x: 0,
-        y: 99,
+        y: bottom,
         config: { ...src.config },
         dataPoints: [...src.dataPoints],
       };
       return [...b, clone];
     });
+  }, [mutate]);
+
+  const moveTile = useCallback((id: string, x: number, y: number) => {
+    mutate((b) => layout.moveTile(b, id, x, y));
   }, [mutate]);
 
   const renameTile = useCallback((id: string, label: string | null) => {
@@ -286,6 +300,7 @@ export function useBoard(): [TileConfig[], BoardActions] {
     setBoard,
     duplicateTile,
     renameTile,
+    moveTile,
     undo,
     redo,
     canUndo: history.past.length > 0,

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -82,6 +82,7 @@ export interface BoardActions {
   addTile: (type: TileType, extraConfig?: Record<string, unknown>) => void;
   swapTiles: (srcId: string, tgtId: string) => void;
   resetBoard: () => void;
+  setBoard: (next: TileConfig[]) => void;
   undo: () => void;
   redo: () => void;
   canUndo: boolean;
@@ -216,6 +217,10 @@ export function useBoard(): [TileConfig[], BoardActions] {
     mutate(() => DEFAULT_BOARD);
   }, [mutate]);
 
+  const setBoard = useCallback((next: TileConfig[]) => {
+    mutate(() => next);
+  }, [mutate]);
+
   const undo = useCallback(() => {
     setHistory((h) => {
       if (h.past.length === 0) return h;
@@ -248,6 +253,7 @@ export function useBoard(): [TileConfig[], BoardActions] {
     addTile,
     swapTiles,
     resetBoard,
+    setBoard,
     undo,
     redo,
     canUndo: history.past.length > 0,

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -87,6 +87,7 @@ export interface BoardActions {
   duplicateTile: (id: string) => void;
   renameTile: (id: string, label: string | null) => void;
   moveTile: (id: string, x: number, y: number) => void;
+  resizeTile: (id: string, w: number, h: number) => void;
   undo: () => void;
   redo: () => void;
   canUndo: boolean;
@@ -253,6 +254,10 @@ export function useBoard(): [TileConfig[], BoardActions] {
     mutate((b) => layout.moveTile(b, id, x, y));
   }, [mutate]);
 
+  const resizeTile = useCallback((id: string, w: number, h: number) => {
+    mutate((b) => layout.resizeTile(b, id, w, h));
+  }, [mutate]);
+
   const renameTile = useCallback((id: string, label: string | null) => {
     mutate((b) =>
       b.map((t) => {
@@ -301,6 +306,7 @@ export function useBoard(): [TileConfig[], BoardActions] {
     duplicateTile,
     renameTile,
     moveTile,
+    resizeTile,
     undo,
     redo,
     canUndo: history.past.length > 0,

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -30,7 +30,7 @@ export interface TileConfig {
 const BOARD_STORAGE_KEY = 'outage-board-v3';
 const HISTORY_LIMIT = 50;
 
-const DEFAULT_BOARD: TileConfig[] = [
+export const DEFAULT_BOARD: TileConfig[] = [
   { id: 't1', type: 'stat',          x: 0, y: 0, w: 1, h: 2, config: { metric: 'uptime' },     dataPoints: [] },
   { id: 't2', type: 'stat',          x: 1, y: 0, w: 1, h: 2, config: { metric: 'incidents' },   dataPoints: [] },
   { id: 't3', type: 'stat',          x: 2, y: 0, w: 1, h: 2, config: { metric: 'mttr' },        dataPoints: [] },
@@ -46,24 +46,11 @@ const TILE_SIZES: { w: number; h: number }[] = [
   { w: 1, h: 1 }, { w: 1, h: 2 }, { w: 2, h: 1 }, { w: 2, h: 2 }, { w: 3, h: 2 }, { w: 2, h: 3 },
 ];
 
-function readBoard(): TileConfig[] {
-  if (typeof window === 'undefined') return DEFAULT_BOARD;
-  try {
-    const raw = localStorage.getItem(BOARD_STORAGE_KEY);
-    if (raw) return JSON.parse(raw) as TileConfig[];
-  } catch {
-    // ignore
-  }
-  return DEFAULT_BOARD;
-}
-
-function writeBoard(board: TileConfig[]) {
-  try {
-    localStorage.setItem(BOARD_STORAGE_KEY, JSON.stringify(board));
-  } catch {
-    // ignore
-  }
-}
+// Persistence now lives in `useBoardSet` (storage key 'outage-boards-v4').
+// useBoard is controlled by an external (tiles, onCommit) pair and no longer
+// reads or writes localStorage itself. BOARD_STORAGE_KEY is retained only as
+// a doc-string anchor so the historical key shows up in code search.
+void BOARD_STORAGE_KEY;
 
 interface History {
   past: TileConfig[][];
@@ -155,33 +142,56 @@ export interface BoardActions {
   canRedo: boolean;
 }
 
-export function useBoard(bp: Breakpoint = 'desktop'): [TileConfig[], BoardActions] {
-  const [history, setHistory] = useState<History>({ past: [], present: DEFAULT_BOARD, future: [] });
+export interface UseBoardParams {
+  bp?: Breakpoint;
+  boardId: string;
+  tiles: TileConfig[];
+  onCommit: (tiles: TileConfig[]) => void;
+}
+
+export function useBoard({ bp = 'desktop', boardId, tiles, onCommit }: UseBoardParams): [TileConfig[], BoardActions] {
+  const [history, setHistory] = useState<History>(() => ({
+    past: [],
+    present: layout.compactDown(tiles),
+    future: [],
+  }));
   const [lastTidyDelta, setLastTidyDelta] = useState<number | null>(null);
-  const hydrated = useRef(false);
   const cols = COLS_FOR[bp];
 
-  // Hydrate from localStorage after mount. Compact once on load so any
-  // historical overlaps (the DEFAULT_BOARD relied on grid auto-flow, and
-  // older saves used y=99 as a "place at end" sentinel) collapse into
-  // valid (x, y) positions before we switch to explicit grid placement.
-  useEffect(() => {
-    const stored = readBoard();
-    setHistory({ past: [], present: layout.compactDown(stored), future: [] });
-    hydrated.current = true;
-  }, []);
+  // Track which tiles array reference came from our own commits, so we can
+  // distinguish an external tiles change (active-board switch, import) from
+  // the parent echoing our last commit back at us.
+  const ownCommit = useRef<TileConfig[] | null>(null);
+  const lastBoardId = useRef(boardId);
 
-  // Persist whenever the present board changes (after hydration)
+  // External tiles change: either the active board id changed, or the parent
+  // replaced the tiles outside our knowledge (e.g. an import). Reset history
+  // to the new tiles.
   useEffect(() => {
-    if (!hydrated.current) return;
-    writeBoard(history.present);
-  }, [history.present]);
+    if (boardId !== lastBoardId.current) {
+      const next = layout.compactDown(tiles);
+      setHistory({ past: [], present: next, future: [] });
+      lastBoardId.current = boardId;
+      ownCommit.current = tiles;
+      return;
+    }
+    if (ownCommit.current === tiles) return;
+    // Parent changed tiles by a hand that wasn't us — reset.
+    setHistory({ past: [], present: tiles, future: [] });
+    ownCommit.current = tiles;
+  }, [boardId, tiles]);
 
-  // When the breakpoint changes (or after hydration), auto-generate any
-  // missing per-breakpoint layouts so tablet / mobile have something to
-  // render before the user touches the board.
+  // Notify parent whenever our present changes.
   useEffect(() => {
-    if (!hydrated.current) return;
+    if (history.present === ownCommit.current) return;
+    ownCommit.current = history.present;
+    onCommit(history.present);
+  }, [history.present, onCommit]);
+
+  // When the breakpoint changes, auto-generate any missing per-breakpoint
+  // layouts so tablet / mobile have something to render before the user
+  // touches the board.
+  useEffect(() => {
     setHistory((h) => {
       const generated = ensureBreakpointLayouts(h.present, bp);
       return generated === h.present ? h : { ...h, present: generated };

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -83,6 +83,8 @@ export interface BoardActions {
   swapTiles: (srcId: string, tgtId: string) => void;
   resetBoard: () => void;
   setBoard: (next: TileConfig[]) => void;
+  duplicateTile: (id: string) => void;
+  renameTile: (id: string, label: string | null) => void;
   undo: () => void;
   redo: () => void;
   canUndo: boolean;
@@ -221,6 +223,34 @@ export function useBoard(): [TileConfig[], BoardActions] {
     mutate(() => next);
   }, [mutate]);
 
+  const duplicateTile = useCallback((id: string) => {
+    mutate((b) => {
+      const src = b.find((t) => t.id === id);
+      if (!src) return b;
+      const clone: TileConfig = {
+        ...src,
+        id: 't' + Date.now(),
+        x: 0,
+        y: 99,
+        config: { ...src.config },
+        dataPoints: [...src.dataPoints],
+      };
+      return [...b, clone];
+    });
+  }, [mutate]);
+
+  const renameTile = useCallback((id: string, label: string | null) => {
+    mutate((b) =>
+      b.map((t) => {
+        if (t.id !== id) return t;
+        const nextConfig = { ...t.config };
+        if (label === null || label.trim() === '') delete nextConfig.label;
+        else nextConfig.label = label;
+        return { ...t, config: nextConfig };
+      })
+    );
+  }, [mutate]);
+
   const undo = useCallback(() => {
     setHistory((h) => {
       if (h.past.length === 0) return h;
@@ -254,6 +284,8 @@ export function useBoard(): [TileConfig[], BoardActions] {
     swapTiles,
     resetBoard,
     setBoard,
+    duplicateTile,
+    renameTile,
     undo,
     redo,
     canUndo: history.past.length > 0,

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -1,7 +1,9 @@
 'use client';
 
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import * as layout from '@/lib/board/layout';
+import type { BoxRect } from '@/lib/board/layout';
+import { COLS_FOR, type Breakpoint } from './useBreakpoint';
 
 export type TileType =
   | 'stat'
@@ -22,6 +24,7 @@ export interface TileConfig {
   h: number;
   config: Record<string, unknown>;
   dataPoints: string[];
+  layouts?: Partial<Record<Breakpoint, BoxRect>>;
 }
 
 const BOARD_STORAGE_KEY = 'outage-board-v3';
@@ -75,6 +78,62 @@ function pushHistory(h: History, next: TileConfig[]): History {
   return { past, present: next, future: [] };
 }
 
+function effectiveRect(t: TileConfig, bp: Breakpoint): BoxRect {
+  const stored = t.layouts?.[bp];
+  if (stored) return stored;
+  return { x: t.x, y: t.y, w: t.w, h: t.h };
+}
+
+/** Return a synthetic TileConfig view where (x,y,w,h) reflect the breakpoint. */
+function asEffective(t: TileConfig, bp: Breakpoint): TileConfig {
+  if (bp === 'desktop') return t;
+  const r = effectiveRect(t, bp);
+  return { ...t, x: r.x, y: r.y, w: r.w, h: r.h };
+}
+
+/** Write a new rect for tile `id` at breakpoint `bp`. */
+function writeRect(tile: TileConfig, bp: Breakpoint, rect: BoxRect): TileConfig {
+  if (bp === 'desktop') {
+    return { ...tile, x: rect.x, y: rect.y, w: rect.w, h: rect.h };
+  }
+  return { ...tile, layouts: { ...tile.layouts, [bp]: rect } };
+}
+
+/**
+ * Auto-generate a layout for `bp` for any tile that doesn't have one yet.
+ * Mobile = single-column stack sorted by current placement; tablet =
+ * clamp width to the tablet column count, then compact down.
+ */
+function ensureBreakpointLayouts(board: TileConfig[], bp: Breakpoint): TileConfig[] {
+  if (bp === 'desktop') return board;
+  if (board.every((t) => t.layouts?.[bp])) return board;
+  const cols = COLS_FOR[bp];
+  const sorted = [...board].sort((a, b) => a.y - b.y || a.x - b.x);
+  const generated: { id: string; rect: BoxRect }[] = [];
+  if (bp === 'mobile') {
+    let y = 0;
+    for (const t of sorted) {
+      generated.push({ id: t.id, rect: { x: 0, y, w: 1, h: t.h } });
+      y += t.h;
+    }
+  } else {
+    // tablet — clamp width, then compact down.
+    const widened = sorted.map((t) => ({
+      ...t,
+      w: Math.min(t.w, cols),
+      x: Math.min(t.x, cols - 1),
+    }));
+    const packed = layout.tidy(widened, cols).next;
+    for (const t of packed) generated.push({ id: t.id, rect: { x: t.x, y: t.y, w: t.w, h: t.h } });
+  }
+  const byId = new Map(generated.map((g) => [g.id, g.rect]));
+  return board.map((t) =>
+    t.layouts?.[bp]
+      ? t
+      : { ...t, layouts: { ...t.layouts, [bp]: byId.get(t.id) ?? effectiveRect(t, bp) } }
+  );
+}
+
 export interface BoardActions {
   updateTile: (id: string, patch: Partial<TileConfig>) => void;
   removeTile: (id: string) => void;
@@ -96,10 +155,11 @@ export interface BoardActions {
   canRedo: boolean;
 }
 
-export function useBoard(): [TileConfig[], BoardActions] {
+export function useBoard(bp: Breakpoint = 'desktop'): [TileConfig[], BoardActions] {
   const [history, setHistory] = useState<History>({ past: [], present: DEFAULT_BOARD, future: [] });
   const [lastTidyDelta, setLastTidyDelta] = useState<number | null>(null);
   const hydrated = useRef(false);
+  const cols = COLS_FOR[bp];
 
   // Hydrate from localStorage after mount. Compact once on load so any
   // historical overlaps (the DEFAULT_BOARD relied on grid auto-flow, and
@@ -117,9 +177,35 @@ export function useBoard(): [TileConfig[], BoardActions] {
     writeBoard(history.present);
   }, [history.present]);
 
+  // When the breakpoint changes (or after hydration), auto-generate any
+  // missing per-breakpoint layouts so tablet / mobile have something to
+  // render before the user touches the board.
+  useEffect(() => {
+    if (!hydrated.current) return;
+    setHistory((h) => {
+      const generated = ensureBreakpointLayouts(h.present, bp);
+      return generated === h.present ? h : { ...h, present: generated };
+    });
+  }, [bp]);
+
   const mutate = useCallback((producer: (b: TileConfig[]) => TileConfig[]) => {
     setHistory((h) => pushHistory(h, producer(h.present)));
   }, []);
+
+  // Run a layout-module operation against the effective view, then
+  // back-merge each tile's new rect into its appropriate breakpoint slot.
+  const runLayoutOp = useCallback((op: (effective: TileConfig[], cols: number) => TileConfig[]) => {
+    mutate((b) => {
+      const effective = b.map((t) => asEffective(t, bp));
+      const next = op(effective, cols);
+      const byId = new Map(next.map((t) => [t.id, { x: t.x, y: t.y, w: t.w, h: t.h }]));
+      return b.map((t) => {
+        const rect = byId.get(t.id);
+        if (!rect) return t;
+        return writeRect(t, bp, rect);
+      });
+    });
+  }, [mutate, bp, cols]);
 
   const updateTile = useCallback((id: string, patch: Partial<TileConfig>) => {
     mutate((b) =>
@@ -140,15 +226,15 @@ export function useBoard(): [TileConfig[], BoardActions] {
   }, [mutate]);
 
   const cycleResize = useCallback((id: string) => {
-    mutate((b) =>
-      b.map((t) => {
+    runLayoutOp((effective) =>
+      effective.map((t) => {
         if (t.id !== id) return t;
         const idx = TILE_SIZES.findIndex((s) => s.w === t.w && s.h === t.h);
         const next = TILE_SIZES[(idx + 1) % TILE_SIZES.length];
-        return { ...t, w: next.w, h: next.h };
+        return { ...t, w: Math.min(next.w, cols), h: next.h };
       })
     );
-  }, [mutate]);
+  }, [runLayoutOp, cols]);
 
   const toggleDataPoint = useCallback((id: string, key: string) => {
     mutate((b) =>
@@ -197,36 +283,43 @@ export function useBoard(): [TileConfig[], BoardActions] {
     const id = 't' + Date.now();
     const size = defaultSizes[type];
     mutate((b) => {
-      const bottom = b.reduce((m, t) => Math.max(m, t.y + t.h), 0);
-      return [
-        ...b,
-        {
-          id,
-          type,
-          x: 0,
-          y: bottom,
-          w: size.w,
-          h: size.h,
-          config: { ...defaultConfigs[type], ...extraConfig },
-          dataPoints: defaultDataPoints[type],
-        },
-      ];
+      const bottom = b.reduce((m, t) => {
+        const r = effectiveRect(t, bp);
+        return Math.max(m, r.y + r.h);
+      }, 0);
+      const w = Math.min(size.w, cols);
+      const newTile: TileConfig = {
+        id,
+        type,
+        x: 0,
+        y: bottom,
+        w,
+        h: size.h,
+        config: { ...defaultConfigs[type], ...extraConfig },
+        dataPoints: defaultDataPoints[type],
+      };
+      // For non-desktop, also seed the breakpoint layout so the tile
+      // doesn't render at its desktop coords on the active breakpoint.
+      if (bp !== 'desktop') {
+        newTile.layouts = { [bp]: { x: 0, y: bottom, w, h: size.h } };
+      }
+      return [...b, newTile];
     });
-  }, [mutate]);
+  }, [mutate, bp, cols]);
 
   const swapTiles = useCallback((srcId: string, tgtId: string) => {
     if (srcId === tgtId) return;
-    mutate((b) => {
-      const src = b.find((t) => t.id === srcId);
-      const tgt = b.find((t) => t.id === tgtId);
-      if (!src || !tgt) return b;
-      return b.map((t) => {
+    runLayoutOp((effective) => {
+      const src = effective.find((t) => t.id === srcId);
+      const tgt = effective.find((t) => t.id === tgtId);
+      if (!src || !tgt) return effective;
+      return effective.map((t) => {
         if (t.id === srcId) return { ...t, x: tgt.x, y: tgt.y, w: tgt.w, h: tgt.h };
         if (t.id === tgtId) return { ...t, x: src.x, y: src.y, w: src.w, h: src.h };
         return t;
       });
     });
-  }, [mutate]);
+  }, [runLayoutOp]);
 
   const resetBoard = useCallback(() => {
     mutate(() => DEFAULT_BOARD);
@@ -240,34 +333,46 @@ export function useBoard(): [TileConfig[], BoardActions] {
     mutate((b) => {
       const src = b.find((t) => t.id === id);
       if (!src) return b;
-      const bottom = b.reduce((m, t) => Math.max(m, t.y + t.h), 0);
+      const bottom = b.reduce((m, t) => {
+        const r = effectiveRect(t, bp);
+        return Math.max(m, r.y + r.h);
+      }, 0);
+      const w = Math.min(src.w, cols);
       const clone: TileConfig = {
         ...src,
         id: 't' + Date.now(),
         x: 0,
         y: bottom,
+        w,
         config: { ...src.config },
         dataPoints: [...src.dataPoints],
+        layouts: bp !== 'desktop' ? { [bp]: { x: 0, y: bottom, w, h: src.h } } : src.layouts,
       };
       return [...b, clone];
     });
-  }, [mutate]);
+  }, [mutate, bp, cols]);
 
   const moveTile = useCallback((id: string, x: number, y: number) => {
-    mutate((b) => layout.moveTile(b, id, x, y));
-  }, [mutate]);
+    runLayoutOp((effective, c) => layout.moveTile(effective, id, x, y, c));
+  }, [runLayoutOp]);
 
   const resizeTile = useCallback((id: string, w: number, h: number) => {
-    mutate((b) => layout.resizeTile(b, id, w, h));
-  }, [mutate]);
+    runLayoutOp((effective, c) => layout.resizeTile(effective, id, w, h, c));
+  }, [runLayoutOp]);
 
   const tidy = useCallback(() => {
     setHistory((h) => {
-      const { next, rowsSaved } = layout.tidy(h.present);
+      const effective = h.present.map((t) => asEffective(t, bp));
+      const { next, rowsSaved } = layout.tidy(effective, cols);
       setLastTidyDelta(rowsSaved);
-      return pushHistory(h, next);
+      const byId = new Map(next.map((t) => [t.id, { x: t.x, y: t.y, w: t.w, h: t.h }]));
+      const newRaw = h.present.map((t) => {
+        const rect = byId.get(t.id);
+        return rect ? writeRect(t, bp, rect) : t;
+      });
+      return pushHistory(h, newRaw);
     });
-  }, []);
+  }, [bp, cols]);
 
   const renameTile = useCallback((id: string, label: string | null) => {
     mutate((b) =>
@@ -305,6 +410,13 @@ export function useBoard(): [TileConfig[], BoardActions] {
     });
   }, []);
 
+  // The effective view that consumers render. Each tile's (x,y,w,h) is
+  // substituted with the active breakpoint's stored rect when present.
+  const effectiveBoard = useMemo(
+    () => history.present.map((t) => asEffective(t, bp)),
+    [history.present, bp],
+  );
+
   const actions: BoardActions = {
     updateTile,
     removeTile,
@@ -326,5 +438,5 @@ export function useBoard(): [TileConfig[], BoardActions] {
     canRedo: history.future.length > 0,
   };
 
-  return [history.present, actions];
+  return [effectiveBoard, actions];
 }

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 
 export type TileType =
   | 'stat'
@@ -24,6 +24,7 @@ export interface TileConfig {
 }
 
 const BOARD_STORAGE_KEY = 'outage-board-v3';
+const HISTORY_LIMIT = 50;
 
 const DEFAULT_BOARD: TileConfig[] = [
   { id: 't1', type: 'stat',          x: 0, y: 0, w: 1, h: 2, config: { metric: 'uptime' },     dataPoints: [] },
@@ -60,6 +61,19 @@ function writeBoard(board: TileConfig[]) {
   }
 }
 
+interface History {
+  past: TileConfig[][];
+  present: TileConfig[];
+  future: TileConfig[][];
+}
+
+function pushHistory(h: History, next: TileConfig[]): History {
+  if (next === h.present) return h;
+  const past = [...h.past, h.present];
+  if (past.length > HISTORY_LIMIT) past.shift();
+  return { past, present: next, future: [] };
+}
+
 export interface BoardActions {
   updateTile: (id: string, patch: Partial<TileConfig>) => void;
   removeTile: (id: string) => void;
@@ -68,23 +82,34 @@ export interface BoardActions {
   addTile: (type: TileType, extraConfig?: Record<string, unknown>) => void;
   swapTiles: (srcId: string, tgtId: string) => void;
   resetBoard: () => void;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
 }
 
 export function useBoard(): [TileConfig[], BoardActions] {
-  const [board, setBoard] = useState<TileConfig[]>(DEFAULT_BOARD);
+  const [history, setHistory] = useState<History>({ past: [], present: DEFAULT_BOARD, future: [] });
+  const hydrated = useRef(false);
 
   // Hydrate from localStorage after mount
   useEffect(() => {
-    setBoard(readBoard());
+    setHistory({ past: [], present: readBoard(), future: [] });
+    hydrated.current = true;
   }, []);
 
-  // Persist whenever board changes
+  // Persist whenever the present board changes (after hydration)
   useEffect(() => {
-    writeBoard(board);
-  }, [board]);
+    if (!hydrated.current) return;
+    writeBoard(history.present);
+  }, [history.present]);
+
+  const mutate = useCallback((producer: (b: TileConfig[]) => TileConfig[]) => {
+    setHistory((h) => pushHistory(h, producer(h.present)));
+  }, []);
 
   const updateTile = useCallback((id: string, patch: Partial<TileConfig>) => {
-    setBoard((b) =>
+    mutate((b) =>
       b.map((t) =>
         t.id === id
           ? {
@@ -95,14 +120,14 @@ export function useBoard(): [TileConfig[], BoardActions] {
           : t
       )
     );
-  }, []);
+  }, [mutate]);
 
   const removeTile = useCallback((id: string) => {
-    setBoard((b) => b.filter((t) => t.id !== id));
-  }, []);
+    mutate((b) => b.filter((t) => t.id !== id));
+  }, [mutate]);
 
   const cycleResize = useCallback((id: string) => {
-    setBoard((b) =>
+    mutate((b) =>
       b.map((t) => {
         if (t.id !== id) return t;
         const idx = TILE_SIZES.findIndex((s) => s.w === t.w && s.h === t.h);
@@ -110,10 +135,10 @@ export function useBoard(): [TileConfig[], BoardActions] {
         return { ...t, w: next.w, h: next.h };
       })
     );
-  }, []);
+  }, [mutate]);
 
   const toggleDataPoint = useCallback((id: string, key: string) => {
-    setBoard((b) =>
+    mutate((b) =>
       b.map((t) => {
         if (t.id !== id) return t;
         const has = t.dataPoints.includes(key);
@@ -123,7 +148,7 @@ export function useBoard(): [TileConfig[], BoardActions] {
         };
       })
     );
-  }, []);
+  }, [mutate]);
 
   const addTile = useCallback((type: TileType, extraConfig: Record<string, unknown> = {}) => {
     const defaultConfigs: Record<TileType, Record<string, unknown>> = {
@@ -158,7 +183,7 @@ export function useBoard(): [TileConfig[], BoardActions] {
     };
     const id = 't' + Date.now();
     const size = defaultSizes[type];
-    setBoard((b) => [
+    mutate((b) => [
       ...b,
       {
         id,
@@ -171,11 +196,11 @@ export function useBoard(): [TileConfig[], BoardActions] {
         dataPoints: defaultDataPoints[type],
       },
     ]);
-  }, []);
+  }, [mutate]);
 
   const swapTiles = useCallback((srcId: string, tgtId: string) => {
     if (srcId === tgtId) return;
-    setBoard((b) => {
+    mutate((b) => {
       const src = b.find((t) => t.id === srcId);
       const tgt = b.find((t) => t.id === tgtId);
       if (!src || !tgt) return b;
@@ -185,10 +210,34 @@ export function useBoard(): [TileConfig[], BoardActions] {
         return t;
       });
     });
-  }, []);
+  }, [mutate]);
 
   const resetBoard = useCallback(() => {
-    setBoard(DEFAULT_BOARD);
+    mutate(() => DEFAULT_BOARD);
+  }, [mutate]);
+
+  const undo = useCallback(() => {
+    setHistory((h) => {
+      if (h.past.length === 0) return h;
+      const previous = h.past[h.past.length - 1];
+      return {
+        past: h.past.slice(0, -1),
+        present: previous,
+        future: [h.present, ...h.future],
+      };
+    });
+  }, []);
+
+  const redo = useCallback(() => {
+    setHistory((h) => {
+      if (h.future.length === 0) return h;
+      const [next, ...rest] = h.future;
+      return {
+        past: [...h.past, h.present],
+        present: next,
+        future: rest,
+      };
+    });
   }, []);
 
   const actions: BoardActions = {
@@ -199,7 +248,11 @@ export function useBoard(): [TileConfig[], BoardActions] {
     addTile,
     swapTiles,
     resetBoard,
+    undo,
+    redo,
+    canUndo: history.past.length > 0,
+    canRedo: history.future.length > 0,
   };
 
-  return [board, actions];
+  return [history.present, actions];
 }

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -134,6 +134,9 @@ export interface BoardActions {
   renameTile: (id: string, label: string | null) => void;
   moveTile: (id: string, x: number, y: number) => void;
   resizeTile: (id: string, w: number, h: number) => void;
+  bulkMove: (ids: string[], dx: number, dy: number) => void;
+  bulkDelete: (ids: string[]) => void;
+  bulkDuplicate: (ids: string[]) => void;
   tidy: () => void;
   lastTidyDelta: number | null;
   undo: () => void;
@@ -370,6 +373,54 @@ export function useBoard({ bp = 'desktop', boardId, tiles, onCommit }: UseBoardP
     runLayoutOp((effective, c) => layout.resizeTile(effective, id, w, h, c));
   }, [runLayoutOp]);
 
+  const bulkMove = useCallback((ids: string[], dx: number, dy: number) => {
+    if (ids.length === 0 || (dx === 0 && dy === 0)) return;
+    runLayoutOp((effective, c) => {
+      let next = effective;
+      for (const id of ids) {
+        const t = next.find((x) => x.id === id);
+        if (!t) continue;
+        next = layout.moveTile(next, id, t.x + dx, t.y + dy, c);
+      }
+      return next;
+    });
+  }, [runLayoutOp]);
+
+  const bulkDelete = useCallback((ids: string[]) => {
+    if (ids.length === 0) return;
+    mutate((b) => b.filter((t) => !ids.includes(t.id)));
+  }, [mutate]);
+
+  const bulkDuplicate = useCallback((ids: string[]) => {
+    if (ids.length === 0) return;
+    mutate((b) => {
+      const bottomStart = b.reduce((m, t) => {
+        const r = effectiveRect(t, bp);
+        return Math.max(m, r.y + r.h);
+      }, 0);
+      const additions: TileConfig[] = [];
+      let yCursor = bottomStart;
+      ids.forEach((id, i) => {
+        const src = b.find((t) => t.id === id);
+        if (!src) return;
+        const w = Math.min(src.w, cols);
+        const clone: TileConfig = {
+          ...src,
+          id: 't' + Date.now() + '_' + i,
+          x: 0,
+          y: yCursor,
+          w,
+          config: { ...src.config },
+          dataPoints: [...src.dataPoints],
+          layouts: bp !== 'desktop' ? { [bp]: { x: 0, y: yCursor, w, h: src.h } } : src.layouts,
+        };
+        yCursor += src.h;
+        additions.push(clone);
+      });
+      return [...b, ...additions];
+    });
+  }, [mutate, bp, cols]);
+
   const tidy = useCallback(() => {
     setHistory((h) => {
       const effective = h.present.map((t) => asEffective(t, bp));
@@ -440,6 +491,9 @@ export function useBoard({ bp = 'desktop', boardId, tiles, onCommit }: UseBoardP
     renameTile,
     moveTile,
     resizeTile,
+    bulkMove,
+    bulkDelete,
+    bulkDuplicate,
     tidy,
     lastTidyDelta,
     undo,

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -88,6 +88,8 @@ export interface BoardActions {
   renameTile: (id: string, label: string | null) => void;
   moveTile: (id: string, x: number, y: number) => void;
   resizeTile: (id: string, w: number, h: number) => void;
+  tidy: () => void;
+  lastTidyDelta: number | null;
   undo: () => void;
   redo: () => void;
   canUndo: boolean;
@@ -96,6 +98,7 @@ export interface BoardActions {
 
 export function useBoard(): [TileConfig[], BoardActions] {
   const [history, setHistory] = useState<History>({ past: [], present: DEFAULT_BOARD, future: [] });
+  const [lastTidyDelta, setLastTidyDelta] = useState<number | null>(null);
   const hydrated = useRef(false);
 
   // Hydrate from localStorage after mount. Compact once on load so any
@@ -258,6 +261,14 @@ export function useBoard(): [TileConfig[], BoardActions] {
     mutate((b) => layout.resizeTile(b, id, w, h));
   }, [mutate]);
 
+  const tidy = useCallback(() => {
+    setHistory((h) => {
+      const { next, rowsSaved } = layout.tidy(h.present);
+      setLastTidyDelta(rowsSaved);
+      return pushHistory(h, next);
+    });
+  }, []);
+
   const renameTile = useCallback((id: string, label: string | null) => {
     mutate((b) =>
       b.map((t) => {
@@ -307,6 +318,8 @@ export function useBoard(): [TileConfig[], BoardActions] {
     renameTile,
     moveTile,
     resizeTile,
+    tidy,
+    lastTidyDelta,
     undo,
     redo,
     canUndo: history.past.length > 0,

--- a/src/hooks/useBoardSet.ts
+++ b/src/hooks/useBoardSet.ts
@@ -1,0 +1,181 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { TileConfig } from './useBoard';
+
+export interface BoardEntry {
+  id: string;
+  name: string;
+  starred?: boolean;
+  tiles: TileConfig[];
+}
+
+export interface BoardSet {
+  active: string;
+  boards: BoardEntry[];
+}
+
+const SET_KEY = 'outage-boards-v4';
+const LEGACY_KEY = 'outage-board-v3';
+
+const DEFAULT_TILES: TileConfig[] = [
+  { id: 't1', type: 'stat',          x: 0, y: 0, w: 1, h: 2, config: { metric: 'uptime' },     dataPoints: [] },
+  { id: 't2', type: 'stat',          x: 1, y: 0, w: 1, h: 2, config: { metric: 'incidents' },   dataPoints: [] },
+  { id: 't3', type: 'stat',          x: 2, y: 0, w: 1, h: 2, config: { metric: 'mttr' },        dataPoints: [] },
+  { id: 't4', type: 'stat',          x: 3, y: 0, w: 1, h: 2, config: { metric: 'dd' },          dataPoints: [] },
+  { id: 't5', type: 'service-watch', x: 0, y: 1, w: 2, h: 2, config: { service: 'slack' },      dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 't6', type: 'service-watch', x: 2, y: 1, w: 2, h: 2, config: { service: 'github' },     dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 't7', type: 'incident-feed', x: 4, y: 0, w: 2, h: 3, config: {},                        dataPoints: [] },
+  { id: 't8', type: 'service-grid',  x: 0, y: 3, w: 4, h: 2, config: {},                        dataPoints: [] },
+  { id: 't9', type: 'status-map',    x: 4, y: 3, w: 2, h: 2, config: {},                        dataPoints: [] },
+];
+
+function defaultSet(): BoardSet {
+  return {
+    active: 'main',
+    boards: [{ id: 'main', name: 'My board', starred: true, tiles: DEFAULT_TILES }],
+  };
+}
+
+function readBoardSet(): BoardSet {
+  if (typeof window === 'undefined') return defaultSet();
+  // Preferred: v4.
+  try {
+    const raw = localStorage.getItem(SET_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as BoardSet;
+      if (parsed && Array.isArray(parsed.boards) && parsed.boards.length > 0) {
+        return parsed;
+      }
+    }
+  } catch {
+    // ignore
+  }
+  // Migrate v3 → v4 (one-shot).
+  try {
+    const legacy = localStorage.getItem(LEGACY_KEY);
+    if (legacy) {
+      const tiles = JSON.parse(legacy) as TileConfig[];
+      const set: BoardSet = {
+        active: 'main',
+        boards: [{ id: 'main', name: 'My board', starred: true, tiles }],
+      };
+      try { localStorage.setItem(SET_KEY, JSON.stringify(set)); } catch { /* ignore */ }
+      try { localStorage.removeItem(LEGACY_KEY); } catch { /* ignore */ }
+      return set;
+    }
+  } catch {
+    // ignore
+  }
+  return defaultSet();
+}
+
+function writeBoardSet(set: BoardSet) {
+  try { localStorage.setItem(SET_KEY, JSON.stringify(set)); } catch { /* ignore */ }
+}
+
+export interface UseBoardSet {
+  boards: BoardEntry[];
+  activeId: string;
+  active: BoardEntry;
+  hydrated: boolean;
+  setActive: (id: string) => void;
+  setActiveTiles: (tiles: TileConfig[]) => void;
+  addBoard: (name: string, tiles?: TileConfig[]) => string;
+  renameBoard: (id: string, name: string) => void;
+  deleteBoard: (id: string) => void;
+  duplicateBoard: (id: string) => void;
+  starBoard: (id: string) => void;
+}
+
+export function useBoardSet(): UseBoardSet {
+  const [state, setState] = useState<BoardSet>(defaultSet);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    const stored = readBoardSet();
+    const starred = stored.boards.find((b) => b.starred);
+    if (starred && stored.active !== starred.id) stored.active = starred.id;
+    setState(stored);
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    writeBoardSet(state);
+  }, [state, hydrated]);
+
+  const active = state.boards.find((b) => b.id === state.active) ?? state.boards[0];
+
+  const setActive = useCallback((id: string) => {
+    setState((s) => (s.boards.some((b) => b.id === id) ? { ...s, active: id } : s));
+  }, []);
+
+  const setActiveTiles = useCallback((tiles: TileConfig[]) => {
+    setState((s) => ({
+      ...s,
+      boards: s.boards.map((b) => (b.id === s.active ? { ...b, tiles } : b)),
+    }));
+  }, []);
+
+  const addBoard = useCallback((name: string, tiles: TileConfig[] = []): string => {
+    const id = 'b' + Date.now();
+    setState((s) => ({
+      ...s,
+      boards: [...s.boards, { id, name, tiles }],
+      active: id,
+    }));
+    return id;
+  }, []);
+
+  const renameBoard = useCallback((id: string, name: string) => {
+    setState((s) => ({
+      ...s,
+      boards: s.boards.map((b) => (b.id === id ? { ...b, name } : b)),
+    }));
+  }, []);
+
+  const deleteBoard = useCallback((id: string) => {
+    setState((s) => {
+      if (s.boards.length <= 1) return s;
+      const next = s.boards.filter((b) => b.id !== id);
+      const active = s.active === id ? next[0].id : s.active;
+      return { ...s, boards: next, active };
+    });
+  }, []);
+
+  const duplicateBoard = useCallback((id: string) => {
+    setState((s) => {
+      const src = s.boards.find((b) => b.id === id);
+      if (!src) return s;
+      const newId = 'b' + Date.now();
+      const clone: BoardEntry = {
+        id: newId,
+        name: src.name + ' copy',
+        tiles: JSON.parse(JSON.stringify(src.tiles)),
+      };
+      return { ...s, boards: [...s.boards, clone], active: newId };
+    });
+  }, []);
+
+  const starBoard = useCallback((id: string) => {
+    setState((s) => ({
+      ...s,
+      boards: s.boards.map((b) => ({ ...b, starred: b.id === id })),
+    }));
+  }, []);
+
+  return {
+    boards: state.boards,
+    activeId: state.active,
+    active,
+    hydrated,
+    setActive,
+    setActiveTiles,
+    addBoard,
+    renameBoard,
+    deleteBoard,
+    duplicateBoard,
+    starBoard,
+  };
+}

--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type Breakpoint = 'mobile' | 'tablet' | 'desktop';
+
+export const COLS_FOR: Record<Breakpoint, number> = {
+  mobile: 1,
+  tablet: 3,
+  desktop: 6,
+};
+
+function read(): Breakpoint {
+  if (typeof window === 'undefined') return 'desktop';
+  if (window.matchMedia('(max-width: 640px)').matches) return 'mobile';
+  if (window.matchMedia('(max-width: 1024px)').matches) return 'tablet';
+  return 'desktop';
+}
+
+export function useBreakpoint(): Breakpoint {
+  const [bp, setBp] = useState<Breakpoint>('desktop');
+
+  useEffect(() => {
+    setBp(read());
+    const mqMobile = window.matchMedia('(max-width: 640px)');
+    const mqTablet = window.matchMedia('(max-width: 1024px)');
+    const update = () => setBp(read());
+    mqMobile.addEventListener('change', update);
+    mqTablet.addEventListener('change', update);
+    return () => {
+      mqMobile.removeEventListener('change', update);
+      mqTablet.removeEventListener('change', update);
+    };
+  }, []);
+
+  return bp;
+}

--- a/src/hooks/usePresentMode.ts
+++ b/src/hooks/usePresentMode.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface PresentMode {
+  present: boolean;
+  rotateMs: number | null;
+}
+
+function readSearchParams(): PresentMode {
+  if (typeof window === 'undefined') return { present: false, rotateMs: null };
+  const params = new URLSearchParams(window.location.search);
+  const present = params.get('present') === '1';
+  if (!present) return { present: false, rotateMs: null };
+  const rotate = Number(params.get('rotate'));
+  const rotateMs = Number.isFinite(rotate) && rotate > 0 ? rotate * 1000 : null;
+  return { present: true, rotateMs };
+}
+
+export function usePresentMode(): PresentMode {
+  const [mode, setMode] = useState<PresentMode>({ present: false, rotateMs: null });
+
+  useEffect(() => {
+    setMode(readSearchParams());
+    const onPop = () => setMode(readSearchParams());
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, []);
+
+  return mode;
+}
+
+export function enterPresent() {
+  if (typeof window === 'undefined') return;
+  const params = new URLSearchParams(window.location.search);
+  params.set('present', '1');
+  window.history.pushState({}, '', `${window.location.pathname}?${params}`);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+export function exitPresent() {
+  if (typeof window === 'undefined') return;
+  const params = new URLSearchParams(window.location.search);
+  params.delete('present');
+  params.delete('rotate');
+  const qs = params.toString();
+  window.history.pushState({}, '', qs ? `${window.location.pathname}?${qs}` : window.location.pathname);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export type ShortcutMap = Record<string, (e: KeyboardEvent) => void>;
+
+interface Options {
+  enabled?: boolean;
+}
+
+function normalize(e: KeyboardEvent): string {
+  const parts: string[] = [];
+  if (e.metaKey || e.ctrlKey) parts.push('mod');
+  if (e.shiftKey) parts.push('shift');
+  if (e.altKey) parts.push('alt');
+  let key = e.key;
+  if (key.length === 1) key = key.toLowerCase();
+  parts.push(key);
+  return parts.join('+');
+}
+
+function inEditable(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false;
+  if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT') return true;
+  return target.isContentEditable;
+}
+
+export function useShortcuts(map: ShortcutMap, { enabled = true }: Options = {}) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      const combo = normalize(e);
+      // Always allow Escape, even inside inputs.
+      if (combo !== 'Escape' && inEditable(e.target)) return;
+      const fn = map[combo];
+      if (fn) {
+        e.preventDefault();
+        fn(e);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [map, enabled]);
+}

--- a/src/hooks/useTweaks.ts
+++ b/src/hooks/useTweaks.ts
@@ -7,7 +7,11 @@ export interface Tweaks {
   density: 'compact' | 'comfortable';
   showGridLines: boolean;
   tileRadius: number;
+  /** Most-recent first, capped at 8. Front-padding/dedupe handled by setTweak. */
+  accentRecents?: string[];
 }
+
+const RECENTS_LIMIT = 8;
 
 const TWEAKS_STORAGE_KEY = 'outage-board-tweaks';
 
@@ -61,7 +65,14 @@ export function useTweaks(): [Tweaks, TweaksApi] {
   }, [tweaks]);
 
   const setTweak = useCallback((key: keyof Tweaks, value: unknown) => {
-    setTweaksState((prev) => ({ ...prev, [key]: value }));
+    setTweaksState((prev) => {
+      if (key === 'accent' && typeof value === 'string') {
+        const recents = [value, ...(prev.accentRecents ?? []).filter((c) => c !== value)]
+          .slice(0, RECENTS_LIMIT);
+        return { ...prev, accent: value, accentRecents: recents };
+      }
+      return { ...prev, [key]: value };
+    });
   }, []);
 
   const setTweaks = useCallback((next: Tweaks) => {

--- a/src/hooks/useTweaks.ts
+++ b/src/hooks/useTweaks.ts
@@ -37,12 +37,17 @@ function applyTweaks(t: Tweaks) {
   root.dataset.gridLines = t.showGridLines ? 'on' : 'off';
 }
 
-export function useTweaks(): [Tweaks, (key: keyof Tweaks, value: unknown) => void] {
-  const [tweaks, setTweaks] = useState<Tweaks>(DEFAULT_TWEAKS);
+export interface TweaksApi {
+  setTweak: (key: keyof Tweaks, value: unknown) => void;
+  setTweaks: (next: Tweaks) => void;
+}
+
+export function useTweaks(): [Tweaks, TweaksApi] {
+  const [tweaks, setTweaksState] = useState<Tweaks>(DEFAULT_TWEAKS);
 
   useEffect(() => {
     const stored = readTweaks();
-    setTweaks(stored);
+    setTweaksState(stored);
     applyTweaks(stored);
   }, []);
 
@@ -56,8 +61,12 @@ export function useTweaks(): [Tweaks, (key: keyof Tweaks, value: unknown) => voi
   }, [tweaks]);
 
   const setTweak = useCallback((key: keyof Tweaks, value: unknown) => {
-    setTweaks((prev) => ({ ...prev, [key]: value }));
+    setTweaksState((prev) => ({ ...prev, [key]: value }));
   }, []);
 
-  return [tweaks, setTweak];
+  const setTweaks = useCallback((next: Tweaks) => {
+    setTweaksState({ ...DEFAULT_TWEAKS, ...next });
+  }, []);
+
+  return [tweaks, { setTweak, setTweaks }];
 }

--- a/src/lib/board/io.ts
+++ b/src/lib/board/io.ts
@@ -1,0 +1,63 @@
+import type { TileConfig, TileType } from '@/hooks/useBoard';
+import type { Tweaks } from '@/hooks/useTweaks';
+
+export interface BoardFile {
+  version: 1;
+  exportedAt: string;
+  board: TileConfig[];
+  tweaks?: Tweaks;
+}
+
+const TILE_TYPES: TileType[] = [
+  'stat', 'service-watch', 'service-grid', 'incident-feed',
+  'rss', 'uptime-chart', 'status-map', 'statuspage',
+];
+
+export function serializeBoard(input: { board: TileConfig[]; tweaks?: Tweaks }): string {
+  const payload: BoardFile = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    board: input.board,
+    tweaks: input.tweaks,
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+function isTile(value: unknown): value is TileConfig {
+  if (!value || typeof value !== 'object') return false;
+  const t = value as Record<string, unknown>;
+  return (
+    typeof t.id === 'string' &&
+    typeof t.type === 'string' &&
+    TILE_TYPES.includes(t.type as TileType) &&
+    typeof t.x === 'number' &&
+    typeof t.y === 'number' &&
+    typeof t.w === 'number' &&
+    typeof t.h === 'number' &&
+    typeof t.config === 'object' && t.config !== null &&
+    Array.isArray(t.dataPoints)
+  );
+}
+
+function isTweaks(value: unknown): value is Tweaks {
+  if (!value || typeof value !== 'object') return false;
+  const t = value as Record<string, unknown>;
+  return (
+    typeof t.accent === 'string' &&
+    (t.density === 'compact' || t.density === 'comfortable') &&
+    typeof t.showGridLines === 'boolean' &&
+    typeof t.tileRadius === 'number'
+  );
+}
+
+export function parseBoardFile(raw: string): { board: TileConfig[]; tweaks?: Tweaks } | null {
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { return null; }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const p = parsed as Record<string, unknown>;
+  const boardCandidate = p.board ?? parsed; // tolerate bare array too
+  if (!Array.isArray(boardCandidate)) return null;
+  if (!boardCandidate.every(isTile)) return null;
+  const tweaks = isTweaks(p.tweaks) ? p.tweaks : undefined;
+  return { board: boardCandidate, tweaks };
+}

--- a/src/lib/board/layout.ts
+++ b/src/lib/board/layout.ts
@@ -1,0 +1,152 @@
+import type { TileConfig } from '@/hooks/useBoard';
+
+export interface BoxRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export const DEFAULT_COLS = 6;
+
+export function tilesOverlap(a: BoxRect, b: BoxRect): boolean {
+  return !(
+    a.x + a.w <= b.x ||
+    b.x + b.w <= a.x ||
+    a.y + a.h <= b.y ||
+    b.y + b.h <= a.y
+  );
+}
+
+export function findCollisions(board: TileConfig[], candidate: TileConfig): TileConfig[] {
+  return board.filter((t) => t.id !== candidate.id && tilesOverlap(t, candidate));
+}
+
+export function clampToGrid<T extends BoxRect>(t: T, cols = DEFAULT_COLS): T {
+  const w = Math.max(1, Math.min(cols, t.w));
+  const x = Math.max(0, Math.min(cols - w, t.x));
+  const y = Math.max(0, t.y);
+  const h = Math.max(1, t.h);
+  return { ...t, x, y, w, h };
+}
+
+/**
+ * Push `target` down past any collisions in `board`, then push any tiles
+ * that still overlap further down. Stable: tiles that don't collide stay
+ * put. Used as the post-drop reflow.
+ */
+export function resolveCollisions(board: TileConfig[], targetId: string): TileConfig[] {
+  const out = board.map((t) => ({ ...t }));
+  let changed = true;
+  let guard = 0;
+  while (changed && guard++ < 200) {
+    changed = false;
+    for (let i = 0; i < out.length; i++) {
+      const a = out[i];
+      for (let j = 0; j < out.length; j++) {
+        if (i === j) continue;
+        const b = out[j];
+        if (!tilesOverlap(a, b)) continue;
+        // Move whichever tile is the "later" one down (target wins ties).
+        const moveB = b.id !== targetId;
+        if (moveB) {
+          b.y = a.y + a.h;
+        } else {
+          a.y = b.y + b.h;
+        }
+        changed = true;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Top-down compaction: each tile (in y-then-x order) slides up as far as
+ * it can without colliding. Mirrors react-grid-layout's "vertical
+ * compact" behaviour.
+ */
+export function compactDown(board: TileConfig[]): TileConfig[] {
+  const sorted = [...board].sort((a, b) => a.y - b.y || a.x - b.x);
+  const placed: TileConfig[] = [];
+  for (const tile of sorted) {
+    let y = 0;
+    // Slide up until it collides with a placed tile.
+    while (placed.some((p) => tilesOverlap(p, { ...tile, y }))) {
+      y++;
+    }
+    placed.push({ ...tile, y });
+  }
+  return placed;
+}
+
+/**
+ * Move tile `id` to (x, y); push any colliding tiles down so nothing
+ * overlaps. Returns the new board (same length, same ids).
+ */
+export function moveTile(
+  board: TileConfig[],
+  id: string,
+  x: number,
+  y: number,
+  cols = DEFAULT_COLS,
+): TileConfig[] {
+  const target = board.find((t) => t.id === id);
+  if (!target) return board;
+  const moved = clampToGrid({ ...target, x, y }, cols);
+  const next = board.map((t) => (t.id === id ? moved : t));
+  return resolveCollisions(next, id);
+}
+
+/**
+ * Resize tile `id` to (w, h); push any colliding tiles down so nothing
+ * overlaps.
+ */
+export function resizeTile(
+  board: TileConfig[],
+  id: string,
+  w: number,
+  h: number,
+  cols = DEFAULT_COLS,
+): TileConfig[] {
+  const target = board.find((t) => t.id === id);
+  if (!target) return board;
+  const resized = clampToGrid({ ...target, w, h }, cols);
+  const next = board.map((t) => (t.id === id ? resized : t));
+  return resolveCollisions(next, id);
+}
+
+/**
+ * "Tidy" the board: compact down, then left-justify each tile into the
+ * first available column. Returns the new board and the number of rows
+ * saved compared to the input.
+ */
+export function tidy(board: TileConfig[], cols = DEFAULT_COLS): { next: TileConfig[]; rowsSaved: number } {
+  const beforeRows = board.reduce((m, t) => Math.max(m, t.y + t.h), 0);
+
+  // First pass: vertical compaction.
+  const compacted = compactDown(board);
+
+  // Second pass: row-by-row left-justify.
+  const sorted = [...compacted].sort((a, b) => a.y - b.y || a.x - b.x);
+  const placed: TileConfig[] = [];
+  for (const tile of sorted) {
+    let bestX = tile.x;
+    let bestY = tile.y;
+    // Try each column at every row from 0 up.
+    outer: for (let y = 0; y <= bestY; y++) {
+      for (let x = 0; x <= cols - tile.w; x++) {
+        const candidate = { ...tile, x, y };
+        if (!placed.some((p) => tilesOverlap(p, candidate))) {
+          bestX = x;
+          bestY = y;
+          break outer;
+        }
+      }
+    }
+    placed.push({ ...tile, x: bestX, y: bestY });
+  }
+
+  const afterRows = placed.reduce((m, t) => Math.max(m, t.y + t.h), 0);
+  return { next: placed, rowsSaved: Math.max(0, beforeRows - afterRows) };
+}

--- a/src/lib/board/templates/index.ts
+++ b/src/lib/board/templates/index.ts
@@ -1,0 +1,113 @@
+import type { TileConfig } from '@/hooks/useBoard';
+import { DEFAULT_BOARD } from '@/hooks/useBoard';
+
+export interface Template {
+  id: string;
+  name: string;
+  description: string;
+  tiles: TileConfig[];
+}
+
+const M365_TILES: TileConfig[] = [
+  { id: 'tpl-m365-1', type: 'stat',          x: 0, y: 0, w: 2, h: 2, config: { metric: 'uptime' },     dataPoints: [] },
+  { id: 'tpl-m365-2', type: 'stat',          x: 2, y: 0, w: 2, h: 2, config: { metric: 'incidents' },  dataPoints: [] },
+  { id: 'tpl-m365-3', type: 'incident-feed', x: 4, y: 0, w: 2, h: 4, config: {},                       dataPoints: [] },
+  { id: 'tpl-m365-4', type: 'service-watch', x: 0, y: 2, w: 2, h: 2, config: { service: 'office365' },  dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 'tpl-m365-5', type: 'service-watch', x: 2, y: 2, w: 2, h: 2, config: { service: 'azure' },      dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 'tpl-m365-6', type: 'uptime-chart',  x: 0, y: 4, w: 3, h: 2, config: { service: 'office365' }, dataPoints: [] },
+  { id: 'tpl-m365-7', type: 'uptime-chart',  x: 3, y: 4, w: 3, h: 2, config: { service: 'azure' },     dataPoints: [] },
+];
+
+const IDENTITY_TILES: TileConfig[] = [
+  { id: 'tpl-id-1', type: 'service-watch', x: 0, y: 0, w: 3, h: 3, config: { service: 'okta' },     dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 'tpl-id-2', type: 'service-watch', x: 3, y: 0, w: 3, h: 3, config: { service: 'auth0' },    dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 'tpl-id-3', type: 'incident-feed', x: 0, y: 3, w: 4, h: 3, config: {},                      dataPoints: [] },
+  { id: 'tpl-id-4', type: 'stat',          x: 4, y: 3, w: 2, h: 2, config: { metric: 'mttr' },      dataPoints: [] },
+  { id: 'tpl-id-5', type: 'stat',          x: 4, y: 5, w: 2, h: 1, config: { metric: 'dd' },        dataPoints: [] },
+];
+
+const CLOUD_TILES: TileConfig[] = [
+  { id: 'tpl-cl-1', type: 'service-watch', x: 0, y: 0, w: 2, h: 2, config: { service: 'aws' },   dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 'tpl-cl-2', type: 'service-watch', x: 2, y: 0, w: 2, h: 2, config: { service: 'gcp' },   dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 'tpl-cl-3', type: 'service-watch', x: 4, y: 0, w: 2, h: 2, config: { service: 'azure' }, dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 'tpl-cl-4', type: 'status-map',    x: 0, y: 2, w: 4, h: 3, config: {},                   dataPoints: [] },
+  { id: 'tpl-cl-5', type: 'incident-feed', x: 4, y: 2, w: 2, h: 3, config: {},                   dataPoints: [] },
+  { id: 'tpl-cl-6', type: 'service-grid',  x: 0, y: 5, w: 6, h: 2, config: {},                   dataPoints: [] },
+];
+
+const DEV_TILES: TileConfig[] = [
+  { id: 'tpl-dv-1', type: 'service-watch', x: 0, y: 0, w: 2, h: 2, config: { service: 'github' },  dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 'tpl-dv-2', type: 'service-watch', x: 2, y: 0, w: 2, h: 2, config: { service: 'npm' },     dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 'tpl-dv-3', type: 'service-watch', x: 4, y: 0, w: 2, h: 2, config: { service: 'docker' },  dataPoints: ['sparkline', 'uptime', 'official', 'downdetector'] },
+  { id: 'tpl-dv-4', type: 'rss',           x: 0, y: 2, w: 3, h: 3, config: { feed: 'aws-blog' },   dataPoints: [] },
+  { id: 'tpl-dv-5', type: 'rss',           x: 3, y: 2, w: 3, h: 3, config: { feed: 'gh-blog' },    dataPoints: [] },
+  { id: 'tpl-dv-6', type: 'incident-feed', x: 0, y: 5, w: 6, h: 2, config: {},                     dataPoints: [] },
+];
+
+export const BUILTIN_TEMPLATES: Template[] = [
+  {
+    id: 'default',
+    name: 'Default',
+    description: 'Mix of stats, two service watches, incident feed, and a heat map.',
+    tiles: DEFAULT_BOARD,
+  },
+  {
+    id: 'm365',
+    name: 'Microsoft 365 focus',
+    description: 'Office 365 + Azure side-by-side with uptime charts.',
+    tiles: M365_TILES,
+  },
+  {
+    id: 'identity',
+    name: 'Identity & SSO',
+    description: 'Okta and Auth0 watches with incident feed.',
+    tiles: IDENTITY_TILES,
+  },
+  {
+    id: 'cloud',
+    name: 'Cloud infra',
+    description: 'AWS, GCP, Azure + heat map and service grid.',
+    tiles: CLOUD_TILES,
+  },
+  {
+    id: 'dev-tools',
+    name: 'Developer tooling',
+    description: 'GitHub, npm, Docker plus engineering RSS feeds.',
+    tiles: DEV_TILES,
+  },
+];
+
+const USER_TEMPLATES_KEY = 'outage-board-user-templates';
+
+export function readUserTemplates(): Template[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(USER_TEMPLATES_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as Template[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((t) => typeof t.id === 'string' && Array.isArray(t.tiles));
+  } catch {
+    return [];
+  }
+}
+
+export function writeUserTemplates(templates: Template[]) {
+  try { localStorage.setItem(USER_TEMPLATES_KEY, JSON.stringify(templates)); } catch { /* ignore */ }
+}
+
+export function saveUserTemplate(name: string, tiles: TileConfig[]): Template {
+  const tpl: Template = {
+    id: 'user-' + Date.now(),
+    name,
+    description: 'Saved from your current board',
+    tiles: JSON.parse(JSON.stringify(tiles)),
+  };
+  const all = [...readUserTemplates(), tpl];
+  writeUserTemplates(all);
+  return tpl;
+}
+
+export function deleteUserTemplate(id: string) {
+  writeUserTemplates(readUserTemplates().filter((t) => t.id !== id));
+}


### PR DESCRIPTION
Implements Waves 1 and 2 of `DASHBOARD_CUSTOMIZATION_PLAN.md` — eight discrete commits, each one item from the plan, so any single change can be reverted without unwinding the others.

## Commits

### Wave 1 — Quality of life

1. **Undo/redo** — `useBoard` wraps state in a 50-entry history stack; toolbar buttons plus `Ctrl/Cmd+Z` and `Ctrl/Cmd+Shift+Z` (or `Ctrl/Cmd+Y`), ignored inside text fields.
2. **Export / import** — Backup section in the Tweaks panel: Export downloads `outage-board.json` (board + tweaks); Import accepts a file or a JSON paste, validated by a shape guard in `src/lib/board/io.ts`.
3. **Keyboard shortcuts + `?` cheat-sheet** — `E`/`A`/`I`/`T` toggle edit/add/import/tweaks; `?` opens a centered overlay listing global, history, and edit-mode shortcuts; `Esc` closes overlays. Shared via `useShortcuts`.
4. **Duplicate + rename tile** — `duplicateTile` clones a tile at the bottom; double-clicking the title in edit mode swaps it for an input (Enter commits to `config.label`, Esc/blur with no change cancels).

### Wave 2 — Layout engine

5. **Layout module + free drag-to-position** — New `src/lib/board/layout.ts` (pure, unit-testable): `tilesOverlap`, `findCollisions`, `clampToGrid`, `resolveCollisions`, `compactDown`, `moveTile`, `resizeTile`, `tidy`. `TileGrid` now applies explicit `gridColumnStart`/`gridRowStart` and computes the drop cell from the grid's bounding rect; dropping pushes overlapping neighbours down, `Shift+drop` keeps the original pure-swap behaviour. Hydration runs `compactDown` once so old auto-flow saves collapse cleanly.
6. **Freeform resize handles** — Bottom-right handle on every tile in edit mode; drag snaps to cells, right-click cycles the preset sizes for muscle memory, Esc aborts.
7. **Tidy button** — Toolbar button (edit mode only) runs the bin-pack pass; tooltip reports rows saved on the last run.
8. **Responsive breakpoint layouts** — `TileConfig.layouts?.{mobile,tablet,desktop}` stores per-breakpoint `BoxRect`s additively (no migration). `useBoard(bp)` exposes the effective view and routes move/resize/tidy through the active breakpoint's slot. On first switch into mobile/tablet, layouts auto-generate (mobile = single-column stack; tablet = clamped + tidied).

## Test plan

- [ ] Edit a tile, click Undo / Redo in the toolbar — also via `Ctrl/Cmd+Z` and `Ctrl/Cmd+Shift+Z`.
- [ ] Open Tweaks → Backup, click Export, wipe `localStorage`, click Import → board restores.
- [ ] Press `?` → cheat-sheet appears; each shortcut behaves as advertised; `Esc` closes overlays.
- [ ] Duplicate a tile from the chrome menu; double-click a tile title in edit mode and rename it.
- [ ] In edit mode, drag a tile to an empty cell — neighbours reflow down; hold `Shift` while dropping → pure swap.
- [ ] Drag a bottom-right resize handle to resize; right-click the handle to cycle preset sizes.
- [ ] Delete a tile, click "Tidy" → gaps close, tooltip updates.
- [ ] Resize browser to phone width → board stacks vertically (1 column); resize to tablet width → 3 columns; back to desktop → original layout intact.
- [ ] `npm run lint` clean, `npm run build` succeeds.

https://claude.ai/code/session_01MYXoXuq7fUGhwHLv8jG1bB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYXoXuq7fUGhwHLv8jG1bB)_