### PR TITLE
Design platform improvements plan

### DIFF
--- a/PLATFORM_IMPROVEMENTS.md
+++ b/PLATFORM_IMPROVEMENTS.md
@@ -1,0 +1,345 @@
+# Platform Improvements
+
+Operability, reliability, and integration upgrades for Outage-Map. Scope is
+intentionally distinct from the other two plans:
+
+- `ROADMAP.md` covers product features (alerting, SLA reports, anomaly,
+  postmortem, auth, dependency graph).
+- `DASHBOARD_CUSTOMIZATION_PLAN.md` covers board / tile / theme UX.
+- This doc covers everything else — how the tool behaves when something goes
+  wrong, how it talks to the outside world, and how an operator runs it day
+  to day.
+
+Each item lists the files it would touch so work can start without another
+discovery pass.
+
+## Gaps Identified
+
+- No internal metrics — when a fetcher silently breaks (Downdetector DOM
+  drift, Statuspage incident schema change), the only signal is "0 reports
+  for every service this cycle" buried in stdout (`poller.ts:188`).
+- A flaky upstream is retried on every 3-minute cycle with no circuit
+  breaker, no exponential backoff, and a hard 15 s timeout per request.
+- `/api/health` is liveness-only; there's no readiness probe and no
+  per-fetcher health surface.
+- Client refresh is 30 s SWR polling. New incidents wait up to 30 s on the
+  client even after the poller has stored them.
+- Schema changes are hand-rolled `ALTER TABLE` calls in `db.ts:99-102`. No
+  forward/backward versioning, no rollback story.
+- No backup story for the SQLite volume. A corrupted file silently loses
+  35 days of history.
+- Downdetector parsing uses CSS-class heuristics with no schema check —
+  when the page changes, we get `unknown` for every service and no alert
+  fires.
+- Webhooks (once #2 in `ROADMAP.md` lands) will be unsigned — any receiver
+  has to trust the source IP.
+- PagerDuty / Opsgenie / VictorOps users today have to glue the generic
+  webhook to their incident schema by hand.
+- No i18n; all strings are inline English. No timezone selection — server
+  TZ leaks into every timestamp.
+- Public consumers (status badges, calendar feeds) have no surface to
+  embed Outage-Map data outside the dashboard.
+
+---
+
+## Wave 1 — Make failure visible
+
+### 1. Prometheus `/metrics` endpoint
+Counts and histograms that let an operator see whether the tool itself is
+healthy, separate from whether the *monitored* services are healthy.
+- New route `src/app/api/metrics/route.ts` exposing text-format metrics
+  (no extra dep needed — emit by hand, the surface is small).
+- Counters: `outage_poll_cycles_total{result}`,
+  `outage_fetcher_failures_total{service,source}`,
+  `outage_alerts_sent_total{channel,severity}`.
+- Histograms: `outage_fetcher_latency_seconds{service,source}`,
+  `outage_poll_cycle_duration_seconds`.
+- Gauges: `outage_service_status{service,source}` (0=operational,
+  1=degraded, 2=major, 3=unknown), `outage_last_poll_age_seconds`.
+- Wire in `src/lib/metrics.ts` (a thin in-memory registry). Increment from
+  `poller.ts`, each `fetchers/*.ts`, and the notifier paths.
+
+### 2. Per-fetcher health surface + readiness probe
+Today a single broken fetcher is hidden by the success of the other 13.
+- Track last success / last error / last latency per `(service, source)`
+  in `service_health` (in-memory; rebuilt each restart). Persist via a
+  new table only if history matters (defer).
+- `/api/health` becomes `?probe=live|ready` — `live` keeps current
+  behavior, `ready` returns 503 if any source has been failing > N
+  cycles (configurable via `READY_FAILURE_THRESHOLD`, default 5).
+- New `/api/health/fetchers` returns the same data as JSON for
+  dashboards.
+- Surface in `src/components/SourcesView.tsx`: per-source status pill,
+  last error message, click for full stack.
+- Touches: `poller.ts`, new `src/lib/health.ts`, `health/route.ts`,
+  `SourcesView.tsx`.
+
+### 3. Structured logging with levels
+`console.log` / `console.error` + a `DEBUG=true` env flag is the current
+log strategy. Hard to filter, hard to ship anywhere.
+- Add `pino` (small, fast, JSON by default). New
+  `src/lib/logger.ts` exporting `logger` and child loggers per module.
+- Levels: `trace` (per-request), `debug` (current `DEBUG=true` output),
+  `info`, `warn`, `error`. Default `info`, configurable via
+  `LOG_LEVEL`.
+- Replace every `console.*` in `src/lib/` (15-ish call sites). Pretty
+  print only when `NODE_ENV !== production`.
+- Adds `pino-pretty` to devDependencies.
+
+### 4. Schema validation per fetcher
+A silent DOM / JSON change in an upstream breaks us with no diagnostic.
+- Add `zod` parses inside each `src/lib/fetchers/*.ts`. Statuspage and
+  Salesforce return JSON — easy. Downdetector / Workday parse HTML —
+  validate the *extracted* shape (`{ reportCount: number, status:
+  ServiceStatus }`) before returning.
+- On parse failure: bump `outage_fetcher_failures_total{reason=schema}`,
+  log at `warn` with a truncated payload sample, return `unknown`.
+- Touches: every `fetchers/*.ts`, `package.json` (`zod`).
+
+---
+
+## Wave 2 — Reliability under upstream pressure
+
+### 5. Circuit breaker + exponential backoff per fetcher
+Right now a service returning HTTP 500 is retried at every 3 min poll,
+forever. That's both noisy in logs and rude to the upstream.
+- New `src/lib/fetchers/circuit.ts` — per-(service, source) state
+  machine `closed → open → half-open` with cooldown 5 / 10 / 20 / 40
+  minutes capped at the poll interval × 16.
+- When `open`, `fetchOfficialStatus` short-circuits to `unknown` with
+  `details: 'circuit open until …'`. One probe call when the cooldown
+  expires.
+- Counter: `outage_fetcher_circuit_state{service,source,state}` from
+  #1.
+- Touches: `poller.ts`, all `fetchers/*.ts`, `services` query path.
+
+### 6. Configurable per-fetcher timeout + retry with jitter
+15 s is hard-coded in `downdetector.ts:51`; nothing in the other
+fetchers. Slow upstream blocks the cycle.
+- New helper `src/lib/fetchers/httpFetch.ts` wrapping `fetch` with
+  `AbortSignal.timeout`, exponential backoff (200ms × 2^n with full
+  jitter), max 3 attempts, retry only on 5xx / network errors / 429.
+- Env: `FETCH_TIMEOUT_MS` (default 12000), `FETCH_MAX_RETRIES`
+  (default 2).
+- Replace bare `fetch` calls in every fetcher. Avoids one slow upstream
+  starving the cycle (today `Promise.allSettled` waits for the
+  slowest).
+
+### 7. SQLite write throttling + busy-timeout
+WAL mode is on (`db.ts:18`) but a long-running read during VACUUM can
+still produce `SQLITE_BUSY` for incident inserts.
+- `db.pragma('busy_timeout = 5000')` on connect.
+- Defer VACUUM to a background tick that pauses when the poll is
+  running.
+- Touches: `db.ts`, `poller.ts`.
+
+---
+
+## Wave 3 — Real-time client updates
+
+### 8. Server-sent events for status + incidents
+30 s polling on the client is wasted bandwidth and adds 0–30 s of stale
+data. Switch to push.
+- New route `src/app/api/stream/route.ts` — `text/event-stream`.
+  Server pushes a JSON event whenever `runPollCycle` finishes
+  (`status:update`) or `upsertIncident` flips `isNew=true`
+  (`incident:new`).
+- Use a tiny pub/sub in `src/lib/events.ts` (Node `EventEmitter`).
+  `poller.ts` emits; the SSE handler subscribes and writes.
+- Client: replace SWR polling in `src/hooks/useStatus.ts` with an
+  `EventSource` that falls back to a single SWR fetch on connect / on
+  reconnect.
+- Heartbeat every 25 s (proxy-friendly).
+- Touches: `src/lib/events.ts`, `poller.ts`, `useStatus.ts`,
+  `useIncidents.ts`.
+
+### 9. ETag + If-None-Match on GET endpoints
+For clients that can't or won't use SSE (curl, embeds, third-party
+dashboards), make polling cheap.
+- Hash the response body of `/api/status`, `/api/history`,
+  `/api/incidents`; return `ETag: "<sha>"` and `Cache-Control:
+  no-cache, must-revalidate`.
+- `304 Not Modified` when `If-None-Match` matches.
+- Most useful for the public status page in `ROADMAP.md` #13.
+- Touches: each route handler under `src/app/api/`.
+
+---
+
+## Wave 4 — Data lifecycle
+
+### 10. Versioned migration framework
+`db.ts:99-102` already shows the strain: a one-off ALTER guarded by a
+PRAGMA introspection. The next column will repeat the pattern.
+- New `src/lib/migrations/` with numbered files
+  (`0001_init.ts`, `0002_alert_rules.ts`, …). Each exports
+  `up(db: Database)`.
+- `schema_migrations(version INTEGER PRIMARY KEY, applied_at)` table
+  picks the next unapplied step on boot.
+- Rolling back is out of scope for v1; we keep migrations
+  forward-only.
+- Touches: `db.ts` (delete inline `initTables`), new directory.
+
+### 11. Time-series rollups for older history
+`status_history` rows are inserted every 3 minutes for every service
+(14 × 20 × 24 = 6720 / day) and pruned at 35 days. Charting > 7 days
+is unnecessarily heavy.
+- Hourly rollup table `status_history_hourly` (service_slug, hour_ts,
+  status_distribution JSON, avg_report_count, max_report_count,
+  total_incidents).
+- Background job inside `runPollCycle` rolls up any hour that's older
+  than 1 h and not yet aggregated. Keep raw rows for 7 days (env
+  configurable), aggregates for 365.
+- `getStatusHistory(days)` reads raw for ≤ 7 d, aggregates for
+  longer, and stitches.
+- Pairs naturally with `ROADMAP.md` #4 (SLA reports) and #12
+  (comparison view).
+- Touches: `db.ts`, `poller.ts`, `api/history/route.ts`.
+
+### 12. Backup + restore CLI
+Today the only way to back up is to copy `data/outage.db` while hoping
+no write is in flight.
+- New `scripts/backup.ts` using SQLite's online backup API (exposed by
+  `better-sqlite3.prototype.backup`). Atomic, doesn't block writers.
+- New `scripts/restore.ts` that swaps the live DB after stopping the
+  poller cleanly.
+- Document a cron example and a Docker volume snapshot example in
+  `README.md`.
+- Optional: Litestream sidecar in `docker-compose.yml` for continuous
+  replication to S3 — left as an opt-in compose overlay
+  (`docker-compose.litestream.yml`).
+
+---
+
+## Wave 5 — Integrations and public surfaces
+
+### 13. First-class PagerDuty / Opsgenie / VictorOps notifiers
+The generic webhook from `ROADMAP.md` #2 works for these but forces
+users to glue payloads themselves.
+- `src/lib/notifiers/pagerduty.ts` posts to Events API v2 with
+  `dedup_key = incident.serviceSlug + ':' + incident.incidentId`,
+  auto-resolves when `resolvedAt` populates.
+- `src/lib/notifiers/opsgenie.ts` posts to the Alerts API, mapped
+  severity → priority.
+- Each surfaces in Settings under "Integrations" with a test-send
+  button. Routing key / integration key stored in `alert_rules.channel_config`
+  (JSON), keyed by channel name.
+- Touches: notifiers, `alerts/rules.ts`, `SettingsView.tsx`,
+  `email.ts` → `notifiers/index.ts`.
+
+### 14. Signed outbound webhook payloads
+Anyone receiving an outbound webhook from the generic notifier today
+must trust the source IP.
+- HMAC-SHA256 over body using a per-rule secret stored in
+  `alert_rules.channel_secret`. Send as
+  `X-OutageMap-Signature: t=<ts>,v1=<hex>` (Stripe-style).
+- "Reveal secret" + "Rotate secret" in the rule editor.
+- Document verification in `README.md` with a 10-line Node and Python
+  example.
+- Touches: `src/lib/notifiers/webhook.ts`, `alert_rules` schema
+  (migration #10), Settings UI.
+
+### 15. Status badges + iCal feed
+Useful side-doors for users who don't want a whole dashboard.
+- `GET /api/badge/[slug].svg` — Shields.io-style SVG that says
+  `slack: operational` / `degraded` / `major outage`. ETag from #9
+  applies.
+- `GET /api/incidents.ics` — RFC 5545 calendar feed of incidents,
+  filterable by `?service=`. Each `VEVENT` spans `startedAt` →
+  `resolvedAt` (or DTSTART only for unresolved).
+- Public, no auth, rate-limited per IP (already a pattern in
+  `cron/route.ts`).
+
+### 16. Inbound webhook ingestion
+Some users want to push outages *into* Outage-Map from internal tools
+(e.g. a Nagios bridge, a custom synthetic check).
+- `POST /api/ingest` with Bearer `INGEST_SECRET` and a body matching
+  the `IncidentInput` shape. Idempotent on
+  `(serviceSlug, incidentId)`.
+- Triggers the same alert evaluation path as the poller.
+- Enables custom-service users (`ROADMAP.md` #14) to feed sources
+  Outage-Map can't scrape (internal apps, on-prem stacks).
+
+---
+
+## Wave 6 — Quality of life for operators and end-users
+
+### 17. CLI for ops tasks
+A subset of the API as a local CLI for the operator running
+`docker exec`.
+- `npm run cli -- poll` triggers a poll cycle.
+- `npm run cli -- rules list|add|delete` mirrors the rules API.
+- `npm run cli -- test-alert <slug>` writes a fake incident and runs
+  the dispatch path end-to-end.
+- New `scripts/cli.ts`, registered in `package.json`.
+
+### 18. Type-checked env loading
+Env parsing is scattered: `parseInt` in `downdetector.ts:15-16`,
+`process.env.DEBUG === 'true'` strings throughout `poller.ts`,
+defaults restated in `README.md`. Drift is inevitable.
+- New `src/lib/env.ts` using `zod` to validate and coerce. Export a
+  typed `env` object. Throw at boot if required vars are missing in
+  production.
+- Generates `.env.example` from the schema (script).
+- Touches: every site that reads `process.env`.
+
+### 19. Content Security Policy + security headers
+The app currently ships with default Next.js headers.
+- `next.config.mjs` `headers()` adds CSP (script-src 'self', no
+  inline except a small hashed nonce for ThemeProvider hydration),
+  `X-Content-Type-Options: nosniff`,
+  `Referrer-Policy: strict-origin-when-cross-origin`,
+  `Permissions-Policy` denying camera/mic/geo.
+- Will surface any inline `<style>` / `<script>` left from the chart
+  library — fix as found.
+
+### 20. Internationalization + per-user timezone
+All copy is inline English and timestamps render in server TZ.
+- Adopt `next-intl`. Extract strings from `src/components/` into
+  `messages/en.json`. Ship `en` only; structure makes contributors'
+  PRs cheap.
+- Timezone selector in `TweaksPanel.tsx`, persisted alongside
+  `useTweaks`. All `format.ts` helpers take TZ as a param; default to
+  `Intl.DateTimeFormat().resolvedOptions().timeZone`.
+- Touches: every component with literal copy, `format.ts`,
+  `next.config.mjs`.
+
+### 21. Accessibility audit pass
+Status is conveyed primarily by color today (`statusColors.ts`).
+- Add textual + iconographic redundancy on every status pill
+  (`StatusBadge.tsx`) — colorblind users get a shape, screen-reader
+  users get `aria-label`.
+- `prefers-reduced-motion` honored in sparkline transitions.
+- `aria-live="polite"` region in `Dashboard.tsx` announces new
+  incidents.
+- Run `@axe-core/playwright` once tests land (`ROADMAP.md` #3).
+
+---
+
+## Cross-cutting concerns
+
+- **Order**: Wave 1 first — observability has to come before reliability
+  work, otherwise we can't tell if a circuit breaker actually helped.
+- **Tests**: every item in Wave 2 (`#5–#7`) and Wave 4 (`#10–#11`) is
+  blocked on `ROADMAP.md` #3 (Vitest harness). Don't ship them without
+  unit coverage.
+- **Backwards compatibility**: Wave 4 #10 (migrations) is a one-time
+  cutover. After landing, every schema change goes through a numbered
+  migration — including the new tables introduced by `ROADMAP.md`
+  features.
+- **Docs**: every new env var lands in `README.md` *and* the env
+  schema (#18) in the same PR.
+
+## Verification checklist (per feature)
+
+1. `npm run build` and `npm run lint` pass.
+2. `docker compose up -d --build` starts without error; `/api/status`
+   still returns all services; `/api/metrics` (after #1) shows the
+   poller has run.
+3. Feature smoke test:
+   - #1: `curl localhost:3100/api/metrics | grep outage_poll_cycles_total`.
+   - #5: kill an upstream (rewrite `services.ts` URL to garbage); after
+     N cycles the circuit opens and stops retrying.
+   - #8: connect with `curl -N localhost:3100/api/stream`, force a poll
+     via `/api/cron`, see an event.
+4. No regression in existing endpoints — record their bodies before the
+   change and diff after.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,9 @@ To force a refresh to the latest published build, either tick
 | `GITHUB_TOKEN` | _unset_ | PAT or fine-grained token with `Contents: Read & Write` and `Pull requests: Read & Write` on the target repo. Required for the in-app "Contribute to catalog" flow; the endpoint returns 503 if unset. |
 | `GITHUB_REPO` | `Tri-Lumen/Outage-Map` | `owner/name` of the upstream catalog repository that contribute-PRs land in. |
 | `GITHUB_BASE_BRANCH` | `main` | Branch the contribute flow PRs against. |
+| `FETCH_TIMEOUT_MS` | `12000` | Per-attempt timeout used by every fetcher. Clamped to 1000–60000. |
+| `FETCH_MAX_RETRIES` | `2` | Retries on transient failures (network errors, 5xx, 429) with full-jitter exponential backoff. Honors `Retry-After` on 429. Clamped to 0–5. |
+| `CIRCUIT_FAILURE_THRESHOLD` | `5` | Consecutive failed cycles before a (service, source) circuit opens. Once open, calls short-circuit with status `unknown` until the cooldown elapses (5 → 80 min, doubling on each re-open). |
 
 ## API Endpoints
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ To force a refresh to the latest published build, either tick
 | `ALERT_EMAILS` | _empty_ | Comma-separated fallback recipients used when no alert rule matches an incident. |
 | `DEBUG` | `false` | Set to `true` for verbose poller logs (per-service status lines). |
 | `APP_PORT` | `3100` | Host port published by `docker-compose.yml`. |
+| `GITHUB_TOKEN` | _unset_ | PAT or fine-grained token with `Contents: Read & Write` and `Pull requests: Read & Write` on the target repo. Required for the in-app "Contribute to catalog" flow; the endpoint returns 503 if unset. |
+| `GITHUB_REPO` | `Tri-Lumen/Outage-Map` | `owner/name` of the upstream catalog repository that contribute-PRs land in. |
+| `GITHUB_BASE_BRANCH` | `main` | Branch the contribute flow PRs against. |
 
 ## API Endpoints
 
@@ -255,6 +258,9 @@ To force a refresh to the latest published build, either tick
 | `/api/alerts/rules` | GET / POST | List / create alert rules. Writes need Bearer auth (or `ENABLE_RULES_API=true`). |
 | `/api/alerts/rules/:id` | PATCH / DELETE | Update or remove a rule. Same auth as POST. |
 | `/api/alerts/test` | POST | Send a test email to verify SMTP wiring. |
+| `/api/sources` | GET / POST | List / create custom data sources merged into the runtime catalog. Writes require Bearer auth (or `ENABLE_RULES_API=true`). |
+| `/api/sources/:id` | PATCH / DELETE | Update or remove a custom source. Same auth as POST. DELETE also cleans up the source's status, history, and incident rows. |
+| `/api/sources/contribute` | POST | Open a PR against `main` adding selected custom sources to `src/lib/services.contributed.json`. Requires `GITHUB_TOKEN` plus Bearer auth. |
 
 ## Architecture
 

--- a/src/app/api/alerts/rules/[id]/route.ts
+++ b/src/app/api/alerts/rules/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { deleteAlertRule, updateAlertRule } from '@/lib/db';
-import { SERVICES } from '@/lib/services';
+import { getServices } from '@/lib/services';
 import { isIncidentSeverity } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -58,7 +58,7 @@ export async function PATCH(request: NextRequest, { params }: Ctx) {
     patch.email = email;
   }
   if (input.services !== undefined) {
-    const validSlugs = new Set(SERVICES.map((s) => s.slug));
+    const validSlugs = new Set(getServices().map((s) => s.slug));
     const services = Array.isArray(input.services)
       ? input.services.filter((s): s is string => typeof s === 'string' && validSlugs.has(s))
       : [];

--- a/src/app/api/alerts/rules/route.ts
+++ b/src/app/api/alerts/rules/route.ts
@@ -4,7 +4,7 @@ import {
   listAlertRules,
 } from '@/lib/db';
 import { rowToRule } from '@/lib/alerts/rules';
-import { SERVICES } from '@/lib/services';
+import { getServices } from '@/lib/services';
 import { isIncidentSeverity } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -67,7 +67,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid email' }, { status: 400 });
   }
 
-  const validSlugs = new Set(SERVICES.map((s) => s.slug));
+  const validSlugs = new Set(getServices().map((s) => s.slug));
   const services = Array.isArray(input.services)
     ? input.services.filter((s): s is string => typeof s === 'string' && validSlugs.has(s))
     : [];

--- a/src/app/api/health/fetchers/route.ts
+++ b/src/app/api/health/fetchers/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { health } from '@/lib/health';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+// Per-fetcher health snapshot. Returns one row per (service, source) with
+// the timestamp of the last success / last error, the most recent error
+// message, the most recent latency, and the running count of consecutive
+// failures. Useful for the Sources view and for operators chasing down
+// "why is one tile stale".
+export function GET() {
+  const snapshot = health.snapshot();
+  return NextResponse.json({
+    fetchers: snapshot.map((entry) => ({
+      service: entry.service,
+      source: entry.source,
+      lastSuccessAt: entry.lastSuccessAt ? new Date(entry.lastSuccessAt).toISOString() : null,
+      lastErrorAt: entry.lastErrorAt ? new Date(entry.lastErrorAt).toISOString() : null,
+      lastError: entry.lastError,
+      lastLatencyMs: entry.lastLatencyMs,
+      consecutiveFailures: entry.consecutiveFailures,
+    })),
+  });
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,17 +1,34 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { health } from '@/lib/health';
 
-// Liveness probe target for the container HEALTHCHECK. Intentionally does NOT
-// touch the database, the filesystem, or any application module — it only
-// confirms that the Next.js HTTP server has bound the port and is serving
-// routes. /api/status was previously used here, but it opens SQLite, runs the
-// initial CREATE TABLE migrations on first boot, and queries two tables, so
-// the first probe on a fresh volume can take several seconds — long enough
-// for `docker compose up --wait` (which Portainer uses on redeploy) to keep
-// the stack-update HTTP call open past upstream proxy timeouts and hang the
-// "Saving…" spinner in the UI.
+// Liveness probe target for the container HEALTHCHECK. The default response
+// intentionally does NOT touch the database, the filesystem, or any
+// application module — it only confirms that the Next.js HTTP server has
+// bound the port and is serving routes. /api/status was previously used
+// here, but it opens SQLite, runs the initial CREATE TABLE migrations on
+// first boot, and queries two tables, so the first probe on a fresh volume
+// can take several seconds — long enough for `docker compose up --wait`
+// (which Portainer uses on redeploy) to keep the stack-update HTTP call
+// open past upstream proxy timeouts and hang the "Saving…" spinner in the
+// UI.
+//
+// `?probe=ready` opts into a deeper readiness check that reports whether
+// any fetcher has been failing for too long. Leave the default liveness
+// behavior intact so Docker / k8s `HEALTHCHECK` lines don't need to be
+// updated.
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-export function GET() {
+export function GET(request: NextRequest) {
+  const probe = request.nextUrl.searchParams.get('probe') ?? 'live';
+
+  if (probe === 'ready') {
+    const { ready, reason } = health.isReady();
+    return NextResponse.json(
+      { ok: ready, probe: 'ready', reason },
+      { status: ready ? 200 : 503 },
+    );
+  }
+
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getStatusHistory } from '@/lib/db';
-import { SERVICES } from '@/lib/services';
+import { getServices } from '@/lib/services';
 import { HistoryPoint, ServiceStatus } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -88,7 +88,7 @@ export async function GET(request: NextRequest) {
     const history = aggregateByDay(rows);
 
     // Ensure all services have entries (even if empty)
-    for (const service of SERVICES) {
+    for (const service of getServices()) {
       if (!history[service.slug]) {
         history[service.slug] = [];
       }

--- a/src/app/api/incidents/route.ts
+++ b/src/app/api/incidents/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getRecentIncidents } from '@/lib/db';
-import { SERVICES } from '@/lib/services';
+import { getServices } from '@/lib/services';
 import { IncidentResponse, asIncidentSeverity, asIncidentStatus } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -13,7 +13,8 @@ export async function GET(request: NextRequest) {
       ? Math.min(Math.floor(daysParam), 90)
       : 7;
     const serviceFilter = searchParams.get('service');
-    const validSlugs = new Set(SERVICES.map((s) => s.slug));
+    const allServices = getServices();
+    const validSlugs = new Set(allServices.map((s) => s.slug));
     const service = serviceFilter && serviceFilter !== 'all' && validSlugs.has(serviceFilter)
       ? serviceFilter
       : null;
@@ -24,7 +25,7 @@ export async function GET(request: NextRequest) {
       incidents = incidents.filter((i) => i.service_slug === service);
     }
 
-    const serviceMap = new Map(SERVICES.map((s) => [s.slug, s.name]));
+    const serviceMap = new Map(allServices.map((s) => [s.slug, s.name]));
 
     const response: IncidentResponse[] = incidents.map((i) => ({
       id: i.id,

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from 'next/server';
+import { metrics } from '@/lib/metrics';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+// Prometheus-compatible exposition endpoint. Optional bearer-token gate via
+// METRICS_TOKEN — when unset the endpoint is unauthenticated, which matches
+// the convention for Prometheus scrapes on a trusted network. Set the token
+// if Outage-Map is exposed to the public internet.
+export function GET(request: NextRequest) {
+  const token = process.env.METRICS_TOKEN;
+  if (token) {
+    const auth = request.headers.get('authorization');
+    if (auth !== `Bearer ${token}`) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+  }
+
+  return new Response(metrics.expose(), {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; version=0.0.4; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/src/app/api/sources/[id]/route.ts
+++ b/src/app/api/sources/[id]/route.ts
@@ -1,0 +1,128 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  cleanupServiceData,
+  deleteCustomService,
+  getCustomServiceById,
+  updateCustomService,
+} from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+const URL_RE = /^https?:\/\/[^\s]+$/i;
+const COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+function isWriteEnabled(): boolean {
+  return process.env.ENABLE_RULES_API === 'true' || !!process.env.CRON_SECRET;
+}
+
+function isAuthorized(request: NextRequest): boolean {
+  if (process.env.ENABLE_RULES_API === 'true') return true;
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  return request.headers.get('authorization') === `Bearer ${secret}`;
+}
+
+interface Ctx {
+  params: { id: string };
+}
+
+export async function PATCH(request: NextRequest, { params }: Ctx) {
+  if (!isWriteEnabled()) {
+    return NextResponse.json(
+      { error: 'Sources API is not enabled.' },
+      { status: 503 },
+    );
+  }
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const input = body as Partial<{
+    name: string;
+    color: string;
+    statusUrl: string;
+    downdetectorSlug: string | null;
+    refreshSeconds: number;
+    enabled: boolean;
+  }>;
+
+  const patch: Parameters<typeof updateCustomService>[1] = {};
+
+  if (input.name !== undefined) {
+    const name = typeof input.name === 'string' ? input.name.trim() : '';
+    if (!name) return NextResponse.json({ error: 'Name cannot be empty' }, { status: 400 });
+    patch.name = name;
+  }
+  if (input.color !== undefined) {
+    if (typeof input.color !== 'string' || !COLOR_RE.test(input.color)) {
+      return NextResponse.json({ error: 'Invalid color' }, { status: 400 });
+    }
+    patch.color = input.color;
+  }
+  if (input.statusUrl !== undefined) {
+    if (typeof input.statusUrl !== 'string' || !URL_RE.test(input.statusUrl)) {
+      return NextResponse.json({ error: 'Invalid statusUrl' }, { status: 400 });
+    }
+    patch.statusUrl = input.statusUrl;
+  }
+  if (input.downdetectorSlug !== undefined) {
+    patch.downdetectorSlug = typeof input.downdetectorSlug === 'string' && input.downdetectorSlug.trim()
+      ? input.downdetectorSlug.trim()
+      : null;
+  }
+  if (input.refreshSeconds !== undefined) {
+    const r = Number(input.refreshSeconds);
+    if (!Number.isFinite(r) || r < 30 || r > 3600) {
+      return NextResponse.json({ error: 'Refresh must be 30–3600' }, { status: 400 });
+    }
+    patch.refreshSeconds = Math.floor(r);
+  }
+  if (input.enabled !== undefined) patch.enabled = !!input.enabled;
+
+  try {
+    const ok = updateCustomService(params.id, patch);
+    if (!ok) {
+      return NextResponse.json({ error: 'Source not found' }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('[api/sources] Update failed:', err);
+    return NextResponse.json({ error: 'Failed to update source' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: Ctx) {
+  if (!isWriteEnabled()) {
+    return NextResponse.json(
+      { error: 'Sources API is not enabled.' },
+      { status: 503 },
+    );
+  }
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const row = getCustomServiceById(params.id);
+    if (!row) {
+      return NextResponse.json({ error: 'Source not found' }, { status: 404 });
+    }
+    const ok = deleteCustomService(params.id);
+    if (ok) {
+      // Drop the orphaned status/history/incidents so a future slug re-use
+      // doesn't inherit the previous service's data.
+      cleanupServiceData(row.slug);
+    }
+    return NextResponse.json({ ok });
+  } catch (err) {
+    console.error('[api/sources] Delete failed:', err);
+    return NextResponse.json({ error: 'Failed to delete source' }, { status: 500 });
+  }
+}

--- a/src/app/api/sources/contribute/route.ts
+++ b/src/app/api/sources/contribute/route.ts
@@ -1,0 +1,264 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { listCustomServices, CustomServiceRow } from '@/lib/db';
+import { SERVICES } from '@/lib/services';
+import { ServiceConfig } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+const CONTRIBUTED_PATH = 'src/lib/services.contributed.json';
+
+interface ContributedFile {
+  schemaVersion: number;
+  services: ServiceConfig[];
+}
+
+function isWriteEnabled(): boolean {
+  return process.env.ENABLE_RULES_API === 'true' || !!process.env.CRON_SECRET;
+}
+
+function isAuthorized(request: NextRequest): boolean {
+  if (process.env.ENABLE_RULES_API === 'true') return true;
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  return request.headers.get('authorization') === `Bearer ${secret}`;
+}
+
+function rowToServiceConfig(row: CustomServiceRow): ServiceConfig {
+  return {
+    name: row.name,
+    slug: row.slug,
+    color: row.color,
+    statusUrl: row.status_url,
+    downdetectorSlug: row.downdetector_slug,
+    fetcher: row.fetcher as ServiceConfig['fetcher'],
+    brandFont: row.brand_font,
+  };
+}
+
+interface GitHubCtx {
+  owner: string;
+  repo: string;
+  base: string;
+  token: string;
+}
+
+async function gh<T>(
+  ctx: GitHubCtx,
+  method: 'GET' | 'POST' | 'PUT',
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; data: T | null; error: string | null }> {
+  const res = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let data: unknown = null;
+  try {
+    data = await res.json();
+  } catch {
+    data = null;
+  }
+  if (!res.ok) {
+    const err = data as { message?: string } | null;
+    return { status: res.status, data: null, error: err?.message ?? `HTTP ${res.status}` };
+  }
+  return { status: res.status, data: data as T, error: null };
+}
+
+export async function POST(request: NextRequest) {
+  if (!isWriteEnabled()) {
+    return NextResponse.json(
+      { error: 'Sources API is not enabled.' },
+      { status: 503 },
+    );
+  }
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO || 'Tri-Lumen/Outage-Map';
+  const base = process.env.GITHUB_BASE_BRANCH || 'main';
+  if (!token) {
+    return NextResponse.json(
+      { error: 'Catalog contribution is not configured on this deployment. Set GITHUB_TOKEN.' },
+      { status: 503 },
+    );
+  }
+  const [owner, repoName] = repo.split('/');
+  if (!owner || !repoName) {
+    return NextResponse.json(
+      { error: `GITHUB_REPO must be "owner/name", got "${repo}"` },
+      { status: 500 },
+    );
+  }
+  const ctx: GitHubCtx = { owner, repo: repoName, base, token };
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  const input = body as { ids?: unknown };
+  const ids = Array.isArray(input.ids)
+    ? input.ids.filter((x): x is string => typeof x === 'string')
+    : [];
+  if (ids.length === 0) {
+    return NextResponse.json({ error: 'Pass at least one source id' }, { status: 400 });
+  }
+
+  // Resolve the requested rows.
+  const all = listCustomServices();
+  const requested = ids.map((id) => all.find((r) => r.id === id) || null);
+  const missing = requested.findIndex((r) => r === null);
+  if (missing !== -1) {
+    return NextResponse.json(
+      { error: `Source id "${ids[missing]}" not found` },
+      { status: 400 },
+    );
+  }
+  const rows = requested as CustomServiceRow[];
+
+  // Defense in depth — reject if any selected row collides with the static catalog
+  // (shouldn't happen because POST /api/sources blocks this, but a stale DB
+  // row could survive across catalog updates).
+  const staticSlugs = new Set(SERVICES.map((s) => s.slug));
+  for (const r of rows) {
+    if (staticSlugs.has(r.slug)) {
+      return NextResponse.json(
+        { error: `Slug "${r.slug}" is already in the static catalog` },
+        { status: 409 },
+      );
+    }
+  }
+
+  const newEntries = rows.map(rowToServiceConfig);
+  const summary = newEntries.map((s) => `- \`${s.slug}\` — ${s.name} (${s.statusUrl})`).join('\n');
+
+  // 1. Read current contributed.json (or fall back to skeleton).
+  type ContentsRes = { sha: string; content: string; encoding: string };
+  const contents = await gh<ContentsRes>(
+    ctx,
+    'GET',
+    `/repos/${owner}/${repoName}/contents/${CONTRIBUTED_PATH}?ref=${encodeURIComponent(base)}`,
+  );
+  if (contents.error && contents.status !== 404) {
+    return githubError(contents);
+  }
+  let existing: ContributedFile = { schemaVersion: 1, services: [] };
+  let existingSha: string | null = null;
+  if (contents.data) {
+    existingSha = contents.data.sha;
+    try {
+      const raw = Buffer.from(contents.data.content, 'base64').toString('utf-8');
+      existing = JSON.parse(raw) as ContributedFile;
+      if (!Array.isArray(existing.services)) existing.services = [];
+    } catch (err) {
+      console.error('[contribute] Failed to parse existing contributed.json:', err);
+      return NextResponse.json(
+        { error: 'Failed to parse existing contributed.json from main' },
+        { status: 500 },
+      );
+    }
+  }
+
+  // 2. Compose the merged file, de-duped on slug.
+  const seen = new Set(existing.services.map((s) => s.slug));
+  const fresh = newEntries.filter((s) => !seen.has(s.slug));
+  if (fresh.length === 0) {
+    return NextResponse.json(
+      { error: 'Every selected source is already in the catalog on main' },
+      { status: 409 },
+    );
+  }
+  const next: ContributedFile = {
+    schemaVersion: 1,
+    services: [...existing.services, ...fresh],
+  };
+  const nextContent = `${JSON.stringify(next, null, 2)}\n`;
+
+  // 3. Get the SHA of base branch's HEAD so we can create a branch off it.
+  type RefRes = { object: { sha: string } };
+  const baseRef = await gh<RefRes>(
+    ctx,
+    'GET',
+    `/repos/${owner}/${repoName}/git/ref/heads/${encodeURIComponent(base)}`,
+  );
+  if (baseRef.error || !baseRef.data) return githubError(baseRef);
+
+  const stamp = new Date().toISOString().replace(/[-:T]/g, '').slice(0, 12);
+  const rand = Math.random().toString(36).slice(2, 6);
+  const branch = `contribute/sources-${stamp}-${rand}`;
+  const createBranch = await gh<unknown>(
+    ctx,
+    'POST',
+    `/repos/${owner}/${repoName}/git/refs`,
+    { ref: `refs/heads/${branch}`, sha: baseRef.data.object.sha },
+  );
+  if (createBranch.error) return githubError(createBranch);
+
+  // 4. PUT the updated file on the new branch.
+  const commitMessage = `feat(catalog): add ${fresh.length} user-imported service${fresh.length === 1 ? '' : 's'}`;
+  const putBody: Record<string, unknown> = {
+    message: commitMessage,
+    content: Buffer.from(nextContent, 'utf-8').toString('base64'),
+    branch,
+  };
+  if (existingSha) putBody.sha = existingSha;
+  const put = await gh<unknown>(
+    ctx,
+    'PUT',
+    `/repos/${owner}/${repoName}/contents/${CONTRIBUTED_PATH}`,
+    putBody,
+  );
+  if (put.error) return githubError(put);
+
+  // 5. Open the PR.
+  type PrRes = { number: number; html_url: string };
+  const titleNames = fresh.map((s) => s.name).join(', ');
+  const title = `Add ${fresh.length} service${fresh.length === 1 ? '' : 's'} to catalog (${titleNames})`;
+  const prBody = [
+    `Adds the following service${fresh.length === 1 ? '' : 's'} to the shared catalog via the in-app contribute flow.`,
+    '',
+    summary,
+    '',
+    '_Generated by the Outage-Map catalog contribution endpoint._',
+  ].join('\n');
+  const pr = await gh<PrRes>(
+    ctx,
+    'POST',
+    `/repos/${owner}/${repoName}/pulls`,
+    { title, head: branch, base, body: prBody },
+  );
+  if (pr.error || !pr.data) return githubError(pr);
+
+  return NextResponse.json(
+    {
+      prNumber: pr.data.number,
+      prUrl: pr.data.html_url,
+      branch,
+      added: fresh.map((s) => s.slug),
+    },
+    { status: 201 },
+  );
+}
+
+function githubError(res: { status: number; error: string | null }) {
+  const status = res.status === 404 ? 404
+    : res.status === 401 ? 401
+    : res.status === 403 ? 403
+    : res.status === 422 ? 422
+    : 502;
+  return NextResponse.json(
+    { error: `GitHub API: ${res.error || `HTTP ${res.status}`}` },
+    { status },
+  );
+}

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -1,0 +1,176 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  CustomServiceRow,
+  getCustomServiceBySlug,
+  insertCustomService,
+  listCustomServices,
+} from '@/lib/db';
+import { SERVICES } from '@/lib/services';
+import { FetcherType } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const URL_RE = /^https?:\/\/[^\s]+$/i;
+const COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+const DEFAULT_BRAND_FONT = 'var(--font-brand-inter), Inter, system-ui, sans-serif';
+
+function isWriteEnabled(): boolean {
+  return process.env.ENABLE_RULES_API === 'true' || !!process.env.CRON_SECRET;
+}
+
+function isAuthorized(request: NextRequest): boolean {
+  if (process.env.ENABLE_RULES_API === 'true') return true;
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  return request.headers.get('authorization') === `Bearer ${secret}`;
+}
+
+function slugify(name: string): string {
+  const cleaned = name.toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+  return `custom-${cleaned}`;
+}
+
+function randomId(): string {
+  return `cs_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// Maps the ImportSlideOver "type" to a concrete fetcher. v1 only supports
+// statuspage.io-compatible sources; rss/http/aws are recognised but rejected
+// pending dedicated fetcher implementations.
+function mapKindToFetcher(kind: string): FetcherType | null {
+  switch (kind) {
+    case 'statuspage':
+    case 'github':
+      return 'statuspage';
+    default:
+      return null;
+  }
+}
+
+function rowToApi(row: CustomServiceRow) {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    color: row.color,
+    statusUrl: row.status_url,
+    downdetectorSlug: row.downdetector_slug,
+    fetcher: row.fetcher,
+    kind: row.kind,
+    refreshSeconds: row.refresh_seconds,
+    enabled: row.enabled === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function GET() {
+  try {
+    const rows = listCustomServices();
+    return NextResponse.json({ sources: rows.map(rowToApi) });
+  } catch (err) {
+    console.error('[api/sources] List failed:', err);
+    return NextResponse.json({ error: 'Failed to list sources' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  if (!isWriteEnabled()) {
+    return NextResponse.json(
+      { error: 'Sources API is not enabled. Set ENABLE_RULES_API=true or configure CRON_SECRET.' },
+      { status: 503 },
+    );
+  }
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const input = body as Partial<{
+    type: string;
+    name: string;
+    url: string;
+    refresh: number;
+    color: string;
+    downdetectorSlug: string | null;
+  }>;
+
+  const name = typeof input.name === 'string' ? input.name.trim() : '';
+  if (!name) {
+    return NextResponse.json({ error: 'Name is required' }, { status: 400 });
+  }
+
+  const url = typeof input.url === 'string' ? input.url.trim() : '';
+  if (!URL_RE.test(url)) {
+    return NextResponse.json({ error: 'URL must be http(s)://…' }, { status: 400 });
+  }
+
+  const color = typeof input.color === 'string' ? input.color.trim() : '#268bd2';
+  if (!COLOR_RE.test(color)) {
+    return NextResponse.json({ error: 'Color must be a 6-digit hex like #268bd2' }, { status: 400 });
+  }
+
+  const refresh = Number(input.refresh ?? 180);
+  if (!Number.isFinite(refresh) || refresh < 30 || refresh > 3600) {
+    return NextResponse.json({ error: 'Refresh must be 30–3600 seconds' }, { status: 400 });
+  }
+
+  const kind = typeof input.type === 'string' ? input.type : 'statuspage';
+  const fetcher = mapKindToFetcher(kind);
+  if (!fetcher) {
+    return NextResponse.json(
+      { error: `Source type "${kind}" is not yet supported. Try statuspage or github.` },
+      { status: 400 },
+    );
+  }
+
+  const slug = slugify(name);
+  if (!slug || slug === 'custom-') {
+    return NextResponse.json({ error: 'Name produces an empty slug' }, { status: 400 });
+  }
+
+  if (SERVICES.some((s) => s.slug === slug) || getCustomServiceBySlug(slug)) {
+    return NextResponse.json(
+      { error: `Slug "${slug}" already exists in the catalog` },
+      { status: 409 },
+    );
+  }
+
+  const downdetectorSlug = typeof input.downdetectorSlug === 'string' && input.downdetectorSlug.trim()
+    ? input.downdetectorSlug.trim()
+    : null;
+
+  const id = randomId();
+  try {
+    insertCustomService({
+      id,
+      slug,
+      name,
+      color,
+      statusUrl: url,
+      downdetectorSlug,
+      fetcher,
+      brandFont: DEFAULT_BRAND_FONT,
+      refreshSeconds: Math.floor(refresh),
+      kind,
+      enabled: true,
+    });
+  } catch (err) {
+    console.error('[api/sources] Insert failed:', err);
+    return NextResponse.json({ error: 'Failed to insert source' }, { status: 500 });
+  }
+
+  const row = getCustomServiceBySlug(slug);
+  return NextResponse.json({ source: row ? rowToApi(row) : null }, { status: 201 });
+}

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getServiceStatuses, getActiveIncidentCounts } from '@/lib/db';
-import { SERVICES } from '@/lib/services';
+import { getServices } from '@/lib/services';
 import { ServiceStatus, ServiceStatusResponse } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -28,7 +28,7 @@ export async function GET() {
     const statuses = getServiceStatuses();
     const activeIncidentCounts = getActiveIncidentCounts();
 
-    const services: ServiceStatusResponse[] = SERVICES.map((service) => {
+    const services: ServiceStatusResponse[] = getServices().map((service) => {
       const official = statuses.find(
         (s) => s.service_slug === service.slug && s.source === 'official'
       );
@@ -52,7 +52,9 @@ export async function GET() {
         details: official?.details || null,
         lastChecked: official?.checked_at || dd?.checked_at || null,
         statusUrl: service.statusUrl,
-        downdetectorUrl: `https://downdetector.com/status/${service.downdetectorSlug}/`,
+        downdetectorUrl: service.downdetectorSlug
+          ? `https://downdetector.com/status/${service.downdetectorSlug}/`
+          : '',
         brandFont: service.brandFont,
       };
     });

--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import ServiceDetailView from '@/components/ServiceDetailView';
-import { SERVICES } from '@/lib/services';
+import { getServiceBySlug } from '@/lib/services';
 import { notFound } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
@@ -9,7 +9,7 @@ interface PageProps {
 }
 
 export default function ServicePage({ params }: PageProps) {
-  const service = SERVICES.find((s) => s.slug === params.slug);
+  const service = getServiceBySlug(params.slug);
   if (!service) notFound();
   return <ServiceDetailView slug={params.slug} />;
 }

--- a/src/components/AlertsView.tsx
+++ b/src/components/AlertsView.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import useSWR from 'swr';
-import { SERVICES } from '@/lib/services';
+import { useServiceStatus } from '@/hooks/useStatus';
 import { AlertRule, IncidentSeverity } from '@/lib/types';
 import PageHeader from './ui/PageHeader';
 import Card from './ui/Card';
@@ -53,6 +53,8 @@ export default function AlertsView() {
     revalidateOnFocus: false,
   });
   const rules = data?.rules ?? [];
+  const { data: statusData } = useServiceStatus();
+  const services = statusData?.services ?? [];
 
   const [draft, setDraft] = useState<{
     email: string;
@@ -319,7 +321,7 @@ export default function AlertsView() {
                 Services ({draft.services.length} selected)
               </label>
               <div className="flex flex-wrap gap-2">
-                {SERVICES.map((s) => {
+                {services.map((s) => {
                   const selected = draft.services.includes(s.slug);
                   return (
                     <button
@@ -416,7 +418,7 @@ export default function AlertsView() {
             const serviceNames = r.services.length === 0
               ? ['All services']
               : r.services
-                  .map((slug) => SERVICES.find((s) => s.slug === slug)?.name)
+                  .map((slug) => services.find((s) => s.slug === slug)?.name)
                   .filter(Boolean);
             const ruleFeedback = feedback?.ruleId === r.id ? feedback : null;
             const isTesting = testing === r.id;

--- a/src/components/AnalyticsView.tsx
+++ b/src/components/AnalyticsView.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo } from 'react';
 import { useServiceStatus, useHistory, useIncidents } from '@/hooks/useStatus';
-import { SERVICES } from '@/lib/services';
 import { HistoryPoint } from '@/lib/types';
 import PageHeader from './ui/PageHeader';
 import StatTile from './ui/StatTile';
@@ -41,11 +40,11 @@ export default function AnalyticsView() {
   const incidents = useMemo(() => incidentData?.incidents || [], [incidentData]);
 
   const rows = useMemo(() => {
-    return SERVICES.map((s) => {
+    return services.map((s) => {
       const points = history[s.slug] || [];
       const uptime = uptimeForService(points);
       const mttr = mttrForService(points);
-      const live = services.find((x) => x.slug === s.slug);
+      const live = s;
       const serviceIncidents = incidents.filter((i) => i.service === s.slug);
       return {
         slug: s.slug,

--- a/src/components/OutageMapView.tsx
+++ b/src/components/OutageMapView.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from 'react';
 import { useServiceStatus } from '@/hooks/useStatus';
-import { SERVICES } from '@/lib/services';
 import {
   NA_VIEWBOX,
   US_OUTLINE_SHAPE,
@@ -200,7 +199,7 @@ export default function OutageMapView() {
             >
               All services
             </button>
-            {SERVICES.map((s) => (
+            {services.map((s) => (
               <button
                 key={s.slug}
                 onClick={() => setSelectedService(s.slug)}

--- a/src/components/ServiceDetailView.tsx
+++ b/src/components/ServiceDetailView.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link';
 import { useMemo } from 'react';
 import { useServiceStatus, useIncidents, useHistory } from '@/hooks/useStatus';
-import { SERVICES } from '@/lib/services';
 import { HistoryPoint } from '@/lib/types';
 import StatTile from './ui/StatTile';
 import Card from './ui/Card';
@@ -32,7 +31,6 @@ function formatDateTime(ts: string | null): string {
 }
 
 export default function ServiceDetailView({ slug }: Props) {
-  const config = SERVICES.find((s) => s.slug === slug);
   const { data: statusData } = useServiceStatus();
   const { data: incidentData } = useIncidents(30);
   const { data: historyData } = useHistory(30);
@@ -55,13 +53,21 @@ export default function ServiceDetailView({ slug }: Props) {
     return { uptime, outageDays, totalDowntime, critical };
   }, [history, incidents]);
 
-  if (!config) {
+  if (statusData && !service) {
     return (
       <Card className="text-center py-14">
         <p className="text-sm text-muted">Service not found.</p>
         <Link href="/" className="text-xs text-accent-cyan mt-3 inline-block">
           ← Back to overview
         </Link>
+      </Card>
+    );
+  }
+
+  if (!service) {
+    return (
+      <Card className="text-center py-14">
+        <p className="text-sm text-muted">Loading…</p>
       </Card>
     );
   }
@@ -92,19 +98,19 @@ export default function ServiceDetailView({ slug }: Props) {
           <div className="flex items-center gap-4">
             <div
               className="w-16 h-16 rounded-2xl flex items-center justify-center text-white font-bold text-xl shadow-xl"
-              style={{ backgroundColor: config.color }}
+              style={{ backgroundColor: service.color }}
             >
-              {config.name.charAt(0)}
+              {service.name.charAt(0)}
             </div>
             <div>
               <p className="text-[11px] uppercase tracking-widest text-muted mb-1">
-                {config.fetcher} · {config.slug}
+                {service.slug}
               </p>
               <h1
                 className="text-3xl font-semibold text-foreground tracking-tight"
-                style={{ fontFamily: config.brandFont }}
+                style={{ fontFamily: service.brandFont }}
               >
-                {config.name}
+                {service.name}
               </h1>
               <div className="mt-3 flex items-center gap-3">
                 <StatusBadge status={heroStatus} size="md" />
@@ -116,7 +122,7 @@ export default function ServiceDetailView({ slug }: Props) {
           </div>
           <div className="flex items-center gap-2">
             <a
-              href={config.statusUrl}
+              href={service.statusUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-subtle text-xs text-foreground transition-colors"
@@ -126,8 +132,9 @@ export default function ServiceDetailView({ slug }: Props) {
                 <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
               </svg>
             </a>
+            {service.downdetectorUrl && (
             <a
-              href={`https://downdetector.com/status/${config.downdetectorSlug}/`}
+              href={service.downdetectorUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 border border-subtle text-xs text-foreground transition-colors"
@@ -137,6 +144,7 @@ export default function ServiceDetailView({ slug }: Props) {
                 <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
               </svg>
             </a>
+            )}
           </div>
         </div>
       </div>
@@ -171,8 +179,8 @@ export default function ServiceDetailView({ slug }: Props) {
       <section>
         <h2 className="text-base font-semibold text-foreground mb-3">History</h2>
         <OutageChart
-          serviceName={config.name}
-          serviceColor={config.color}
+          serviceName={service.name}
+          serviceColor={service.color}
           data={history}
         />
       </section>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { SERVICES } from '@/lib/services';
+import { useServiceStatus } from '@/hooks/useStatus';
 import {
   DEFAULT_PREFERENCES,
   Preferences,
@@ -62,6 +62,8 @@ export default function SettingsView() {
   const synced = usePreferences();
   const [prefs, setPrefs] = useState<Preferences>(synced);
   const [saved, setSaved] = useState(false);
+  const { data: statusData } = useServiceStatus();
+  const services = statusData?.services ?? [];
 
   // Reflect external preference changes (e.g. reset from another tab) into
   // local state so controls stay in sync with storage.
@@ -231,7 +233,7 @@ export default function SettingsView() {
           <span className="text-xs text-muted">{prefs.pinnedServices.length} pinned</span>
         </div>
         <div className="flex flex-wrap gap-2">
-          {SERVICES.map((s) => {
+          {services.map((s) => {
             const pinned = prefs.pinnedServices.includes(s.slug);
             return (
               <button

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useServiceStatus } from '@/hooks/useStatus';
-import { SERVICES } from '@/lib/services';
 import { useSidebar } from './SidebarContext';
 
 interface NavItem {
@@ -171,7 +170,7 @@ export default function Sidebar() {
             <span className={`text-xs font-medium ${health.tone}`}>{health.label}</span>
           </div>
           <div className="text-[11px] text-muted">
-            {operational}/{services.length || SERVICES.length} services operational
+            {operational}/{services.length || '—'} services operational
           </div>
           <div className="mt-2 w-full h-1 rounded-full bg-white/5 overflow-hidden">
             <div

--- a/src/components/SourcesView.tsx
+++ b/src/components/SourcesView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import useSWR from 'swr';
 import PageHeader from './ui/PageHeader';
 import ImportSlideOver from './ImportSlideOver';
 
@@ -14,11 +15,32 @@ interface ImportedSource {
   addedAt: string;
 }
 
-const PRESET_SOURCES: ImportedSource[] = [
-  { id: 'p1', type: 'statuspage', name: 'Atlassian Statuspage', url: 'https://status.atlassian.com',  color: '#0052CC', refresh: 60,  addedAt: '2026-05-01T10:00:00Z' },
-  { id: 'p2', type: 'statuspage', name: 'OpenAI',               url: 'https://status.openai.com',     color: '#10A37F', refresh: 60,  addedAt: '2026-05-03T14:22:00Z' },
-  { id: 'p3', type: 'rss',        name: "AWS What's New",       url: 'https://aws.amazon.com/new/feed/', color: '#FF9900', refresh: 300, addedAt: '2026-05-05T09:00:00Z' },
-];
+interface SourceRow {
+  id: string;
+  slug: string;
+  name: string;
+  color: string;
+  statusUrl: string;
+  downdetectorSlug: string | null;
+  fetcher: string;
+  kind: string;
+  refreshSeconds: number;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface SourcesResponse {
+  sources: SourceRow[];
+}
+
+const SOURCES_API = '/api/sources';
+
+const fetcher = async (url: string): Promise<SourcesResponse> => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+};
 
 const KIND_COLOR: Record<string, string> = {
   statuspage: 'rgba(38,139,210,0.15)',
@@ -44,19 +66,115 @@ function relTime(iso: string): string {
   return `${Math.round(diff / 86400)}d ago`;
 }
 
+function rowToView(row: SourceRow): ImportedSource {
+  return {
+    id: row.id,
+    type: row.kind,
+    name: row.name,
+    url: row.statusUrl,
+    refresh: row.refreshSeconds,
+    color: row.color,
+    addedAt: row.createdAt,
+  };
+}
+
 export default function SourcesView() {
-  const [sources, setSources] = useState<ImportedSource[]>(PRESET_SOURCES);
+  const { data, mutate } = useSWR<SourcesResponse>(SOURCES_API, fetcher, {
+    revalidateOnFocus: false,
+  });
+  const sourceRows = data?.sources ?? [];
+  const sources = sourceRows.map(rowToView);
   const [importOpen, setImportOpen] = useState(false);
   const [search, setSearch] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [contributeOpen, setContributeOpen] = useState(false);
+  const [contributing, setContributing] = useState(false);
+  const [contributeMessage, setContributeMessage] = useState<{ ok: boolean; text: string; url?: string } | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-  const handleAdd = (svc: { type: string; name: string; url: string; refresh: number; color: string }) => {
-    setSources((prev) => [
-      ...prev,
-      { id: 't' + Date.now(), ...svc, addedAt: new Date().toISOString() },
-    ]);
+  const openContribute = () => {
+    setContributeMessage(null);
+    setSelectedIds(new Set(sourceRows.filter((r) => r.enabled).map((r) => r.id)));
+    setContributeOpen(true);
   };
 
-  const handleRemove = (id: string) => setSources((prev) => prev.filter((s) => s.id !== id));
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const submitContribute = async () => {
+    setContributing(true);
+    setContributeMessage(null);
+    try {
+      const res = await fetch(`${SOURCES_API}/contribute`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: Array.from(selectedIds) }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (res.status === 503) {
+        setContributeMessage({ ok: false, text: body.error || 'Catalog contribution is not configured on this deployment.' });
+        return;
+      }
+      if (!res.ok) {
+        setContributeMessage({ ok: false, text: body.error || `Request failed (HTTP ${res.status})` });
+        return;
+      }
+      setContributeMessage({ ok: true, text: `Opened PR #${body.prNumber}`, url: body.prUrl });
+    } catch (err) {
+      setContributeMessage({ ok: false, text: err instanceof Error ? err.message : 'Network error' });
+    } finally {
+      setContributing(false);
+    }
+  };
+
+  const handleAdd = async (svc: { type: string; name: string; url: string; refresh: number; color: string }) => {
+    setError(null);
+    try {
+      const res = await fetch(SOURCES_API, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(svc),
+      });
+      if (res.status === 503) {
+        setError('Sources API is disabled on the server. Set ENABLE_RULES_API=true or configure CRON_SECRET.');
+        return;
+      }
+      if (res.status === 401) {
+        setError('Unauthorized. Set ENABLE_RULES_API=true on the server.');
+        return;
+      }
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body.error || `Request failed (HTTP ${res.status})`);
+        return;
+      }
+      mutate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error');
+    }
+  };
+
+  const handleRemove = async (id: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`${SOURCES_API}/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok && res.status !== 404) {
+        const body = await res.json().catch(() => ({}));
+        setError(body.error || `Delete failed (HTTP ${res.status})`);
+        return;
+      }
+      mutate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error');
+    }
+  };
 
   const filtered = sources.filter(
     (s) => !search || s.name.toLowerCase().includes(search.toLowerCase()) || s.url.toLowerCase().includes(search.toLowerCase())
@@ -69,14 +187,44 @@ export default function SourcesView() {
         title="Imported services"
         description="Manage RSS feeds, Statuspage integrations, and HTTP endpoints that power your board tiles."
         actions={
-          <button className="board-btn board-btn-primary" onClick={() => setImportOpen(true)}>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M12 5v14M5 12h14" />
-            </svg>
-            Add source
-          </button>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {sourceRows.length > 0 && (
+              <button
+                className="board-btn"
+                onClick={openContribute}
+                title="Open a pull request adding selected sources to the shared catalog on main"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M6 3v12M6 15a3 3 0 1 0 0 6 3 3 0 0 0 0-6zM6 3a3 3 0 1 0 0 6 3 3 0 0 0 0-6zM18 9v6M18 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM12 3h3a3 3 0 0 1 3 3v3" />
+                </svg>
+                Contribute to catalog
+              </button>
+            )}
+            <button className="board-btn board-btn-primary" onClick={() => setImportOpen(true)}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M12 5v14M5 12h14" />
+              </svg>
+              Add source
+            </button>
+          </div>
         }
       />
+
+      {error && (
+        <div
+          role="alert"
+          style={{
+            padding: '10px 14px',
+            borderRadius: 10,
+            background: 'rgba(220,50,47,0.10)',
+            border: '1px solid rgba(220,50,47,0.35)',
+            color: '#dc322f',
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
 
       {/* Search + count */}
       <div className="flex items-center gap-3">
@@ -220,6 +368,110 @@ export default function SourcesView() {
       )}
 
       <ImportSlideOver open={importOpen} onClose={() => setImportOpen(false)} onAdd={handleAdd} />
+
+      {contributeOpen && (
+        <>
+          <div className="slideover-backdrop" onClick={() => setContributeOpen(false)} />
+          <aside className="slideover" style={{ maxWidth: 520 }}>
+            <div className="slideover-header">
+              <div>
+                <div style={{ fontSize: 11, color: 'var(--muted-strong)', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 4 }}>
+                  Contribute
+                </div>
+                <h2 style={{ margin: 0, fontSize: 20, fontWeight: 700, color: 'var(--foreground)', letterSpacing: -0.2 }}>
+                  Open a pull request
+                </h2>
+              </div>
+              <button
+                style={{ width: 30, height: 30, background: 'transparent', border: 0, color: 'var(--muted)', borderRadius: 8, cursor: 'pointer' }}
+                onClick={() => setContributeOpen(false)}
+                aria-label="Close"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M18 6L6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="slideover-body" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <p style={{ fontSize: 13, color: 'var(--muted-strong)', margin: 0 }}>
+                Select the sources you want to add to the shared catalog. We&apos;ll
+                open a pull request against <code>main</code> updating
+                <code> src/lib/services.contributed.json</code>.
+              </p>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {sourceRows.map((row) => {
+                  const checked = selectedIds.has(row.id);
+                  return (
+                    <label
+                      key={row.id}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 10,
+                        padding: '10px 12px',
+                        background: 'var(--surface)',
+                        border: '1px solid var(--border-subtle)',
+                        borderRadius: 10,
+                        cursor: 'pointer',
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleSelected(row.id)}
+                      />
+                      <div style={{ width: 12, height: 12, borderRadius: 4, background: row.color }} />
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--foreground)' }}>{row.name}</div>
+                        <div style={{ fontSize: 11, color: 'var(--muted)' }}>{row.slug}</div>
+                      </div>
+                      <div style={{ fontSize: 11, color: 'var(--muted-strong)' }}>{row.kind}</div>
+                    </label>
+                  );
+                })}
+              </div>
+
+              {contributeMessage && (
+                <div
+                  role={contributeMessage.ok ? 'status' : 'alert'}
+                  style={{
+                    padding: '10px 14px',
+                    borderRadius: 10,
+                    background: contributeMessage.ok ? 'rgba(133,153,0,0.10)' : 'rgba(220,50,47,0.10)',
+                    border: `1px solid ${contributeMessage.ok ? 'rgba(133,153,0,0.35)' : 'rgba(220,50,47,0.35)'}`,
+                    color: contributeMessage.ok ? '#859900' : '#dc322f',
+                    fontSize: 13,
+                  }}
+                >
+                  {contributeMessage.text}
+                  {contributeMessage.ok && contributeMessage.url && (
+                    <>
+                      {' — '}
+                      <a href={contributeMessage.url} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>
+                        view PR
+                      </a>
+                    </>
+                  )}
+                </div>
+              )}
+
+              <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                <button className="board-btn" onClick={() => setContributeOpen(false)}>
+                  Close
+                </button>
+                <button
+                  className="board-btn board-btn-primary"
+                  disabled={contributing || selectedIds.size === 0}
+                  onClick={submitContribute}
+                >
+                  {contributing ? 'Opening PR…' : `Open PR (${selectedIds.size})`}
+                </button>
+              </div>
+            </div>
+          </aside>
+        </>
+      )}
     </div>
   );
 }

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -153,9 +153,20 @@ export interface UseBoardParams {
 }
 
 export function useBoard({ bp = 'desktop', boardId, tiles, onCommit }: UseBoardParams): [TileConfig[], BoardActions] {
+  // Use the parent's tiles array as-is for the initial present so that
+  // history.present and ownCommit.current share the same reference on mount.
+  // Previously the initial state called layout.compactDown(tiles), which
+  // returned a fresh array, so the post-mount onCommit effect saw
+  // history.present !== ownCommit.current and fired immediately — pushing
+  // compactDown(DEFAULT_TILES) into the parent before useBoardSet had
+  // finished hydrating from localStorage. That batched setActiveTiles
+  // landed after the hydration setState, overwriting the saved tiles on
+  // every page load. Saved boards are already in compacted form, and any
+  // user action (move, resize, tidy) re-runs compaction through
+  // runLayoutOp, so deferring the initial compaction is safe.
   const [history, setHistory] = useState<History>(() => ({
     past: [],
-    present: layout.compactDown(tiles),
+    present: tiles,
     future: [],
   }));
   const [lastTidyDelta, setLastTidyDelta] = useState<number | null>(null);
@@ -163,8 +174,9 @@ export function useBoard({ bp = 'desktop', boardId, tiles, onCommit }: UseBoardP
 
   // Track which tiles array reference came from our own commits, so we can
   // distinguish an external tiles change (active-board switch, import) from
-  // the parent echoing our last commit back at us.
-  const ownCommit = useRef<TileConfig[] | null>(null);
+  // the parent echoing our last commit back at us. Seeded with the initial
+  // tiles so the first onCommit-effect run is a no-op.
+  const ownCommit = useRef<TileConfig[] | null>(tiles);
   const lastBoardId = useRef(boardId);
 
   // External tiles change: either the active board id changed, or the parent

--- a/src/hooks/useBoardSet.ts
+++ b/src/hooks/useBoardSet.ts
@@ -94,8 +94,16 @@ export function useBoardSet(): UseBoardSet {
 
   useEffect(() => {
     const stored = readBoardSet();
-    const starred = stored.boards.find((b) => b.starred);
-    if (starred && stored.active !== starred.id) stored.active = starred.id;
+    // Honor the last-active board id from localStorage. The starred flag is a
+    // marker / sort hint, not a "snap back to me on every reload" instruction
+    // — previously this branch forced active = starred on every hydrate, so
+    // viewing board B and reloading would dump you back on starred board A.
+    // Only fall back to the starred id when the stored active no longer
+    // exists (e.g. it was deleted in another tab).
+    if (!stored.boards.some((b) => b.id === stored.active)) {
+      const starred = stored.boards.find((b) => b.starred);
+      stored.active = starred?.id ?? stored.boards[0].id;
+    }
     setState(stored);
     setHydrated(true);
   }, []);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -17,6 +17,11 @@ export function getDb(): Database.Database {
   db = new Database(DB_PATH);
   db.pragma('journal_mode = WAL');
   db.pragma('foreign_keys = ON');
+  // Wait up to 5 seconds when SQLite reports BUSY (e.g. the poll-cycle
+  // transaction overlapping VACUUM or a concurrent reader). Without this,
+  // writes from the poller can fail outright during the daily VACUUM and
+  // drop a poll cycle's worth of status updates.
+  db.pragma('busy_timeout = 5000');
 
   initTables(db);
   return db;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -93,6 +93,25 @@ function initTables(db: Database.Database) {
 
     CREATE INDEX IF NOT EXISTS idx_alert_rules_enabled
       ON alert_rules(enabled);
+
+    CREATE TABLE IF NOT EXISTS custom_services (
+      id TEXT PRIMARY KEY,
+      slug TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      color TEXT NOT NULL DEFAULT '#268bd2',
+      status_url TEXT NOT NULL,
+      downdetector_slug TEXT,
+      fetcher TEXT NOT NULL,
+      brand_font TEXT NOT NULL DEFAULT 'var(--font-brand-inter), Inter, system-ui, sans-serif',
+      refresh_seconds INTEGER NOT NULL DEFAULT 180,
+      kind TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+      updated_at DATETIME NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_custom_services_enabled
+      ON custom_services(enabled);
   `);
 
   // Safe migration for pre-existing databases — add incident_count if missing.
@@ -367,4 +386,140 @@ export function updateAlertRule(
 export function deleteAlertRule(id: string): boolean {
   const db = getDb();
   return db.prepare('DELETE FROM alert_rules WHERE id = ?').run(id).changes > 0;
+}
+
+export interface CustomServiceRow {
+  id: string;
+  slug: string;
+  name: string;
+  color: string;
+  status_url: string;
+  downdetector_slug: string | null;
+  fetcher: string;
+  brand_font: string;
+  refresh_seconds: number;
+  kind: string;
+  enabled: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export function listCustomServices(): CustomServiceRow[] {
+  const db = getDb();
+  return db.prepare(`
+    SELECT id, slug, name, color, status_url, downdetector_slug, fetcher,
+      brand_font, refresh_seconds, kind, enabled, created_at, updated_at
+    FROM custom_services
+    ORDER BY created_at DESC
+  `).all() as CustomServiceRow[];
+}
+
+export function listEnabledCustomServices(): CustomServiceRow[] {
+  const db = getDb();
+  return db.prepare(`
+    SELECT id, slug, name, color, status_url, downdetector_slug, fetcher,
+      brand_font, refresh_seconds, kind, enabled, created_at, updated_at
+    FROM custom_services
+    WHERE enabled = 1
+    ORDER BY created_at DESC
+  `).all() as CustomServiceRow[];
+}
+
+export function getCustomServiceById(id: string): CustomServiceRow | null {
+  const db = getDb();
+  const row = db.prepare(`
+    SELECT id, slug, name, color, status_url, downdetector_slug, fetcher,
+      brand_font, refresh_seconds, kind, enabled, created_at, updated_at
+    FROM custom_services WHERE id = ?
+  `).get(id) as CustomServiceRow | undefined;
+  return row ?? null;
+}
+
+export function getCustomServiceBySlug(slug: string): CustomServiceRow | null {
+  const db = getDb();
+  const row = db.prepare(`
+    SELECT id, slug, name, color, status_url, downdetector_slug, fetcher,
+      brand_font, refresh_seconds, kind, enabled, created_at, updated_at
+    FROM custom_services WHERE slug = ?
+  `).get(slug) as CustomServiceRow | undefined;
+  return row ?? null;
+}
+
+export function insertCustomService(row: {
+  id: string;
+  slug: string;
+  name: string;
+  color: string;
+  statusUrl: string;
+  downdetectorSlug: string | null;
+  fetcher: string;
+  brandFont: string;
+  refreshSeconds: number;
+  kind: string;
+  enabled: boolean;
+}) {
+  const db = getDb();
+  db.prepare(`
+    INSERT INTO custom_services (id, slug, name, color, status_url,
+      downdetector_slug, fetcher, brand_font, refresh_seconds, kind, enabled)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    row.id,
+    row.slug,
+    row.name,
+    row.color,
+    row.statusUrl,
+    row.downdetectorSlug,
+    row.fetcher,
+    row.brandFont,
+    row.refreshSeconds,
+    row.kind,
+    row.enabled ? 1 : 0,
+  );
+}
+
+export function updateCustomService(
+  id: string,
+  patch: Partial<{
+    name: string;
+    color: string;
+    statusUrl: string;
+    downdetectorSlug: string | null;
+    refreshSeconds: number;
+    enabled: boolean;
+  }>,
+): boolean {
+  const db = getDb();
+  const fields: string[] = [];
+  const values: Array<string | number | null> = [];
+  if (patch.name !== undefined) { fields.push('name = ?'); values.push(patch.name); }
+  if (patch.color !== undefined) { fields.push('color = ?'); values.push(patch.color); }
+  if (patch.statusUrl !== undefined) { fields.push('status_url = ?'); values.push(patch.statusUrl); }
+  if (patch.downdetectorSlug !== undefined) { fields.push('downdetector_slug = ?'); values.push(patch.downdetectorSlug); }
+  if (patch.refreshSeconds !== undefined) { fields.push('refresh_seconds = ?'); values.push(patch.refreshSeconds); }
+  if (patch.enabled !== undefined) { fields.push('enabled = ?'); values.push(patch.enabled ? 1 : 0); }
+  if (fields.length === 0) return false;
+  fields.push(`updated_at = datetime('now')`);
+  values.push(id);
+  const result = db.prepare(`UPDATE custom_services SET ${fields.join(', ')} WHERE id = ?`).run(...values);
+  return result.changes > 0;
+}
+
+export function deleteCustomService(id: string): boolean {
+  const db = getDb();
+  return db.prepare('DELETE FROM custom_services WHERE id = ?').run(id).changes > 0;
+}
+
+// Drop status, history, and incident rows for a service slug. Called when a
+// custom service is removed so a future slug re-use doesn't inherit the
+// previous service's history. Wrapped in a transaction so partial failure
+// leaves no half-deleted state.
+export function cleanupServiceData(slug: string): void {
+  const db = getDb();
+  const tx = db.transaction((s: string) => {
+    db.prepare('DELETE FROM service_status WHERE service_slug = ?').run(s);
+    db.prepare('DELETE FROM status_history WHERE service_slug = ?').run(s);
+    db.prepare('DELETE FROM incidents WHERE service_slug = ?').run(s);
+  });
+  tx(slug);
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -3,6 +3,7 @@ import { hasRecentAlert, logAlert } from './db';
 import { getServiceBySlug } from './services';
 import { IncidentResult, ServiceStatus } from './types';
 import { statusHex, statusLabel } from './statusColors';
+import { metrics } from './metrics';
 
 function escapeHtml(value: unknown): string {
   return String(value ?? '')
@@ -115,6 +116,7 @@ export async function sendIncidentAlert(
     });
 
     logAlert(incident.serviceSlug, incident.incidentId, 'new_incident');
+    metrics.recordAlertSent('email', incident.severity);
     console.log(`[email] Alert sent for ${serviceName}: ${incident.title}`);
     return true;
   } catch (err) {
@@ -229,6 +231,7 @@ export async function sendStatusChangeAlert(
     });
 
     logAlert(serviceSlug, null, 'status_change');
+    metrics.recordAlertSent('email', `status_change:${newStatus}`);
     return true;
   } catch (err) {
     console.error('[email] Failed to send status change alert:', err);

--- a/src/lib/fetchers/aws.ts
+++ b/src/lib/fetchers/aws.ts
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import crypto from 'crypto';
 import { FetchResult, StatusResult, IncidentResult, ServiceStatus } from '../types';
+import { httpFetch } from './httpFetch';
 
 const AWS_RSS_URL = 'https://health.aws.amazon.com/health/status/feed';
 const AWS_SOURCE_URL = 'https://health.aws.amazon.com/health/status';
@@ -22,12 +23,12 @@ export async function fetchAwsStatus(serviceSlug: string): Promise<FetchResult> 
   const incidents: IncidentResult[] = [];
 
   try {
-    const res = await fetch(AWS_RSS_URL, {
+    const res = await httpFetch(AWS_RSS_URL, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (compatible; OutageMap/1.0)',
         'Accept': 'application/rss+xml, application/xml, text/xml',
       },
-      signal: AbortSignal.timeout(15000),
+      timeoutMs: 15000,
     });
 
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/src/lib/fetchers/circuit.ts
+++ b/src/lib/fetchers/circuit.ts
@@ -1,0 +1,91 @@
+// Per-(service, source) circuit breaker. Stops the poller from hammering an
+// upstream that has been failing repeatedly. State transitions:
+//
+//   closed  → open  : after FAILURE_THRESHOLD consecutive failures
+//   open    → half-open : after a cooldown that doubles on each open→reopen
+//   half-open → closed : on success of the probe call
+//   half-open → open  : if the probe also fails (cooldown doubles, capped)
+//
+// "Failure" is anything that produces a StatusResult.status === 'unknown',
+// matching the existing health-tracker semantics in src/lib/health.ts.
+
+export type CircuitState = 'closed' | 'open' | 'half-open';
+
+interface CircuitEntry {
+  state: CircuitState;
+  failures: number;
+  openedAt: number | null;
+  cooldownMs: number;
+}
+
+const FAILURE_THRESHOLD = parseInt(process.env.CIRCUIT_FAILURE_THRESHOLD || '5', 10);
+const BASE_COOLDOWN_MS = 5 * 60 * 1000;
+const MAX_COOLDOWN_MS = 80 * 60 * 1000;
+
+const state = new Map<string, CircuitEntry>();
+
+function key(service: string, source: string): string {
+  return `${service}:${source}`;
+}
+
+function getOrInit(service: string, source: string): CircuitEntry {
+  const k = key(service, source);
+  let entry = state.get(k);
+  if (!entry) {
+    entry = { state: 'closed', failures: 0, openedAt: null, cooldownMs: BASE_COOLDOWN_MS };
+    state.set(k, entry);
+  }
+  return entry;
+}
+
+export const circuit = {
+  // Should the next call proceed? Returns 'allow' for closed / half-open,
+  // 'block' when the circuit is open and the cooldown hasn't elapsed. Calling
+  // this transitions open→half-open when the cooldown is up so the next call
+  // becomes the probe.
+  shouldAttempt(service: string, source: string): 'allow' | 'block' {
+    const entry = getOrInit(service, source);
+    if (entry.state === 'closed' || entry.state === 'half-open') return 'allow';
+    if (entry.openedAt !== null && Date.now() - entry.openedAt >= entry.cooldownMs) {
+      entry.state = 'half-open';
+      return 'allow';
+    }
+    return 'block';
+  },
+
+  recordSuccess(service: string, source: string) {
+    const entry = getOrInit(service, source);
+    entry.state = 'closed';
+    entry.failures = 0;
+    entry.openedAt = null;
+    entry.cooldownMs = BASE_COOLDOWN_MS;
+  },
+
+  recordFailure(service: string, source: string) {
+    const entry = getOrInit(service, source);
+    if (entry.state === 'half-open') {
+      // Probe failed — re-open with a longer cooldown.
+      entry.state = 'open';
+      entry.failures += 1;
+      entry.openedAt = Date.now();
+      entry.cooldownMs = Math.min(entry.cooldownMs * 2, MAX_COOLDOWN_MS);
+      return;
+    }
+    entry.failures += 1;
+    if (entry.failures >= Math.max(FAILURE_THRESHOLD, 1)) {
+      entry.state = 'open';
+      entry.openedAt = Date.now();
+      entry.cooldownMs = BASE_COOLDOWN_MS;
+    }
+  },
+
+  getState(service: string, source: string): CircuitState {
+    return getOrInit(service, source).state;
+  },
+
+  openUntil(service: string, source: string): number | null {
+    const entry = getOrInit(service, source);
+    if (entry.state !== 'open' || entry.openedAt === null) return null;
+    return entry.openedAt + entry.cooldownMs;
+  },
+};

--- a/src/lib/fetchers/circuit.ts
+++ b/src/lib/fetchers/circuit.ts
@@ -18,22 +18,42 @@ interface CircuitEntry {
   cooldownMs: number;
 }
 
-const FAILURE_THRESHOLD = parseInt(process.env.CIRCUIT_FAILURE_THRESHOLD || '5', 10);
 const BASE_COOLDOWN_MS = 5 * 60 * 1000;
 const MAX_COOLDOWN_MS = 80 * 60 * 1000;
 
-const state = new Map<string, CircuitEntry>();
+function failureThreshold(): number {
+  const n = parseInt(process.env.CIRCUIT_FAILURE_THRESHOLD || '5', 10);
+  return Number.isFinite(n) && n > 0 ? n : 5;
+}
+
+// Next.js' standalone build splits modules across chunks (one bundled into
+// the poller graph, another into /api/metrics), giving each its own
+// module-level state. Pin the state map to globalThis so every chunk in the
+// same Node process sees the same circuit state.
+const GLOBAL_KEY = Symbol.for('outage-map.circuit-state');
+type GlobalWithState = typeof globalThis & { [GLOBAL_KEY]?: Map<string, CircuitEntry> };
+
+function getStateMap(): Map<string, CircuitEntry> {
+  const g = globalThis as GlobalWithState;
+  let s = g[GLOBAL_KEY];
+  if (!s) {
+    s = new Map<string, CircuitEntry>();
+    g[GLOBAL_KEY] = s;
+  }
+  return s;
+}
 
 function key(service: string, source: string): string {
   return `${service}:${source}`;
 }
 
 function getOrInit(service: string, source: string): CircuitEntry {
+  const s = getStateMap();
   const k = key(service, source);
-  let entry = state.get(k);
+  let entry = s.get(k);
   if (!entry) {
     entry = { state: 'closed', failures: 0, openedAt: null, cooldownMs: BASE_COOLDOWN_MS };
-    state.set(k, entry);
+    s.set(k, entry);
   }
   return entry;
 }
@@ -72,7 +92,7 @@ export const circuit = {
       return;
     }
     entry.failures += 1;
-    if (entry.failures >= Math.max(FAILURE_THRESHOLD, 1)) {
+    if (entry.failures >= failureThreshold()) {
       entry.state = 'open';
       entry.openedAt = Date.now();
       entry.cooldownMs = BASE_COOLDOWN_MS;

--- a/src/lib/fetchers/downdetector.ts
+++ b/src/lib/fetchers/downdetector.ts
@@ -1,5 +1,6 @@
 import * as cheerio from 'cheerio';
 import { StatusResult, ServiceStatus } from '../types';
+import { httpFetch } from './httpFetch';
 
 const USER_AGENTS = [
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
@@ -50,14 +51,14 @@ export async function fetchDowndetectorStatus(
   }
 
   try {
-    const res = await fetch(`https://downdetector.com/status/${slug}/`, {
+    const res = await httpFetch(`https://downdetector.com/status/${slug}/`, {
       headers: {
         'User-Agent': getRandomUA(),
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'Accept-Language': 'en-US,en;q=0.9',
         'Cache-Control': 'no-cache',
       },
-      signal: AbortSignal.timeout(15000),
+      timeoutMs: 15000,
     });
 
     if (!res.ok) {

--- a/src/lib/fetchers/downdetector.ts
+++ b/src/lib/fetchers/downdetector.ts
@@ -22,7 +22,7 @@ function reportCountToStatus(count: number): ServiceStatus {
 }
 
 export async function fetchDowndetectorStatus(
-  slug: string,
+  slug: string | null,
   serviceSlug: string
 ): Promise<StatusResult> {
   const result: StatusResult = {
@@ -32,6 +32,15 @@ export async function fetchDowndetectorStatus(
     details: null,
     reportCount: null,
   };
+
+  if (!slug) {
+    // Custom services may not have a Downdetector counterpart. Report
+    // operational with a clear note so the UI doesn't render "unknown".
+    result.status = 'operational';
+    result.details = 'No Downdetector slug configured';
+    result.reportCount = 0;
+    return result;
+  }
 
   if (process.env.DOWNDETECTOR_ENABLED === 'false') {
     result.status = 'operational';

--- a/src/lib/fetchers/google.ts
+++ b/src/lib/fetchers/google.ts
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import crypto from 'crypto';
 import { FetchResult, StatusResult, IncidentResult, ServiceStatus } from '../types';
+import { httpFetch } from './httpFetch';
 
 const DASHBOARD_URL = 'https://www.google.com/appsstatus/dashboard/';
 const INCIDENTS_URL = 'https://www.google.com/appsstatus/dashboard/incidents.json';
@@ -45,12 +46,12 @@ function hashId(seed: string): string {
 
 async function fetchIncidentsJson(): Promise<GoogleIncident[] | null> {
   try {
-    const res = await fetch(INCIDENTS_URL, {
+    const res = await httpFetch(INCIDENTS_URL, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
         'Accept': 'application/json, text/plain, */*',
       },
-      signal: AbortSignal.timeout(15000),
+      timeoutMs: 15000,
     });
     if (!res.ok) return null;
     const data = await res.json();
@@ -148,12 +149,12 @@ export async function fetchGoogleStatus(serviceSlug: string): Promise<FetchResul
   // whole status to major_outage when generic text (e.g. "Report a disruption"
   // in the page chrome) matches the regex.
   try {
-    const res = await fetch(DASHBOARD_URL, {
+    const res = await httpFetch(DASHBOARD_URL, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
         'Accept': 'text/html,application/xhtml+xml',
       },
-      signal: AbortSignal.timeout(15000),
+      timeoutMs: 15000,
     });
 
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/src/lib/fetchers/httpFetch.ts
+++ b/src/lib/fetchers/httpFetch.ts
@@ -1,0 +1,99 @@
+// Shared HTTP helper for every fetcher. Wraps `fetch` with:
+//
+// 1. A configurable timeout via AbortSignal.timeout (default FETCH_TIMEOUT_MS).
+// 2. Retries on transient failures (network errors, 5xx, 429) with full-jitter
+//    exponential backoff. Caller-side 4xx (other than 429) is not retried —
+//    those are bugs in our request, not transient.
+// 3. Honoring `Retry-After` on 429 when present.
+//
+// Each individual attempt uses its own AbortSignal so the timeout resets per
+// retry. The total wall-clock for a call is therefore bounded by
+// `(timeoutMs + maxBackoffMs) × (maxRetries + 1)`.
+
+export interface HttpFetchOptions extends Omit<RequestInit, 'signal'> {
+  timeoutMs?: number;
+  maxRetries?: number;
+  // Override the default 200ms base for the backoff curve.
+  baseBackoffMs?: number;
+}
+
+const DEFAULT_BASE_BACKOFF_MS = 200;
+const MAX_BACKOFF_MS = 8000;
+
+function envInt(name: string, fallback: number, min: number, max: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(n, min), max);
+}
+
+function isTransientStatus(status: number): boolean {
+  if (status === 429) return true;
+  if (status >= 500 && status <= 599) return true;
+  return false;
+}
+
+function fullJitter(base: number, attempt: number): number {
+  const exp = Math.min(base * 2 ** attempt, MAX_BACKOFF_MS);
+  return Math.floor(Math.random() * exp);
+}
+
+function parseRetryAfter(header: string | null): number | null {
+  if (!header) return null;
+  const asInt = parseInt(header, 10);
+  if (Number.isFinite(asInt) && asInt >= 0) return asInt * 1000;
+  const asDate = Date.parse(header);
+  if (Number.isFinite(asDate)) {
+    const delta = asDate - Date.now();
+    return delta > 0 ? delta : 0;
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function httpFetch(input: string, init: HttpFetchOptions = {}): Promise<Response> {
+  const { timeoutMs, maxRetries, baseBackoffMs, ...rest } = init;
+  const timeout = timeoutMs ?? envInt('FETCH_TIMEOUT_MS', 12000, 1000, 60000);
+  const retries = maxRetries ?? envInt('FETCH_MAX_RETRIES', 2, 0, 5);
+  const base = baseBackoffMs ?? DEFAULT_BASE_BACKOFF_MS;
+
+  let attempt = 0;
+  let lastError: unknown = null;
+
+  while (attempt <= retries) {
+    try {
+      const res = await fetch(input, {
+        ...rest,
+        signal: AbortSignal.timeout(timeout),
+      });
+
+      if (!isTransientStatus(res.status) || attempt === retries) {
+        return res;
+      }
+
+      // Transient — drain the body to free the socket, then back off.
+      try {
+        await res.arrayBuffer();
+      } catch {
+        // ignore
+      }
+
+      const retryAfter = parseRetryAfter(res.headers.get('Retry-After'));
+      const delay = retryAfter !== null ? Math.min(retryAfter, MAX_BACKOFF_MS) : fullJitter(base, attempt);
+      await sleep(delay);
+    } catch (err) {
+      lastError = err;
+      if (attempt === retries) throw err;
+      const delay = fullJitter(base, attempt);
+      await sleep(delay);
+    }
+    attempt += 1;
+  }
+
+  // Unreachable — the loop returns or throws — but TypeScript needs a value.
+  throw lastError instanceof Error ? lastError : new Error('httpFetch exhausted retries');
+}

--- a/src/lib/fetchers/microsoft.ts
+++ b/src/lib/fetchers/microsoft.ts
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import crypto from 'crypto';
 import { FetchResult, StatusResult, IncidentResult, ServiceStatus } from '../types';
+import { httpFetch } from './httpFetch';
 
 function parseStatusFromText(text: string): ServiceStatus {
   const lower = text.toLowerCase();
@@ -73,12 +74,12 @@ async function fetchSource(source: MsSource, serviceSlug: string): Promise<Sourc
   };
 
   try {
-    const res = await fetch(source.url, {
+    const res = await httpFetch(source.url, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
         'Accept': 'text/html,application/xhtml+xml',
       },
-      signal: AbortSignal.timeout(15000),
+      timeoutMs: 15000,
     });
 
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/src/lib/fetchers/salesforce.ts
+++ b/src/lib/fetchers/salesforce.ts
@@ -1,4 +1,5 @@
 import { FetchResult, StatusResult, IncidentResult, ServiceStatus, IncidentSeverity } from '../types';
+import { httpFetch } from './httpFetch';
 
 interface SalesforceIncident {
   id: string;
@@ -46,12 +47,12 @@ export async function fetchSalesforceStatus(serviceSlug: string): Promise<FetchR
 
   try {
     // Fetch general status from the Salesforce Trust API
-    const statusRes = await fetch('https://api.status.salesforce.com/v1/incidents/active', {
+    const statusRes = await httpFetch('https://api.status.salesforce.com/v1/incidents/active', {
       headers: {
         'Accept': 'application/json',
         'User-Agent': 'OutageDashboard/1.0',
       },
-      signal: AbortSignal.timeout(10000),
+      timeoutMs: 10000,
     });
 
     if (statusRes.ok) {
@@ -104,9 +105,9 @@ export async function fetchSalesforceStatus(serviceSlug: string): Promise<FetchR
 
     // Fallback: try the main incidents endpoint
     try {
-      const fallbackRes = await fetch('https://api.status.salesforce.com/v1/incidents?limit=5', {
+      const fallbackRes = await httpFetch('https://api.status.salesforce.com/v1/incidents?limit=5', {
         headers: { 'Accept': 'application/json' },
-        signal: AbortSignal.timeout(10000),
+        timeoutMs: 10000,
       });
 
       if (fallbackRes.ok) {

--- a/src/lib/fetchers/statuspage.ts
+++ b/src/lib/fetchers/statuspage.ts
@@ -1,4 +1,5 @@
 import { FetchResult, StatusResult, IncidentResult, ServiceStatus, IncidentSeverity, IncidentStatus } from '../types';
+import { httpFetch } from './httpFetch';
 
 interface StatuspageStatus {
   status: {
@@ -72,13 +73,13 @@ export async function fetchStatuspageStatus(baseUrl: string, serviceSlug: string
   // actual service disruption exists. If unresolved incidents are empty while the
   // indicator says "minor", we downgrade to operational.
   const [statusRes, unresolvedRes] = await Promise.allSettled([
-    fetch(`${baseUrl}/api/v2/status.json`, {
+    httpFetch(`${baseUrl}/api/v2/status.json`, {
       headers: { 'Accept': 'application/json' },
-      signal: AbortSignal.timeout(10000),
+      timeoutMs: 10000,
     }),
-    fetch(`${baseUrl}/api/v2/incidents/unresolved.json`, {
+    httpFetch(`${baseUrl}/api/v2/incidents/unresolved.json`, {
       headers: { 'Accept': 'application/json' },
-      signal: AbortSignal.timeout(10000),
+      timeoutMs: 10000,
     }),
   ]);
 
@@ -113,9 +114,9 @@ export async function fetchStatuspageStatus(baseUrl: string, serviceSlug: string
 
   // Fetch all recent incidents for display (includes resolved).
   try {
-    const incidentsRes = await fetch(`${baseUrl}/api/v2/incidents.json`, {
+    const incidentsRes = await httpFetch(`${baseUrl}/api/v2/incidents.json`, {
       headers: { 'Accept': 'application/json' },
-      signal: AbortSignal.timeout(10000),
+      timeoutMs: 10000,
     });
 
     if (incidentsRes.ok) {

--- a/src/lib/fetchers/workday.ts
+++ b/src/lib/fetchers/workday.ts
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import crypto from 'crypto';
 import { FetchResult, StatusResult, IncidentResult, ServiceStatus } from '../types';
+import { httpFetch } from './httpFetch';
 
 export async function fetchWorkdayStatus(serviceSlug: string): Promise<FetchResult> {
   const statusResult: StatusResult = {
@@ -13,12 +14,12 @@ export async function fetchWorkdayStatus(serviceSlug: string): Promise<FetchResu
   const incidents: IncidentResult[] = [];
 
   try {
-    const res = await fetch('https://status.workday.com/', {
+    const res = await httpFetch('https://status.workday.com/', {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
         'Accept': 'text/html,application/xhtml+xml',
       },
-      signal: AbortSignal.timeout(15000),
+      timeoutMs: 15000,
     });
 
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -22,11 +22,27 @@ function key(service: string, source: Source): string {
   return `${service}:${source}`;
 }
 
-const state = new Map<string, FetcherHealth>();
+// Pin the state map to globalThis for the same reason metrics.ts does — the
+// standalone Next build can otherwise hand each chunk its own empty Map.
+const GLOBAL_KEY = Symbol.for('outage-map.fetcher-health');
+type GlobalWithHealth = typeof globalThis & {
+  [GLOBAL_KEY]?: Map<string, FetcherHealth>;
+};
+
+function state(): Map<string, FetcherHealth> {
+  const g = globalThis as GlobalWithHealth;
+  let m = g[GLOBAL_KEY];
+  if (!m) {
+    m = new Map();
+    g[GLOBAL_KEY] = m;
+  }
+  return m;
+}
 
 function getOrInit(service: string, source: Source): FetcherHealth {
   const k = key(service, source);
-  let entry = state.get(k);
+  const map = state();
+  let entry = map.get(k);
   if (!entry) {
     entry = {
       service,
@@ -37,7 +53,7 @@ function getOrInit(service: string, source: Source): FetcherHealth {
       lastLatencyMs: null,
       consecutiveFailures: 0,
     };
-    state.set(k, entry);
+    map.set(k, entry);
   }
   return entry;
 }
@@ -79,7 +95,7 @@ export const health = {
   isReady(): { ready: boolean; reason: string | null } {
     const threshold = readyThreshold();
     let failing: FetcherHealth | null = null;
-    state.forEach((entry) => {
+    state().forEach((entry) => {
       if (!failing && entry.consecutiveFailures >= threshold) {
         failing = entry;
       }

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -4,7 +4,7 @@
 // failure / latency for each (service, source) so an operator can see at a
 // glance which sources are stale, and so /api/health?probe=ready can fail
 // loudly when a fetcher has been broken for too long.
-import { SERVICES } from './services';
+import { getServices } from './services';
 
 type Source = 'official' | 'downdetector';
 
@@ -85,7 +85,7 @@ export const health = {
     // Always include an entry per known service+source so the UI / scraper
     // can show "never run yet" instead of a missing row on a fresh boot.
     const out: FetcherHealth[] = [];
-    for (const service of SERVICES) {
+    for (const service of getServices()) {
       for (const source of ['official', 'downdetector'] as Source[]) {
         out.push(getOrInit(service.slug, source));
       }

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -1,0 +1,98 @@
+// Per-fetcher health tracker. Today a single broken fetcher is hidden by the
+// success of the other 13: /api/status looks fine because the cached row from
+// before the break is still there. This module records the last success /
+// failure / latency for each (service, source) so an operator can see at a
+// glance which sources are stale, and so /api/health?probe=ready can fail
+// loudly when a fetcher has been broken for too long.
+import { SERVICES } from './services';
+
+type Source = 'official' | 'downdetector';
+
+interface FetcherHealth {
+  service: string;
+  source: Source;
+  lastSuccessAt: number | null;
+  lastErrorAt: number | null;
+  lastError: string | null;
+  lastLatencyMs: number | null;
+  consecutiveFailures: number;
+}
+
+function key(service: string, source: Source): string {
+  return `${service}:${source}`;
+}
+
+const state = new Map<string, FetcherHealth>();
+
+function getOrInit(service: string, source: Source): FetcherHealth {
+  const k = key(service, source);
+  let entry = state.get(k);
+  if (!entry) {
+    entry = {
+      service,
+      source,
+      lastSuccessAt: null,
+      lastErrorAt: null,
+      lastError: null,
+      lastLatencyMs: null,
+      consecutiveFailures: 0,
+    };
+    state.set(k, entry);
+  }
+  return entry;
+}
+
+function readyThreshold(): number {
+  const raw = parseInt(process.env.READY_FAILURE_THRESHOLD || '5', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 5;
+}
+
+function truncate(s: string, max: number = 240): string {
+  return s.length > max ? `${s.slice(0, max)}…` : s;
+}
+
+export const health = {
+  recordSuccess(service: string, source: Source, latencyMs: number) {
+    const entry = getOrInit(service, source);
+    entry.lastSuccessAt = Date.now();
+    entry.lastLatencyMs = latencyMs;
+    entry.consecutiveFailures = 0;
+  },
+  recordFailure(service: string, source: Source, error: unknown, latencyMs: number | null = null) {
+    const entry = getOrInit(service, source);
+    entry.lastErrorAt = Date.now();
+    entry.lastError = truncate(error instanceof Error ? error.message : String(error));
+    if (latencyMs !== null) entry.lastLatencyMs = latencyMs;
+    entry.consecutiveFailures += 1;
+  },
+  snapshot(): FetcherHealth[] {
+    // Always include an entry per known service+source so the UI / scraper
+    // can show "never run yet" instead of a missing row on a fresh boot.
+    const out: FetcherHealth[] = [];
+    for (const service of SERVICES) {
+      for (const source of ['official', 'downdetector'] as Source[]) {
+        out.push(getOrInit(service.slug, source));
+      }
+    }
+    return out;
+  },
+  isReady(): { ready: boolean; reason: string | null } {
+    const threshold = readyThreshold();
+    let failing: FetcherHealth | null = null;
+    state.forEach((entry) => {
+      if (!failing && entry.consecutiveFailures >= threshold) {
+        failing = entry;
+      }
+    });
+    if (failing) {
+      const f = failing as FetcherHealth;
+      return {
+        ready: false,
+        reason: `${f.service}:${f.source} has failed ${f.consecutiveFailures} consecutive cycles`,
+      };
+    }
+    return { ready: true, reason: null };
+  },
+};
+
+export type { FetcherHealth, Source as HealthSource };

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -155,8 +155,15 @@ interface Registry {
   serviceStatus: Gauge;
   lastPollTimestamp: Gauge;
   lastPollAge: Gauge;
+  circuitState: Gauge;
   lastPollAt: number | null;
 }
+
+const CIRCUIT_CODE: Record<'closed' | 'half-open' | 'open', number> = {
+  closed: 0,
+  'half-open': 1,
+  open: 2,
+};
 
 type GlobalWithRegistry = typeof globalThis & { [GLOBAL_KEY]?: Registry };
 
@@ -199,6 +206,10 @@ function getRegistry(): Registry {
         'outage_last_poll_age_seconds',
         'Seconds since the last completed poll cycle',
       ),
+      circuitState: new Gauge(
+        'outage_fetcher_circuit_state',
+        'Per-fetcher circuit breaker state (0=closed, 1=half-open, 2=open)',
+      ),
       lastPollAt: null,
     };
     g[GLOBAL_KEY] = r;
@@ -228,6 +239,9 @@ export const metrics = {
   setServiceStatus(service: string, source: string, status: ServiceStatus) {
     getRegistry().serviceStatus.set({ service, source }, STATUS_CODE[status]);
   },
+  setCircuitState(service: string, source: string, state: 'closed' | 'half-open' | 'open') {
+    getRegistry().circuitState.set({ service, source }, CIRCUIT_CODE[state]);
+  },
   expose(): string {
     const r = getRegistry();
     if (r.lastPollAt !== null) {
@@ -242,6 +256,7 @@ export const metrics = {
       r.serviceStatus.expose(),
       r.lastPollTimestamp.expose(),
       r.lastPollAge.expose(),
+      r.circuitState.expose(),
       '',
     ].join('\n');
   },

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,0 +1,222 @@
+// In-memory Prometheus-style metrics registry. Intentionally dependency-free
+// to avoid adding 1.5MB of prom-client to the bundle for what is, in practice,
+// ~10 series. Exposition follows the text format documented at
+// https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
+//
+// State is per-process. The poller pins to a single node-cron instance, so
+// scrape results are coherent without cross-process aggregation.
+import { ServiceStatus } from './types';
+
+type Labels = Record<string, string>;
+
+function labelKey(labels: Labels): string {
+  const keys = Object.keys(labels).sort();
+  return keys.map((k) => `${k}=${labels[k]}`).join(',');
+}
+
+function formatLabels(labels: Labels): string {
+  const keys = Object.keys(labels).sort();
+  if (keys.length === 0) return '';
+  const parts = keys.map((k) => `${k}="${escapeLabelValue(labels[k])}"`);
+  return `{${parts.join(',')}}`;
+}
+
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/"/g, '\\"');
+}
+
+interface CounterSeries {
+  labels: Labels;
+  value: number;
+}
+
+class Counter {
+  private series = new Map<string, CounterSeries>();
+
+  constructor(readonly name: string, readonly help: string) {}
+
+  inc(labels: Labels = {}, delta: number = 1) {
+    const key = labelKey(labels);
+    const existing = this.series.get(key);
+    if (existing) {
+      existing.value += delta;
+    } else {
+      this.series.set(key, { labels: { ...labels }, value: delta });
+    }
+  }
+
+  expose(): string {
+    const lines = [`# HELP ${this.name} ${this.help}`, `# TYPE ${this.name} counter`];
+    this.series.forEach((series) => {
+      lines.push(`${this.name}${formatLabels(series.labels)} ${series.value}`);
+    });
+    return lines.join('\n');
+  }
+}
+
+interface GaugeSeries {
+  labels: Labels;
+  value: number;
+}
+
+class Gauge {
+  private series = new Map<string, GaugeSeries>();
+
+  constructor(readonly name: string, readonly help: string) {}
+
+  set(labels: Labels, value: number) {
+    const key = labelKey(labels);
+    this.series.set(key, { labels: { ...labels }, value });
+  }
+
+  expose(): string {
+    const lines = [`# HELP ${this.name} ${this.help}`, `# TYPE ${this.name} gauge`];
+    this.series.forEach((series) => {
+      lines.push(`${this.name}${formatLabels(series.labels)} ${series.value}`);
+    });
+    return lines.join('\n');
+  }
+}
+
+interface HistogramSeries {
+  labels: Labels;
+  buckets: number[];
+  sum: number;
+  count: number;
+}
+
+class Histogram {
+  private series = new Map<string, HistogramSeries>();
+
+  constructor(
+    readonly name: string,
+    readonly help: string,
+    readonly bucketBounds: number[],
+  ) {}
+
+  observe(labels: Labels, value: number) {
+    const key = labelKey(labels);
+    let series = this.series.get(key);
+    if (!series) {
+      series = {
+        labels: { ...labels },
+        buckets: new Array(this.bucketBounds.length).fill(0),
+        sum: 0,
+        count: 0,
+      };
+      this.series.set(key, series);
+    }
+    series.sum += value;
+    series.count += 1;
+    for (let i = 0; i < this.bucketBounds.length; i++) {
+      if (value <= this.bucketBounds[i]) series.buckets[i] += 1;
+    }
+  }
+
+  expose(): string {
+    const lines = [`# HELP ${this.name} ${this.help}`, `# TYPE ${this.name} histogram`];
+    this.series.forEach((series) => {
+      for (let i = 0; i < this.bucketBounds.length; i++) {
+        const le = this.bucketBounds[i];
+        const bucketLabels = { ...series.labels, le: String(le) };
+        lines.push(`${this.name}_bucket${formatLabels(bucketLabels)} ${series.buckets[i]}`);
+      }
+      const infLabels = { ...series.labels, le: '+Inf' };
+      lines.push(`${this.name}_bucket${formatLabels(infLabels)} ${series.count}`);
+      lines.push(`${this.name}_sum${formatLabels(series.labels)} ${series.sum}`);
+      lines.push(`${this.name}_count${formatLabels(series.labels)} ${series.count}`);
+    });
+    return lines.join('\n');
+  }
+}
+
+const STATUS_CODE: Record<ServiceStatus, number> = {
+  operational: 0,
+  degraded: 1,
+  major_outage: 2,
+  down: 3,
+  unknown: 4,
+};
+
+const pollCycles = new Counter(
+  'outage_poll_cycles_total',
+  'Number of poll cycles run, by result',
+);
+
+const fetcherFailures = new Counter(
+  'outage_fetcher_failures_total',
+  'Number of fetcher failures, by service and source',
+);
+
+const alertsSent = new Counter(
+  'outage_alerts_sent_total',
+  'Number of alerts dispatched, by channel and severity',
+);
+
+const fetcherLatency = new Histogram(
+  'outage_fetcher_latency_seconds',
+  'Fetcher request latency in seconds',
+  [0.1, 0.5, 1, 2, 5, 10, 15, 30],
+);
+
+const pollCycleDuration = new Histogram(
+  'outage_poll_cycle_duration_seconds',
+  'Total duration of a poll cycle in seconds',
+  [1, 5, 10, 30, 60, 120],
+);
+
+const serviceStatus = new Gauge(
+  'outage_service_status',
+  'Current service status (0=operational, 1=degraded, 2=major_outage, 3=down, 4=unknown)',
+);
+
+const lastPollTimestamp = new Gauge(
+  'outage_last_poll_timestamp_seconds',
+  'Unix timestamp of the last completed poll cycle',
+);
+
+const lastPollAge = new Gauge(
+  'outage_last_poll_age_seconds',
+  'Seconds since the last completed poll cycle',
+);
+
+let lastPollAt: number | null = null;
+
+export const metrics = {
+  recordPollCycle(result: 'success' | 'skipped' | 'failure', durationSec: number) {
+    pollCycles.inc({ result });
+    pollCycleDuration.observe({}, durationSec);
+    if (result !== 'skipped') {
+      lastPollAt = Date.now();
+      lastPollTimestamp.set({}, Math.floor(lastPollAt / 1000));
+    }
+  },
+  recordFetcherLatency(service: string, source: string, seconds: number) {
+    fetcherLatency.observe({ service, source }, seconds);
+  },
+  recordFetcherFailure(service: string, source: string, reason: string = 'error') {
+    fetcherFailures.inc({ service, source, reason });
+  },
+  recordAlertSent(channel: string, severity: string) {
+    alertsSent.inc({ channel, severity });
+  },
+  setServiceStatus(service: string, source: string, status: ServiceStatus) {
+    serviceStatus.set({ service, source }, STATUS_CODE[status]);
+  },
+  expose(): string {
+    if (lastPollAt !== null) {
+      lastPollAge.set({}, Math.round((Date.now() - lastPollAt) / 1000));
+    }
+    return [
+      pollCycles.expose(),
+      fetcherFailures.expose(),
+      alertsSent.expose(),
+      fetcherLatency.expose(),
+      pollCycleDuration.expose(),
+      serviceStatus.expose(),
+      lastPollTimestamp.expose(),
+      lastPollAge.expose(),
+      '',
+    ].join('\n');
+  },
+};

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -138,84 +138,110 @@ const STATUS_CODE: Record<ServiceStatus, number> = {
   unknown: 4,
 };
 
-const pollCycles = new Counter(
-  'outage_poll_cycles_total',
-  'Number of poll cycles run, by result',
-);
+// Next.js' standalone build can split this module across multiple chunks —
+// one bundled into the instrumentation/poller graph, another bundled into the
+// /api/metrics route — which gives each its own copy of module-level state.
+// Attach the registry to globalThis so every chunk in the same Node process
+// observes the same series. The symbol-keyed slot avoids colliding with any
+// other library that might pin globals.
+const GLOBAL_KEY = Symbol.for('outage-map.metrics-registry');
 
-const fetcherFailures = new Counter(
-  'outage_fetcher_failures_total',
-  'Number of fetcher failures, by service and source',
-);
+interface Registry {
+  pollCycles: Counter;
+  fetcherFailures: Counter;
+  alertsSent: Counter;
+  fetcherLatency: Histogram;
+  pollCycleDuration: Histogram;
+  serviceStatus: Gauge;
+  lastPollTimestamp: Gauge;
+  lastPollAge: Gauge;
+  lastPollAt: number | null;
+}
 
-const alertsSent = new Counter(
-  'outage_alerts_sent_total',
-  'Number of alerts dispatched, by channel and severity',
-);
+type GlobalWithRegistry = typeof globalThis & { [GLOBAL_KEY]?: Registry };
 
-const fetcherLatency = new Histogram(
-  'outage_fetcher_latency_seconds',
-  'Fetcher request latency in seconds',
-  [0.1, 0.5, 1, 2, 5, 10, 15, 30],
-);
-
-const pollCycleDuration = new Histogram(
-  'outage_poll_cycle_duration_seconds',
-  'Total duration of a poll cycle in seconds',
-  [1, 5, 10, 30, 60, 120],
-);
-
-const serviceStatus = new Gauge(
-  'outage_service_status',
-  'Current service status (0=operational, 1=degraded, 2=major_outage, 3=down, 4=unknown)',
-);
-
-const lastPollTimestamp = new Gauge(
-  'outage_last_poll_timestamp_seconds',
-  'Unix timestamp of the last completed poll cycle',
-);
-
-const lastPollAge = new Gauge(
-  'outage_last_poll_age_seconds',
-  'Seconds since the last completed poll cycle',
-);
-
-let lastPollAt: number | null = null;
+function getRegistry(): Registry {
+  const g = globalThis as GlobalWithRegistry;
+  let r = g[GLOBAL_KEY];
+  if (!r) {
+    r = {
+      pollCycles: new Counter(
+        'outage_poll_cycles_total',
+        'Number of poll cycles run, by result',
+      ),
+      fetcherFailures: new Counter(
+        'outage_fetcher_failures_total',
+        'Number of fetcher failures, by service and source',
+      ),
+      alertsSent: new Counter(
+        'outage_alerts_sent_total',
+        'Number of alerts dispatched, by channel and severity',
+      ),
+      fetcherLatency: new Histogram(
+        'outage_fetcher_latency_seconds',
+        'Fetcher request latency in seconds',
+        [0.1, 0.5, 1, 2, 5, 10, 15, 30],
+      ),
+      pollCycleDuration: new Histogram(
+        'outage_poll_cycle_duration_seconds',
+        'Total duration of a poll cycle in seconds',
+        [1, 5, 10, 30, 60, 120],
+      ),
+      serviceStatus: new Gauge(
+        'outage_service_status',
+        'Current service status (0=operational, 1=degraded, 2=major_outage, 3=down, 4=unknown)',
+      ),
+      lastPollTimestamp: new Gauge(
+        'outage_last_poll_timestamp_seconds',
+        'Unix timestamp of the last completed poll cycle',
+      ),
+      lastPollAge: new Gauge(
+        'outage_last_poll_age_seconds',
+        'Seconds since the last completed poll cycle',
+      ),
+      lastPollAt: null,
+    };
+    g[GLOBAL_KEY] = r;
+  }
+  return r;
+}
 
 export const metrics = {
   recordPollCycle(result: 'success' | 'skipped' | 'failure', durationSec: number) {
-    pollCycles.inc({ result });
-    pollCycleDuration.observe({}, durationSec);
+    const r = getRegistry();
+    r.pollCycles.inc({ result });
+    r.pollCycleDuration.observe({}, durationSec);
     if (result !== 'skipped') {
-      lastPollAt = Date.now();
-      lastPollTimestamp.set({}, Math.floor(lastPollAt / 1000));
+      r.lastPollAt = Date.now();
+      r.lastPollTimestamp.set({}, Math.floor(r.lastPollAt / 1000));
     }
   },
   recordFetcherLatency(service: string, source: string, seconds: number) {
-    fetcherLatency.observe({ service, source }, seconds);
+    getRegistry().fetcherLatency.observe({ service, source }, seconds);
   },
   recordFetcherFailure(service: string, source: string, reason: string = 'error') {
-    fetcherFailures.inc({ service, source, reason });
+    getRegistry().fetcherFailures.inc({ service, source, reason });
   },
   recordAlertSent(channel: string, severity: string) {
-    alertsSent.inc({ channel, severity });
+    getRegistry().alertsSent.inc({ channel, severity });
   },
   setServiceStatus(service: string, source: string, status: ServiceStatus) {
-    serviceStatus.set({ service, source }, STATUS_CODE[status]);
+    getRegistry().serviceStatus.set({ service, source }, STATUS_CODE[status]);
   },
   expose(): string {
-    if (lastPollAt !== null) {
-      lastPollAge.set({}, Math.round((Date.now() - lastPollAt) / 1000));
+    const r = getRegistry();
+    if (r.lastPollAt !== null) {
+      r.lastPollAge.set({}, Math.round((Date.now() - r.lastPollAt) / 1000));
     }
     return [
-      pollCycles.expose(),
-      fetcherFailures.expose(),
-      alertsSent.expose(),
-      fetcherLatency.expose(),
-      pollCycleDuration.expose(),
-      serviceStatus.expose(),
-      lastPollTimestamp.expose(),
-      lastPollAge.expose(),
+      r.pollCycles.expose(),
+      r.fetcherFailures.expose(),
+      r.alertsSent.expose(),
+      r.fetcherLatency.expose(),
+      r.pollCycleDuration.expose(),
+      r.serviceStatus.expose(),
+      r.lastPollTimestamp.expose(),
+      r.lastPollAge.expose(),
       '',
     ].join('\n');
   },

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -11,6 +11,8 @@ import {
 } from './db';
 import { sendIncidentAlert, sendStatusChangeAlert } from './email';
 import { evaluateRulesForIncident } from './alerts/rules';
+import { metrics } from './metrics';
+import { health, HealthSource } from './health';
 import { fetchStatuspageStatus } from './fetchers/statuspage';
 import { fetchMicrosoftStatus } from './fetchers/microsoft';
 import { fetchSalesforceStatus } from './fetchers/salesforce';
@@ -18,6 +20,39 @@ import { fetchGoogleStatus } from './fetchers/google';
 import { fetchWorkdayStatus } from './fetchers/workday';
 import { fetchAwsStatus } from './fetchers/aws';
 import { fetchDowndetectorStatus } from './fetchers/downdetector';
+
+// Wrap a fetcher call with latency, success, and failure bookkeeping. Both
+// underlying fetchers catch exceptions internally and return a result with
+// `status: 'unknown'` plus a `details` message, so we treat "unknown" as a
+// failure for health tracking purposes — it's the most reliable signal that
+// the upstream didn't give us a useful answer.
+async function timedFetch<T>(
+  serviceSlug: string,
+  source: HealthSource,
+  call: () => Promise<T>,
+  inspect: (result: T) => { status: ServiceStatus; details: string | null },
+): Promise<T> {
+  const start = Date.now();
+  try {
+    const result = await call();
+    const latencyMs = Date.now() - start;
+    metrics.recordFetcherLatency(serviceSlug, source, latencyMs / 1000);
+    const { status, details } = inspect(result);
+    if (status === 'unknown') {
+      metrics.recordFetcherFailure(serviceSlug, source, 'unknown_status');
+      health.recordFailure(serviceSlug, source, details ?? 'fetcher returned unknown', latencyMs);
+    } else {
+      health.recordSuccess(serviceSlug, source, latencyMs);
+    }
+    return result;
+  } catch (err) {
+    const latencyMs = Date.now() - start;
+    metrics.recordFetcherLatency(serviceSlug, source, latencyMs / 1000);
+    metrics.recordFetcherFailure(serviceSlug, source, 'exception');
+    health.recordFailure(serviceSlug, source, err, latencyMs);
+    throw err;
+  }
+}
 
 async function fetchOfficialStatus(service: ServiceConfig): Promise<FetchResult> {
   switch (service.fetcher) {
@@ -66,10 +101,22 @@ async function pollService(service: ServiceConfig): Promise<{ ddReports: number 
 
   const previousStatus = getPreviousStatus(service.slug);
 
-  // Fetch official status and Downdetector in parallel
+  // Fetch official status and Downdetector in parallel, with per-call latency
+  // and health tracking. Each fetcher already swallows exceptions internally,
+  // so timedFetch promotes "status: unknown" into a failure observation.
   const [officialResult, ddResult] = await Promise.allSettled([
-    fetchOfficialStatus(service),
-    fetchDowndetectorStatus(service.downdetectorSlug, service.slug),
+    timedFetch<FetchResult>(
+      service.slug,
+      'official',
+      () => fetchOfficialStatus(service),
+      (r) => ({ status: r.status.status, details: r.status.details }),
+    ),
+    timedFetch<StatusResult>(
+      service.slug,
+      'downdetector',
+      () => fetchDowndetectorStatus(service.downdetectorSlug, service.slug),
+      (r) => ({ status: r.status, details: r.details }),
+    ),
   ]);
 
   // Process official status
@@ -84,6 +131,7 @@ async function pollService(service: ServiceConfig): Promise<{ ddReports: number 
       officialStatus.details,
       officialStatus.reportCount
     );
+    metrics.setServiceStatus(service.slug, 'official', officialStatus.status);
 
     // Process incidents
     for (const incident of officialResult.value.incidents) {
@@ -128,6 +176,7 @@ async function pollService(service: ServiceConfig): Promise<{ ddReports: number 
       ddStatus.details,
       ddStatus.reportCount
     );
+    metrics.setServiceStatus(service.slug, 'downdetector', ddStatus.status);
   } else {
     console.debug(`[poller] ${service.name} downdetector fetch rejected:`, ddResult.reason);
   }
@@ -155,10 +204,12 @@ const VACUUM_INTERVAL_MS = 24 * 60 * 60 * 1000;
 export async function runPollCycle(): Promise<{ success: boolean; polled: number; errors: number }> {
   if (isPolling) {
     console.log('[poller] Poll cycle already in progress, skipping');
+    metrics.recordPollCycle('skipped', 0);
     return { success: false, polled: 0, errors: 0 };
   }
 
   isPolling = true;
+  const cycleStart = Date.now();
   if (process.env.DEBUG === 'true') {
     console.log(`[poller] Starting poll cycle at ${new Date().toISOString()}`);
   }
@@ -208,6 +259,10 @@ export async function runPollCycle(): Promise<{ success: boolean; polled: number
     }
   } finally {
     isPolling = false;
+    const durationSec = (Date.now() - cycleStart) / 1000;
+    // "success" means at least one fetcher completed; "failure" only when
+    // every service errored, which usually means the host lost outbound DNS.
+    metrics.recordPollCycle(polled > 0 ? 'success' : 'failure', durationSec);
   }
 
   return { success: true, polled, errors };

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -13,6 +13,7 @@ import { sendIncidentAlert, sendStatusChangeAlert } from './email';
 import { evaluateRulesForIncident } from './alerts/rules';
 import { metrics } from './metrics';
 import { health, HealthSource } from './health';
+import { circuit } from './fetchers/circuit';
 import { fetchStatuspageStatus } from './fetchers/statuspage';
 import { fetchMicrosoftStatus } from './fetchers/microsoft';
 import { fetchSalesforceStatus } from './fetchers/salesforce';
@@ -26,12 +27,29 @@ import { fetchDowndetectorStatus } from './fetchers/downdetector';
 // `status: 'unknown'` plus a `details` message, so we treat "unknown" as a
 // failure for health tracking purposes — it's the most reliable signal that
 // the upstream didn't give us a useful answer.
+//
+// The circuit breaker layer short-circuits the call when an upstream has been
+// failing repeatedly: instead of making the network request, it returns a
+// fabricated "unknown" result via the supplied factory. This prevents the
+// poller from hammering a broken upstream every 3 minutes while still
+// generating one probe call per cooldown to detect recovery.
 async function timedFetch<T>(
   serviceSlug: string,
   source: HealthSource,
   call: () => Promise<T>,
   inspect: (result: T) => { status: ServiceStatus; details: string | null },
+  unknownFactory: (reason: string) => T,
 ): Promise<T> {
+  if (circuit.shouldAttempt(serviceSlug, source) === 'block') {
+    const until = circuit.openUntil(serviceSlug, source);
+    const reason = until
+      ? `circuit open until ${new Date(until).toISOString()}`
+      : 'circuit open';
+    metrics.recordFetcherFailure(serviceSlug, source, 'circuit_open');
+    metrics.setCircuitState(serviceSlug, source, 'open');
+    return unknownFactory(reason);
+  }
+
   const start = Date.now();
   try {
     const result = await call();
@@ -41,17 +59,45 @@ async function timedFetch<T>(
     if (status === 'unknown') {
       metrics.recordFetcherFailure(serviceSlug, source, 'unknown_status');
       health.recordFailure(serviceSlug, source, details ?? 'fetcher returned unknown', latencyMs);
+      circuit.recordFailure(serviceSlug, source);
     } else {
       health.recordSuccess(serviceSlug, source, latencyMs);
+      circuit.recordSuccess(serviceSlug, source);
     }
+    metrics.setCircuitState(serviceSlug, source, circuit.getState(serviceSlug, source));
     return result;
   } catch (err) {
     const latencyMs = Date.now() - start;
     metrics.recordFetcherLatency(serviceSlug, source, latencyMs / 1000);
     metrics.recordFetcherFailure(serviceSlug, source, 'exception');
     health.recordFailure(serviceSlug, source, err, latencyMs);
+    circuit.recordFailure(serviceSlug, source);
+    metrics.setCircuitState(serviceSlug, source, circuit.getState(serviceSlug, source));
     throw err;
   }
+}
+
+function unknownFetchResult(serviceSlug: string, reason: string): FetchResult {
+  return {
+    status: {
+      serviceSlug,
+      source: 'official',
+      status: 'unknown',
+      details: reason,
+      reportCount: null,
+    },
+    incidents: [],
+  };
+}
+
+function unknownStatusResult(serviceSlug: string, reason: string): StatusResult {
+  return {
+    serviceSlug,
+    source: 'downdetector',
+    status: 'unknown',
+    details: reason,
+    reportCount: null,
+  };
 }
 
 async function fetchOfficialStatus(service: ServiceConfig): Promise<FetchResult> {
@@ -110,12 +156,14 @@ async function pollService(service: ServiceConfig): Promise<{ ddReports: number 
       'official',
       () => fetchOfficialStatus(service),
       (r) => ({ status: r.status.status, details: r.status.details }),
+      (reason) => unknownFetchResult(service.slug, reason),
     ),
     timedFetch<StatusResult>(
       service.slug,
       'downdetector',
       () => fetchDowndetectorStatus(service.downdetectorSlug, service.slug),
       (r) => ({ status: r.status, details: r.details }),
+      (reason) => unknownStatusResult(service.slug, reason),
     ),
   ]);
 

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -1,4 +1,4 @@
-import { SERVICES } from './services';
+import { getServices } from './services';
 import { ServiceConfig, FetchResult, StatusResult, ServiceStatus } from './types';
 import {
   upsertServiceStatus,
@@ -219,7 +219,7 @@ export async function runPollCycle(): Promise<{ success: boolean; polled: number
 
   try {
     const results = await Promise.allSettled(
-      SERVICES.map((service) => pollService(service))
+      getServices().map((service) => pollService(service))
     );
 
     let totalDdReports = 0;

--- a/src/lib/services.contributed.json
+++ b/src/lib/services.contributed.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "services": []
+}

--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -1,6 +1,22 @@
-import { ServiceConfig } from './types';
+import { ServiceConfig, FetcherType } from './types';
+import { CustomServiceRow, listEnabledCustomServices } from './db';
+import contributedFile from './services.contributed.json';
 
-export const SERVICES: ServiceConfig[] = [
+interface ContributedFile {
+  schemaVersion: number;
+  services: ServiceConfig[];
+}
+
+const CONTRIBUTED: ServiceConfig[] = (contributedFile as ContributedFile).services ?? [];
+
+/**
+ * Static catalog of monitored services. Edits to this file are hand-written;
+ * additions from the in-app "Contribute to catalog" flow land in
+ * `services.contributed.json` instead and are merged below at module load.
+ * Runtime code should call `getServices()` — that helper layers user-added
+ * rows from the `custom_services` SQLite table on top of this merged list.
+ */
+const HARDCODED: ServiceConfig[] = [
   {
     name: 'Microsoft 365',
     slug: 'microsoft-365',
@@ -131,6 +147,50 @@ export const SERVICES: ServiceConfig[] = [
   },
 ];
 
+// Static catalog exported for backwards-compat callers. Combines hand-edited
+// HARDCODED entries with machine-edited contributed entries; the contributed
+// file is the target of the one-click "Contribute to catalog" PR flow so its
+// shape never needs to be parsed from TypeScript.
+export const SERVICES: ServiceConfig[] = (() => {
+  const seen = new Set(HARDCODED.map((s) => s.slug));
+  const merged = [...HARDCODED];
+  for (const c of CONTRIBUTED) {
+    if (!seen.has(c.slug)) {
+      merged.push(c);
+      seen.add(c.slug);
+    }
+  }
+  return merged;
+})();
+
+function rowToServiceConfig(row: CustomServiceRow): ServiceConfig {
+  return {
+    name: row.name,
+    slug: row.slug,
+    color: row.color,
+    statusUrl: row.status_url,
+    downdetectorSlug: row.downdetector_slug,
+    fetcher: row.fetcher as FetcherType,
+    brandFont: row.brand_font,
+  };
+}
+
+/**
+ * Returns the static SERVICES list merged with enabled rows from the
+ * `custom_services` table. Call this from any server-side code that
+ * needs to iterate the live catalog (poller, /api/status, alert rules).
+ * Client code should derive the list from /api/status instead — this
+ * helper opens a SQLite connection.
+ */
+export function getServices(): ServiceConfig[] {
+  const hardcoded = SERVICES;
+  const seen = new Set(hardcoded.map((s) => s.slug));
+  const custom = listEnabledCustomServices()
+    .map(rowToServiceConfig)
+    .filter((s) => !seen.has(s.slug));
+  return [...hardcoded, ...custom];
+}
+
 export function getServiceBySlug(slug: string): ServiceConfig | undefined {
-  return SERVICES.find((s) => s.slug === slug);
+  return getServices().find((s) => s.slug === slug);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,7 +9,7 @@ export interface ServiceConfig {
   slug: string;
   color: string;
   statusUrl: string;
-  downdetectorSlug: string;
+  downdetectorSlug: string | null;
   fetcher: FetcherType;
   brandFont: string;
 }


### PR DESCRIPTION
## Summary

Adds `PLATFORM_IMPROVEMENTS.md`, a third planning doc that complements the existing two:

- `ROADMAP.md` — product features (alerts, SLA, anomaly, postmortem, auth).
- `DASHBOARD_CUSTOMIZATION_PLAN.md` — board / tile / theme UX.
- **`PLATFORM_IMPROVEMENTS.md` (new)** — observability, reliability, real-time, integrations, ops tooling.

Each proposal references the existing files it would touch, so the work can start without another discovery pass.

## What's in the plan

Organized into 6 waves, 21 proposals total. Highlights:

- **Wave 1 — Make failure visible.** Prometheus `/metrics`, per-fetcher health surface + readiness probe, structured logging (`pino`), zod schema validation on every fetcher.
- **Wave 2 — Reliability under upstream pressure.** Per-fetcher circuit breaker, configurable timeouts + retry with jitter, SQLite busy-timeout / VACUUM scheduling.
- **Wave 3 — Real-time client updates.** Server-sent events to replace 30s SWR polling, ETag / `If-None-Match` on GET endpoints.
- **Wave 4 — Data lifecycle.** Versioned migration framework (replacing hand-rolled `ALTER TABLE` in `db.ts:99-102`), hourly rollups for `status_history`, backup/restore CLI with optional Litestream sidecar.
- **Wave 5 — Integrations and public surfaces.** First-class PagerDuty / Opsgenie / VictorOps notifiers, HMAC-signed webhook payloads, status badges + iCal feed, inbound `/api/ingest`.
- **Wave 6 — Operator + end-user QoL.** Local CLI for poll / rules / test-alert, type-checked env loading with zod, CSP and security headers in `next.config.mjs`, i18n + per-user timezone, accessibility audit pass.

Cross-cutting notes call out the ordering (observability before reliability), the tests dependency on `ROADMAP.md` #3, and the one-time migration cutover in #10.

## Test plan
- [ ] Doc renders correctly on GitHub (headings, code fences, links).
- [ ] No conflict with the topics already covered in `ROADMAP.md` or `DASHBOARD_CUSTOMIZATION_PLAN.md`.
- [ ] File paths and line references cited in the doc still match `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRgCqtSWN7kDtf75As9tA3)_