### PR TITLE
feat: Phase 1–4 — backend layer, frontend wiring, 12 new features, 10 more enhancements

### DIFF
--- a/src/app/api/alerts/log/route.ts
+++ b/src/app/api/alerts/log/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { getDb } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  try {
+    const db = getDb();
+    const rows = db.prepare(`
+      SELECT id, service_slug, incident_id, alert_type, sent_at
+      FROM alert_log
+      ORDER BY sent_at DESC
+      LIMIT 50
+    `).all() as Array<{
+      id: number;
+      service_slug: string;
+      incident_id: string | null;
+      alert_type: string;
+      sent_at: string;
+    }>;
+    return NextResponse.json({ log: rows });
+  } catch (err) {
+    console.error('[api/alerts/log] Error:', err);
+    return NextResponse.json({ error: 'Failed to fetch log' }, { status: 500 });
+  }
+}

--- a/src/app/api/alerts/rules/[id]/route.ts
+++ b/src/app/api/alerts/rules/[id]/route.ts
@@ -45,6 +45,8 @@ export async function PATCH(request: NextRequest, { params }: Ctx) {
     services: unknown;
     minSeverity: unknown;
     emailEnabled: unknown;
+    webhookUrl: unknown;
+    webhookEnabled: unknown;
     enabled: unknown;
   }>;
 
@@ -71,6 +73,19 @@ export async function PATCH(request: NextRequest, { params }: Ctx) {
     patch.minSeverity = input.minSeverity;
   }
   if (input.emailEnabled !== undefined) patch.emailEnabled = !!input.emailEnabled;
+  if (input.webhookUrl !== undefined) {
+    if (input.webhookUrl === null || input.webhookUrl === '') {
+      patch.webhookUrl = null;
+      patch.webhookEnabled = false;
+    } else if (typeof input.webhookUrl === 'string') {
+      const { isValidWebhookUrl } = await import('@/lib/webhook');
+      if (!isValidWebhookUrl(input.webhookUrl.trim())) {
+        return NextResponse.json({ error: 'Invalid or disallowed webhook URL' }, { status: 400 });
+      }
+      patch.webhookUrl = input.webhookUrl.trim();
+    }
+  }
+  if (input.webhookEnabled !== undefined) patch.webhookEnabled = !!input.webhookEnabled;
   if (input.enabled !== undefined) patch.enabled = !!input.enabled;
 
   try {

--- a/src/app/api/alerts/rules/route.ts
+++ b/src/app/api/alerts/rules/route.ts
@@ -59,6 +59,8 @@ export async function POST(request: NextRequest) {
     services: unknown;
     minSeverity: unknown;
     emailEnabled: unknown;
+    webhookUrl: unknown;
+    webhookEnabled: unknown;
     enabled: unknown;
   }>;
 
@@ -76,6 +78,16 @@ export async function POST(request: NextRequest) {
   const emailEnabled = input.emailEnabled !== false;
   const enabled = input.enabled !== false;
 
+  let webhookUrl: string | null = null;
+  if (typeof input.webhookUrl === 'string' && input.webhookUrl.trim()) {
+    const { isValidWebhookUrl } = await import('@/lib/webhook');
+    if (!isValidWebhookUrl(input.webhookUrl.trim())) {
+      return NextResponse.json({ error: 'Invalid or disallowed webhook URL' }, { status: 400 });
+    }
+    webhookUrl = input.webhookUrl.trim();
+  }
+  const webhookEnabled = !!input.webhookEnabled && webhookUrl !== null;
+
   const id = `rule_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
   try {
@@ -85,10 +97,12 @@ export async function POST(request: NextRequest) {
       services: JSON.stringify(services),
       minSeverity,
       emailEnabled,
+      webhookUrl,
+      webhookEnabled,
       enabled,
     });
     return NextResponse.json({
-      rule: { id, email, services, minSeverity, emailEnabled, enabled },
+      rule: { id, email, services, minSeverity, emailEnabled, webhookUrl, webhookEnabled, enabled },
     }, { status: 201 });
   } catch (err) {
     console.error('[api/alerts/rules] Insert failed:', err);

--- a/src/app/api/incidents/metrics/route.ts
+++ b/src/app/api/incidents/metrics/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const days = Math.max(1, Math.min(365, parseInt(searchParams.get('days') || '30', 10)));
+
+  try {
+    const db = getDb();
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+    const mttrRows = db.prepare(`
+      SELECT severity,
+             AVG((julianday(resolved_at) - julianday(started_at)) * 1440) AS avg_minutes,
+             COUNT(*) AS count
+      FROM incidents
+      WHERE started_at >= ? AND resolved_at IS NOT NULL AND status = 'resolved'
+      GROUP BY severity
+    `).all(since) as { severity: string; avg_minutes: number; count: number }[];
+
+    const totals = db.prepare(`
+      SELECT COUNT(*) AS total,
+             SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END) AS resolved
+      FROM incidents
+      WHERE started_at >= ?
+    `).get(since) as { total: number; resolved: number };
+
+    const topServices = db.prepare(`
+      SELECT service_slug, COUNT(*) AS count
+      FROM incidents
+      WHERE started_at >= ?
+      GROUP BY service_slug
+      ORDER BY count DESC
+      LIMIT 5
+    `).all(since) as { service_slug: string; count: number }[];
+
+    const bySeverity = db.prepare(`
+      SELECT severity, COUNT(*) AS count
+      FROM incidents
+      WHERE started_at >= ?
+      GROUP BY severity
+    `).all(since) as { severity: string; count: number }[];
+
+    const mttrBySeverity: Record<string, number> = {};
+    for (const row of mttrRows) {
+      if (row.avg_minutes !== null) {
+        mttrBySeverity[row.severity] = Math.round(row.avg_minutes);
+      }
+    }
+
+    const countBySeverity: Record<string, number> = {};
+    for (const row of bySeverity) {
+      countBySeverity[row.severity] = row.count;
+    }
+
+    return NextResponse.json({
+      days,
+      mttrBySeverity,
+      resolutionRate: totals.total > 0 ? (totals.resolved / totals.total) * 100 : 100,
+      totalIncidents: totals.total,
+      resolvedIncidents: totals.resolved,
+      countBySeverity,
+      topServices,
+    });
+  } catch (err) {
+    console.error('[api/incidents/metrics]', err);
+    return NextResponse.json({ error: 'Failed to compute metrics' }, { status: 500 });
+  }
+}

--- a/src/app/api/incidents/route.ts
+++ b/src/app/api/incidents/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getRecentIncidents } from '@/lib/db';
+import { getPaginatedIncidents } from '@/lib/db';
 import { getServices } from '@/lib/services';
 import { IncidentResponse, asIncidentSeverity, asIncidentStatus } from '@/lib/types';
 
@@ -8,22 +8,32 @@ export const dynamic = 'force-dynamic';
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
+
     const daysParam = Number(searchParams.get('days'));
     const days = Number.isFinite(daysParam) && daysParam > 0
       ? Math.min(Math.floor(daysParam), 90)
       : 7;
-    const serviceFilter = searchParams.get('service');
+
+    const limitParam = Number(searchParams.get('limit'));
+    const limit = Number.isFinite(limitParam) && limitParam > 0
+      ? Math.min(Math.floor(limitParam), 200)
+      : 50;
+
+    const offsetParam = Number(searchParams.get('offset'));
+    const offset = Number.isFinite(offsetParam) && offsetParam >= 0
+      ? Math.floor(offsetParam)
+      : 0;
+
+    const since = searchParams.get('since') || null;
+
     const allServices = getServices();
     const validSlugs = new Set(allServices.map((s) => s.slug));
+    const serviceFilter = searchParams.get('service');
     const service = serviceFilter && serviceFilter !== 'all' && validSlugs.has(serviceFilter)
       ? serviceFilter
       : null;
 
-    let incidents = getRecentIncidents(days);
-
-    if (service) {
-      incidents = incidents.filter((i) => i.service_slug === service);
-    }
+    const { incidents, total } = getPaginatedIncidents({ days, service, limit, offset, since });
 
     const serviceMap = new Map(allServices.map((s) => [s.slug, s.name]));
 
@@ -41,7 +51,7 @@ export async function GET(request: NextRequest) {
       updatedAt: i.updated_at,
     }));
 
-    return NextResponse.json({ incidents: response });
+    return NextResponse.json({ incidents: response, total, limit, offset });
   } catch (err) {
     console.error('[api/incidents] Error:', err);
     return NextResponse.json(

--- a/src/app/api/rss/route.ts
+++ b/src/app/api/rss/route.ts
@@ -9,6 +9,9 @@ const ALLOWED_FEEDS: Record<string, string> = {
   'gh-blog': 'https://github.blog/engineering/feed/',
 };
 
+const PRIVATE_IP_RE =
+  /^(localhost|127\.|0\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|::1|fc00:|fe80:)/i;
+
 interface RssItem {
   title: string;
   url: string | null;
@@ -53,17 +56,39 @@ function parseRss(xml: string): { title: string; items: RssItem[] } {
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const feedId = searchParams.get('feed') || '';
+  const customUrl = searchParams.get('url') || '';
 
-  const feedUrl = ALLOWED_FEEDS[feedId];
-  if (!feedUrl) {
-    return NextResponse.json(
-      { error: `Unknown feed. Valid values: ${Object.keys(ALLOWED_FEEDS).join(', ')}` },
-      { status: 400 },
-    );
+  let feedUrl: string;
+  let cacheKey: string;
+
+  if (feedId === 'custom') {
+    if (!customUrl || !/^https?:\/\//i.test(customUrl)) {
+      return NextResponse.json({ error: 'Invalid custom URL: must start with http:// or https://' }, { status: 400 });
+    }
+    let hostname: string;
+    try {
+      hostname = new URL(customUrl).hostname;
+    } catch {
+      return NextResponse.json({ error: 'Invalid custom URL' }, { status: 400 });
+    }
+    if (PRIVATE_IP_RE.test(hostname)) {
+      return NextResponse.json({ error: 'Private/internal URLs are not allowed' }, { status: 400 });
+    }
+    feedUrl = customUrl;
+    cacheKey = `custom:${customUrl}`;
+  } else {
+    feedUrl = ALLOWED_FEEDS[feedId];
+    if (!feedUrl) {
+      return NextResponse.json(
+        { error: `Unknown feed. Valid values: ${Object.keys(ALLOWED_FEEDS).join(', ')}, custom` },
+        { status: 400 },
+      );
+    }
+    cacheKey = feedId;
   }
 
   const now = Date.now();
-  const cached = cache.get(feedId);
+  const cached = cache.get(cacheKey);
   if (cached && cached.expiresAt > now) {
     return NextResponse.json({ feed: feedId, title: cached.feedTitle, items: cached.items });
   }
@@ -82,7 +107,7 @@ export async function GET(request: NextRequest) {
     const xml = await res.text();
     const { title: feedTitle, items } = parseRss(xml);
 
-    cache.set(feedId, { items, feedTitle, expiresAt: now + CACHE_TTL_MS });
+    cache.set(cacheKey, { items, feedTitle, expiresAt: now + CACHE_TTL_MS });
 
     return NextResponse.json({ feed: feedId, title: feedTitle, items });
   } catch (err) {

--- a/src/app/api/rss/route.ts
+++ b/src/app/api/rss/route.ts
@@ -1,0 +1,97 @@
+import * as cheerio from 'cheerio';
+import { NextRequest, NextResponse } from 'next/server';
+import { httpFetch } from '@/lib/fetchers/httpFetch';
+
+export const dynamic = 'force-dynamic';
+
+const ALLOWED_FEEDS: Record<string, string> = {
+  'aws-blog': 'https://aws.amazon.com/blogs/aws/feed/',
+  'gh-blog': 'https://github.blog/engineering/feed/',
+};
+
+interface RssItem {
+  title: string;
+  url: string | null;
+  publishedAt: string | null;
+}
+
+interface CacheEntry {
+  items: RssItem[];
+  feedTitle: string;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+function parseRss(xml: string): { title: string; items: RssItem[] } {
+  const $ = cheerio.load(xml, { xmlMode: true });
+  const feedTitle = $('channel > title').first().text() || $('feed > title').first().text() || 'RSS Feed';
+
+  const items: RssItem[] = [];
+  // Support both RSS <item> and Atom <entry>
+  $('item, entry').each((_: number, el: cheerio.AnyNode) => {
+    const title = $(el).find('title').first().text().trim();
+    const link =
+      $(el).find('link').attr('href') ||
+      $(el).find('link').first().text().trim() ||
+      null;
+    const pubDate =
+      $(el).find('pubDate').text().trim() ||
+      $(el).find('published').text().trim() ||
+      $(el).find('updated').text().trim() ||
+      null;
+
+    if (title) {
+      items.push({ title, url: link || null, publishedAt: pubDate || null });
+    }
+  });
+
+  return { title: feedTitle, items: items.slice(0, 10) };
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const feedId = searchParams.get('feed') || '';
+
+  const feedUrl = ALLOWED_FEEDS[feedId];
+  if (!feedUrl) {
+    return NextResponse.json(
+      { error: `Unknown feed. Valid values: ${Object.keys(ALLOWED_FEEDS).join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  const now = Date.now();
+  const cached = cache.get(feedId);
+  if (cached && cached.expiresAt > now) {
+    return NextResponse.json({ feed: feedId, title: cached.feedTitle, items: cached.items });
+  }
+
+  try {
+    const res = await httpFetch(feedUrl, {
+      headers: { Accept: 'application/rss+xml, application/atom+xml, text/xml, */*' },
+      timeoutMs: 10000,
+      maxRetries: 1,
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+
+    const xml = await res.text();
+    const { title: feedTitle, items } = parseRss(xml);
+
+    cache.set(feedId, { items, feedTitle, expiresAt: now + CACHE_TTL_MS });
+
+    return NextResponse.json({ feed: feedId, title: feedTitle, items });
+  } catch (err) {
+    console.error(`[api/rss] Failed to fetch feed "${feedId}":`, err);
+
+    if (cached) {
+      return NextResponse.json({ feed: feedId, title: cached.feedTitle, items: cached.items });
+    }
+
+    return NextResponse.json({ error: 'Failed to fetch RSS feed' }, { status: 502 });
+  }
+}

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -1,29 +1,13 @@
-import { NextResponse } from 'next/server';
+import { createHash } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
 import { getServiceStatuses, getActiveIncidentCounts } from '@/lib/db';
 import { getServices } from '@/lib/services';
 import { ServiceStatus, ServiceStatusResponse } from '@/lib/types';
+import { deriveOverallStatus } from '@/lib/statusUtils';
 
 export const dynamic = 'force-dynamic';
 
-function deriveOverallStatus(
-  official: ServiceStatus,
-  downdetector: ServiceStatus,
-  officialIncidentCount: number,
-): ServiceStatus {
-  // Official outage signal always wins.
-  if (official === 'down' || official === 'major_outage') return official;
-  // Only escalate to major based on Downdetector alone if the official source
-  // also has an active incident — Downdetector spikes by themselves are noisy.
-  if ((downdetector === 'down' || downdetector === 'major_outage') && officialIncidentCount > 0) {
-    return 'major_outage';
-  }
-  if (official === 'degraded' || downdetector === 'degraded') return 'degraded';
-  if (official === 'operational') return 'operational';
-  if (official === 'unknown' && downdetector !== 'unknown') return downdetector;
-  return official;
-}
-
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const statuses = getServiceStatuses();
     const activeIncidentCounts = getActiveIncidentCounts();
@@ -64,9 +48,19 @@ export async function GET() {
       return latest;
     }, null as string | null);
 
-    return NextResponse.json({
+    const responseData = {
       services,
       lastUpdated: latestCheck || new Date().toISOString(),
+    };
+
+    const body = JSON.stringify(responseData);
+    const etag = `"${createHash('md5').update(body).digest('hex')}"`;
+    if (request.headers.get('if-none-match') === etag) {
+      return new NextResponse(null, { status: 304, headers: { ETag: etag } });
+    }
+
+    return NextResponse.json(responseData, {
+      headers: { ETag: etag, 'Cache-Control': 'no-cache' },
     });
   } catch (err) {
     console.error('[api/status] Error:', err);

--- a/src/app/api/summary/route.ts
+++ b/src/app/api/summary/route.ts
@@ -1,0 +1,78 @@
+import { createHash } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceStatuses, getActiveIncidentCounts } from '@/lib/db';
+import { getServices } from '@/lib/services';
+import { ServiceStatus, SummaryResponse } from '@/lib/types';
+import { deriveOverallStatus } from '@/lib/statusUtils';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    const statuses = getServiceStatuses();
+    const activeIncidentCounts = getActiveIncidentCounts();
+    const services = getServices();
+
+    const statusMap = new Map(statuses.map((s) => [`${s.service_slug}:${s.source}`, s]));
+
+    let operational = 0;
+    let degraded = 0;
+    let majorOutage = 0;
+    let down = 0;
+    let unknown = 0;
+    let activeIncidents = 0;
+    let latestCheck: string | null = null;
+
+    for (const service of services) {
+      const official = statusMap.get(`${service.slug}:official`);
+      const dd = statusMap.get(`${service.slug}:downdetector`);
+
+      const officialStatus: ServiceStatus = (official?.status as ServiceStatus) || 'unknown';
+      const ddStatus: ServiceStatus = (dd?.status as ServiceStatus) || 'unknown';
+      const incidentCount = activeIncidentCounts[service.slug] || 0;
+      activeIncidents += incidentCount;
+
+      const overall = deriveOverallStatus(officialStatus, ddStatus, incidentCount);
+      switch (overall) {
+        case 'operational': operational++; break;
+        case 'degraded': degraded++; break;
+        case 'major_outage': majorOutage++; break;
+        case 'down': down++; break;
+        default: unknown++;
+      }
+
+      const checkedAt = official?.checked_at || dd?.checked_at;
+      if (checkedAt && (!latestCheck || checkedAt > latestCheck)) latestCheck = checkedAt;
+    }
+
+    const totalServices = services.length;
+    const uptimePct = totalServices > 0
+      ? Math.round((operational / totalServices) * 1000) / 10
+      : 100;
+
+    const response: SummaryResponse = {
+      totalServices,
+      operational,
+      degraded,
+      majorOutage,
+      down,
+      unknown,
+      activeIncidents,
+      uptimePct,
+      lastUpdated: latestCheck || new Date().toISOString(),
+    };
+
+    const body = JSON.stringify(response);
+    const etag = `"${createHash('md5').update(body).digest('hex')}"`;
+    if (request.headers.get('if-none-match') === etag) {
+      return new NextResponse(null, { status: 304, headers: { ETag: etag } });
+    }
+
+    return NextResponse.json(response, {
+      headers: { ETag: etag, 'Cache-Control': 'no-cache' },
+    });
+  } catch (err) {
+    console.error('[api/summary] Error:', err);
+    return NextResponse.json({ error: 'Failed to compute summary' }, { status: 500 });
+  }
+}

--- a/src/components/AddTilePopover.tsx
+++ b/src/components/AddTilePopover.tsx
@@ -20,13 +20,16 @@ interface Props {
 }
 
 const TILES: { type: TileType; name: string; desc: string }[] = [
-  { type: 'stat',          name: 'Stat',          desc: 'Single metric: uptime, MTTR, incidents…' },
-  { type: 'service-watch', name: 'Service Watch',  desc: 'Single service with sparkline + datapoints' },
-  { type: 'service-grid',  name: 'Service Grid',   desc: 'Status of many services at a glance' },
-  { type: 'incident-feed', name: 'Incident Feed',  desc: 'Recent + active incidents timeline' },
-  { type: 'uptime-chart',  name: 'Uptime Chart',   desc: '30-day uptime history for one service' },
-  { type: 'status-map',    name: 'Heat Map',       desc: 'Geographic outage report density' },
-  { type: 'rss',           name: 'RSS Feed',       desc: 'Engineering blogs, release notes' },
+  { type: 'stat',             name: 'Stat',             desc: 'Single metric: uptime, MTTR, incidents…' },
+  { type: 'service-watch',    name: 'Service Watch',    desc: 'Single service with sparkline + datapoints' },
+  { type: 'service-grid',     name: 'Service Grid',     desc: 'Status of many services at a glance' },
+  { type: 'incident-feed',    name: 'Incident Feed',    desc: 'Recent + active incidents timeline' },
+  { type: 'uptime-chart',     name: 'Uptime Chart',     desc: '30-day uptime history for one service' },
+  { type: 'status-map',       name: 'Heat Map',         desc: 'Geographic outage report density' },
+  { type: 'rss',              name: 'RSS Feed',         desc: 'Engineering blogs, release notes' },
+  { type: 'incident-metrics', name: 'Incident Metrics', desc: 'MTTR by severity & resolution rate' },
+  { type: 'fetcher-health',   name: 'Fetcher Health',   desc: 'Source latency & consecutive failures' },
+  { type: 'alert-audit',      name: 'Alert History',    desc: 'Last 50 alert delivery events' },
 ];
 
 type Tab = 'tiles' | 'templates';

--- a/src/components/AlertsView.tsx
+++ b/src/components/AlertsView.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import useSWR from 'swr';
-import { useServiceStatus } from '@/hooks/useStatus';
+import { useServiceStatus, useAlertLog } from '@/hooks/useStatus';
 import { AlertRule, IncidentSeverity } from '@/lib/types';
 import PageHeader from './ui/PageHeader';
 import Card from './ui/Card';
@@ -78,6 +78,10 @@ export default function AlertsView() {
   const [feedback, setFeedback] = useState<TestFeedback | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<typeof draft | null>(null);
+  const [logOpen, setLogOpen] = useState(false);
+  const { data: logData } = useAlertLog(logOpen);
 
   // One-shot migration: lift any rules left in localStorage from the old
   // client-only implementation up into the server, then clear the key.
@@ -195,6 +199,44 @@ export default function AlertsView() {
       mutate();
     } catch {
       mutate();
+    }
+  };
+
+  const startEdit = (rule: AlertRule) => {
+    setEditingId(rule.id);
+    setEditDraft({
+      email: rule.email,
+      services: rule.services ?? [],
+      minSeverity: rule.minSeverity,
+      emailEnabled: rule.emailEnabled ?? true,
+      desktopEnabled: false,
+      webhookUrl: rule.webhookUrl ?? '',
+      webhookEnabled: rule.webhookEnabled ?? false,
+    });
+  };
+
+  const handleSave = async (id: string) => {
+    if (!editDraft) return;
+    const webhookUrlTrimmed = editDraft.webhookUrl.trim();
+    try {
+      const res = await fetch(`${RULES_API}/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          services: editDraft.services,
+          minSeverity: editDraft.minSeverity,
+          emailEnabled: editDraft.emailEnabled,
+          webhookUrl: webhookUrlTrimmed || undefined,
+          webhookEnabled: editDraft.webhookEnabled && !!webhookUrlTrimmed,
+        }),
+      });
+      if (res.ok) {
+        setEditingId(null);
+        setEditDraft(null);
+        mutate();
+      }
+    } catch {
+      /* ignore */
     }
   };
 
@@ -513,6 +555,15 @@ export default function AlertsView() {
                     {isTesting ? 'Sending…' : 'Send test'}
                   </button>
                   <button
+                    onClick={() => editingId === r.id ? (setEditingId(null), setEditDraft(null)) : startEdit(r)}
+                    className="p-2 rounded-md text-muted hover:text-accent-cyan hover:bg-white/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                    aria-label={`Edit rule for ${r.email}`}
+                  >
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.8} stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+                    </svg>
+                  </button>
+                  <button
                     onClick={() => deleteRule(r.id)}
                     className="p-2 rounded-md text-muted hover:text-red-400 hover:bg-red-500/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                     aria-label={`Delete rule for ${r.email}`}
@@ -522,6 +573,102 @@ export default function AlertsView() {
                     </svg>
                   </button>
                 </div>
+                {editingId === r.id && editDraft && (
+                  <div className="mt-3 pt-3 border-t border-subtle space-y-4">
+                    <p className="text-xs text-muted">Editing rule for <span className="text-foreground font-medium">{r.email}</span></p>
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                      <div>
+                        <label className="block text-xs font-medium text-muted mb-1.5">Minimum severity</label>
+                        <div className="flex items-center gap-0.5 p-1 rounded-lg bg-surface border border-subtle">
+                          {SEVERITY_ORDER.map((s) => (
+                            <button
+                              key={s}
+                              onClick={() => setEditDraft({ ...editDraft, minSeverity: s })}
+                              aria-pressed={editDraft.minSeverity === s}
+                              className={`flex-1 px-3 py-1.5 rounded-md text-xs capitalize transition-all duration-150 ${
+                                editDraft.minSeverity === s
+                                  ? 'bg-surface-elevated text-foreground font-semibold shadow-sm'
+                                  : 'font-medium text-muted hover:text-foreground'
+                              }`}
+                            >
+                              {s}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                      <div>
+                        <label className="block text-xs font-medium text-muted mb-1.5">Channels</label>
+                        <div className="flex flex-wrap gap-2">
+                          <label className="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-subtle cursor-pointer hover:border-strong">
+                            <input type="checkbox" checked={editDraft.emailEnabled}
+                              onChange={(e) => setEditDraft({ ...editDraft, emailEnabled: e.target.checked })}
+                              className="accent-accent" />
+                            <span className="text-xs text-foreground">Email</span>
+                          </label>
+                        </div>
+                      </div>
+                      <div className="lg:col-span-2">
+                        <label className="block text-xs font-medium text-muted mb-1.5">Services ({editDraft.services.length} selected)</label>
+                        <div className="flex flex-wrap gap-2">
+                          {services.map((s) => {
+                            const sel = editDraft.services.includes(s.slug);
+                            return (
+                              <button
+                                key={s.slug}
+                                onClick={() => setEditDraft({
+                                  ...editDraft,
+                                  services: sel
+                                    ? editDraft.services.filter((x) => x !== s.slug)
+                                    : [...editDraft.services, s.slug],
+                                })}
+                                aria-pressed={sel}
+                                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border transition-all ${
+                                  sel ? 'border-accent bg-surface-elevated text-foreground' : 'border-subtle text-muted hover:border-strong'
+                                }`}
+                              >
+                                <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: s.color }} />
+                                {s.name}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                      <div className="lg:col-span-2">
+                        <label className="block text-xs font-medium text-muted mb-1.5">Webhook URL</label>
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="url"
+                            value={editDraft.webhookUrl}
+                            onChange={(e) => setEditDraft({ ...editDraft, webhookUrl: e.target.value })}
+                            placeholder="https://hooks.slack.com/..."
+                            className="flex-1 px-3 py-2 rounded-md bg-white/5 border border-subtle text-sm text-foreground placeholder:text-muted-strong focus:outline-none focus:border-accent/50"
+                          />
+                          <label className="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-subtle cursor-pointer hover:border-strong whitespace-nowrap">
+                            <input type="checkbox" checked={editDraft.webhookEnabled}
+                              disabled={!editDraft.webhookUrl.trim() || !/^https?:\/\//i.test(editDraft.webhookUrl.trim())}
+                              onChange={(e) => setEditDraft({ ...editDraft, webhookEnabled: e.target.checked })}
+                              className="accent-accent" />
+                            <span className="text-xs text-foreground">Enable</span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center justify-end gap-2 pt-2 border-t border-subtle">
+                      <button
+                        onClick={() => { setEditingId(null); setEditDraft(null); }}
+                        className="px-4 py-2 rounded-md text-xs font-medium text-muted hover:text-foreground"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        onClick={() => handleSave(r.id)}
+                        className="px-4 py-2 rounded-md bg-accent hover:opacity-90 text-white text-xs font-medium transition-opacity"
+                      >
+                        Save changes
+                      </button>
+                    </div>
+                  </div>
+                )}
                 {ruleFeedback && (
                   <div
                     role="status"
@@ -539,6 +686,56 @@ export default function AlertsView() {
               </Card>
             );
           })
+        )}
+      </section>
+
+      <section>
+        <button
+          onClick={() => setLogOpen((o) => !o)}
+          className="inline-flex items-center gap-2 text-xs font-medium text-muted hover:text-foreground transition-colors mb-3"
+        >
+          <svg
+            className={`w-3.5 h-3.5 transition-transform ${logOpen ? 'rotate-90' : ''}`}
+            fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+          </svg>
+          Alert history
+        </button>
+        {logOpen && (
+          <Card padded={false} className="overflow-hidden">
+            {!logData ? (
+              <p className="px-5 py-4 text-xs text-muted">Loading…</p>
+            ) : logData.log.length === 0 ? (
+              <p className="px-5 py-4 text-xs text-muted">No alerts have been sent yet.</p>
+            ) : (
+              <ul className="divide-y divide-white/[0.04]">
+                {logData.log.map((entry) => {
+                  const dotColor = entry.alert_type === 'email' ? '#268bd2'
+                    : entry.alert_type === 'webhook' ? '#6c71c4'
+                    : '#2aa198';
+                  const ts = new Date(entry.sent_at);
+                  const diffMs = Date.now() - ts.getTime();
+                  const diffMin = Math.floor(diffMs / 60000);
+                  const timeLabel = diffMin < 60 ? `${diffMin}m ago`
+                    : diffMin < 1440 ? `${Math.floor(diffMin / 60)}h ago`
+                    : `${Math.floor(diffMin / 1440)}d ago`;
+                  return (
+                    <li key={entry.id} className="flex items-center gap-3 px-5 py-2.5 text-xs">
+                      <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: dotColor }} />
+                      <span className="text-muted-strong tabular-nums w-16 flex-shrink-0">{timeLabel}</span>
+                      <span className="text-foreground font-medium">{entry.service_slug}</span>
+                      <span className="text-muted">·</span>
+                      <span className="text-muted">{entry.alert_type}</span>
+                      {entry.incident_id && (
+                        <span className="ml-auto text-muted text-[10px] tabular-nums">#{entry.incident_id.slice(0, 8)}</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </Card>
         )}
       </section>
     </div>

--- a/src/components/AlertsView.tsx
+++ b/src/components/AlertsView.tsx
@@ -62,12 +62,16 @@ export default function AlertsView() {
     minSeverity: IncidentSeverity;
     emailEnabled: boolean;
     desktopEnabled: boolean;
+    webhookUrl: string;
+    webhookEnabled: boolean;
   }>({
     email: '',
     services: [],
     minSeverity: 'major',
     emailEnabled: true,
     desktopEnabled: false,
+    webhookUrl: '',
+    webhookEnabled: false,
   });
   const [showForm, setShowForm] = useState(false);
   const [testing, setTesting] = useState<string | null>(null);
@@ -122,6 +126,7 @@ export default function AlertsView() {
     setSubmitting(true);
     setSubmitError(null);
     try {
+      const webhookUrlTrimmed = draft.webhookUrl.trim();
       const res = await fetch(RULES_API, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -130,6 +135,8 @@ export default function AlertsView() {
           services: draft.services,
           minSeverity: draft.minSeverity,
           emailEnabled: draft.emailEnabled,
+          webhookUrl: webhookUrlTrimmed || undefined,
+          webhookEnabled: draft.webhookEnabled && !!webhookUrlTrimmed,
           enabled: true,
         }),
       });
@@ -152,6 +159,8 @@ export default function AlertsView() {
         minSeverity: 'major',
         emailEnabled: true,
         desktopEnabled: false,
+        webhookUrl: '',
+        webhookEnabled: false,
       });
       setShowForm(false);
       mutate();
@@ -374,6 +383,32 @@ export default function AlertsView() {
                 </label>
               </div>
             </div>
+
+            <div className="lg:col-span-2">
+              <label className="block text-xs font-medium text-muted mb-2">Webhook URL <span className="text-muted-strong font-normal">(optional — Slack, Teams, or any HTTP endpoint)</span></label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="url"
+                  value={draft.webhookUrl}
+                  onChange={(e) => setDraft({ ...draft, webhookUrl: e.target.value, webhookEnabled: draft.webhookEnabled && !!e.target.value.trim() })}
+                  placeholder="https://hooks.slack.com/services/..."
+                  className="flex-1 px-3 py-2 rounded-md bg-white/5 border border-subtle text-sm text-foreground placeholder:text-muted-strong focus:outline-none focus:border-accent/50"
+                />
+                <label className="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-subtle cursor-pointer hover:border-strong whitespace-nowrap">
+                  <input
+                    type="checkbox"
+                    checked={draft.webhookEnabled}
+                    disabled={!draft.webhookUrl.trim() || !/^https?:\/\//i.test(draft.webhookUrl.trim())}
+                    onChange={(e) => setDraft({ ...draft, webhookEnabled: e.target.checked })}
+                    className="accent-accent"
+                  />
+                  <span className="text-xs text-foreground">Enable</span>
+                </label>
+              </div>
+              {draft.webhookUrl.trim() && !/^https?:\/\//i.test(draft.webhookUrl.trim()) && (
+                <p className="text-[11px] text-red-400 mt-1">URL must start with https://</p>
+              )}
+            </div>
           </div>
 
           {submitError && (
@@ -456,6 +491,11 @@ export default function AlertsView() {
                       </span>
                       {r.emailEnabled && (
                         <span className="text-[10px] text-muted">· email</span>
+                      )}
+                      {r.webhookEnabled && r.webhookUrl && (
+                        <span className="text-[10px] text-muted" title={r.webhookUrl}>
+                          · webhook ({(() => { try { return new URL(r.webhookUrl).hostname; } catch { return r.webhookUrl.slice(0, 30); } })()})
+                        </span>
                       )}
                     </div>
                     <p className="text-xs text-muted mt-1 truncate">

--- a/src/components/AnalyticsView.tsx
+++ b/src/components/AnalyticsView.tsx
@@ -227,6 +227,37 @@ export default function AnalyticsView() {
         </Card>
       </section>
 
+      {rows.length > 0 && aggregate.totalIncidents > 0 && (
+        <section>
+          <div className="flex items-center gap-2 mb-3">
+            <span className="w-1 h-5 rounded-full bg-accent" />
+            <h2 className="text-base font-semibold text-foreground">Top services by incidents</h2>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {[...rows]
+              .filter((r) => r.incidents > 0)
+              .sort((a, b) => b.incidents - a.incidents)
+              .slice(0, 5)
+              .map((r, i) => (
+                <div
+                  key={r.slug}
+                  className="flex items-center gap-3 px-4 py-2.5 rounded-xl surface-card border border-subtle"
+                >
+                  <span className="text-xs font-bold text-muted w-4">#{i + 1}</span>
+                  <span className="w-2 h-2 rounded-full" style={{ backgroundColor: r.color }} />
+                  <span className="text-sm font-medium text-foreground">{r.name}</span>
+                  <span className="text-xs text-muted ml-2">{r.incidents} incidents</span>
+                  {r.criticalIncidents > 0 && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-500/10 text-red-400">
+                      {r.criticalIncidents} crit
+                    </span>
+                  )}
+                </div>
+              ))}
+          </div>
+        </section>
+      )}
+
       {incidentChartData.length > 0 && (
         <section>
           <Card>

--- a/src/components/AnalyticsView.tsx
+++ b/src/components/AnalyticsView.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useCallback } from 'react';
 import { useServiceStatus, useHistory, useIncidents } from '@/hooks/useStatus';
+import { usePreferences } from '@/hooks/usePreferences';
 import { HistoryPoint } from '@/lib/types';
 import PageHeader from './ui/PageHeader';
 import StatTile from './ui/StatTile';
@@ -15,6 +16,7 @@ import {
   ResponsiveContainer,
   CartesianGrid,
   Cell,
+  Legend,
 } from 'recharts';
 
 function uptimeForService(points: HistoryPoint[]): number {
@@ -33,6 +35,8 @@ function mttrForService(points: HistoryPoint[]): number {
 export default function AnalyticsView() {
   const [rangeDays, setRangeDays] = useState<7 | 30 | 90>(30);
   const [search, setSearch] = useState('');
+  const prefs = usePreferences();
+  const slaTarget = prefs.slaTarget ?? 99.9;
 
   const { data: statusData } = useServiceStatus();
   const { data: historyData } = useHistory(rangeDays);
@@ -70,10 +74,24 @@ export default function AnalyticsView() {
       rows.reduce((s, r) => s + r.uptime, 0) / Math.max(rows.length, 1);
     const totalDowntime = rows.reduce((s, r) => s + r.totalDowntime, 0);
     const totalIncidents = rows.reduce((s, r) => s + r.incidents, 0);
-    const slaTarget = 99.9;
     const meetingSla = rows.filter((r) => r.uptime >= slaTarget).length;
     return { avgUptime, totalDowntime, totalIncidents, slaTarget, meetingSla };
-  }, [rows]);
+  }, [rows, slaTarget]);
+
+  const incidentChartData = useMemo(() => {
+    return rows
+      .filter((r) => r.incidents > 0)
+      .map((r) => {
+        const svcIncidents = incidents.filter((i) => i.service === r.slug);
+        return {
+          name: r.name.split(' ')[0],
+          critical: svcIncidents.filter((i) => i.severity === 'critical').length,
+          major:    svcIncidents.filter((i) => i.severity === 'major').length,
+          minor:    svcIncidents.filter((i) => i.severity === 'minor').length,
+        };
+      })
+      .sort((a, b) => (b.critical + b.major + b.minor) - (a.critical + a.major + a.minor));
+  }, [rows, incidents]);
 
   const visibleRows = useMemo(
     () => rows.filter((r) => r.name.toLowerCase().includes(search.toLowerCase())),
@@ -141,8 +159,8 @@ export default function AnalyticsView() {
           value={`${aggregate.avgUptime.toFixed(2)}%`}
           accent="green"
           hint="Across all services"
-          trend={aggregate.avgUptime >= 99.9 ? 'up' : 'down'}
-          trendLabel={aggregate.avgUptime >= 99.9 ? 'Above SLA' : 'Below 99.9%'}
+          trend={aggregate.avgUptime >= aggregate.slaTarget ? 'up' : 'down'}
+          trendLabel={aggregate.avgUptime >= aggregate.slaTarget ? 'Above SLA' : `Below ${aggregate.slaTarget}%`}
         />
         <StatTile
           label="SLA Compliance"
@@ -209,6 +227,49 @@ export default function AnalyticsView() {
         </Card>
       </section>
 
+      {incidentChartData.length > 0 && (
+        <section>
+          <Card>
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h2 className="text-sm font-semibold text-foreground">Incident breakdown by severity</h2>
+                <p className="text-xs text-muted mt-0.5">Services with at least one incident in the period</p>
+              </div>
+            </div>
+            <ResponsiveContainer width="100%" height={240}>
+              <BarChart data={incidentChartData} margin={{ top: 10, right: 20, bottom: 0, left: -10 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border-subtle)" />
+                <XAxis
+                  dataKey="name"
+                  tick={{ fill: 'var(--muted)', fontSize: 11 }}
+                  tickLine={false}
+                  axisLine={{ stroke: 'var(--border-strong)' }}
+                />
+                <YAxis
+                  tick={{ fill: 'var(--muted)', fontSize: 11 }}
+                  tickLine={false}
+                  axisLine={{ stroke: 'var(--border-strong)' }}
+                  allowDecimals={false}
+                />
+                <Tooltip
+                  contentStyle={{
+                    background: 'var(--surface-elevated)',
+                    border: '1px solid var(--border-strong)',
+                    borderRadius: 8,
+                    fontSize: 12,
+                    color: 'var(--foreground)',
+                  }}
+                />
+                <Legend wrapperStyle={{ fontSize: 11, color: 'var(--muted)' }} />
+                <Bar dataKey="critical" stackId="a" fill="#EF5350" name="Critical" radius={[0, 0, 0, 0]} />
+                <Bar dataKey="major" stackId="a" fill="#FF8A65" name="Major" />
+                <Bar dataKey="minor" stackId="a" fill="#FFD54F" name="Minor" radius={[6, 6, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </Card>
+        </section>
+      )}
+
       <section>
         <div className="flex items-center justify-between mb-3 gap-4 flex-wrap">
           <h2 className="text-base font-semibold text-foreground flex items-center gap-2">
@@ -264,7 +325,7 @@ export default function AnalyticsView() {
                       <td className="px-5 py-3 text-right tabular-nums">
                         <span
                           className={
-                            r.uptime >= 99.9
+                            r.uptime >= aggregate.slaTarget
                               ? 'text-emerald-400'
                               : r.uptime >= 99
                                 ? 'text-yellow-400'

--- a/src/components/AnalyticsView.tsx
+++ b/src/components/AnalyticsView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { useServiceStatus, useHistory, useIncidents } from '@/hooks/useStatus';
 import { HistoryPoint } from '@/lib/types';
 import PageHeader from './ui/PageHeader';
@@ -31,9 +31,12 @@ function mttrForService(points: HistoryPoint[]): number {
 }
 
 export default function AnalyticsView() {
+  const [rangeDays, setRangeDays] = useState<7 | 30 | 90>(30);
+  const [search, setSearch] = useState('');
+
   const { data: statusData } = useServiceStatus();
-  const { data: historyData } = useHistory(30);
-  const { data: incidentData } = useIncidents(30);
+  const { data: historyData } = useHistory(rangeDays);
+  const { data: incidentData } = useIncidents(rangeDays);
 
   const services = useMemo(() => statusData?.services || [], [statusData]);
   const history = useMemo(() => historyData?.history || {}, [historyData]);
@@ -72,6 +75,32 @@ export default function AnalyticsView() {
     return { avgUptime, totalDowntime, totalIncidents, slaTarget, meetingSla };
   }, [rows]);
 
+  const visibleRows = useMemo(
+    () => rows.filter((r) => r.name.toLowerCase().includes(search.toLowerCase())),
+    [rows, search],
+  );
+
+  const exportCsv = useCallback(() => {
+    const headers = ['Service', 'Uptime %', 'Downtime (min)', 'MTTR (min)', 'Incidents', 'Critical', 'SLA'];
+    const csvRows = visibleRows.map((r) => [
+      r.name,
+      r.uptimeLabel,
+      r.totalDowntime,
+      r.mttr,
+      r.incidents,
+      r.criticalIncidents,
+      r.uptime >= aggregate.slaTarget ? 'Met' : 'Breached',
+    ]);
+    const csv = [headers, ...csvRows].map((row) => row.join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `outage-analytics-${rangeDays}d.csv`;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }, [visibleRows, aggregate.slaTarget, rangeDays]);
+
   const uptimeChartData = rows.map((r) => ({
     name: r.name.split(' ')[0],
     uptime: Number(r.uptime.toFixed(2)),
@@ -85,10 +114,26 @@ export default function AnalyticsView() {
   return (
     <div className="space-y-8">
       <PageHeader
-        eyebrow="30-Day Analytics"
+        eyebrow={`${rangeDays}-Day Analytics`}
         title="Reliability & SLA trends"
         description="Uptime, downtime minutes, and incident distribution across monitored services."
       />
+
+      <div className="flex items-center gap-2">
+        <div className="inline-flex items-center gap-1 bg-white/5 rounded-full p-1">
+          {([7, 30, 90] as const).map((d) => (
+            <button
+              key={d}
+              onClick={() => setRangeDays(d)}
+              className={`px-3 py-1 text-xs rounded-full transition-colors ${
+                rangeDays === d ? 'bg-accent text-white' : 'text-muted hover:text-foreground'
+              }`}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+      </div>
 
       <section className="grid grid-cols-2 lg:grid-cols-4 gap-3 lg:gap-4">
         <StatTile
@@ -109,10 +154,10 @@ export default function AnalyticsView() {
           label="Total Downtime"
           value={`${Math.round(aggregate.totalDowntime / 60)}h`}
           accent="amber"
-          hint={`${aggregate.totalDowntime.toLocaleString()} min · last 30d`}
+          hint={`${aggregate.totalDowntime.toLocaleString()} min · last ${rangeDays}d`}
         />
         <StatTile
-          label="Incidents (30d)"
+          label={`Incidents (${rangeDays}d)`}
           value={aggregate.totalIncidents}
           accent={aggregate.totalIncidents > 10 ? 'red' : 'indigo'}
           hint="All severities"
@@ -124,7 +169,7 @@ export default function AnalyticsView() {
           <div className="flex items-center justify-between mb-4">
             <div>
               <h2 className="text-sm font-semibold text-foreground">Uptime by service</h2>
-              <p className="text-xs text-muted mt-0.5">30-day rolling window</p>
+              <p className="text-xs text-muted mt-0.5">{rangeDays}-day rolling window</p>
             </div>
             <span className="text-xs text-muted">SLA target: {aggregate.slaTarget}%</span>
           </div>
@@ -165,10 +210,30 @@ export default function AnalyticsView() {
       </section>
 
       <section>
-        <h2 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">
-          <span className="w-1 h-5 rounded-full bg-accent-cyan" />
-          Service reliability breakdown
-        </h2>
+        <div className="flex items-center justify-between mb-3 gap-4 flex-wrap">
+          <h2 className="text-base font-semibold text-foreground flex items-center gap-2">
+            <span className="w-1 h-5 rounded-full bg-accent-cyan" />
+            Service reliability breakdown
+          </h2>
+          <div className="flex items-center gap-2">
+            <input
+              type="search"
+              placeholder="Filter services…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="px-3 py-1.5 text-xs rounded-lg bg-white/5 border border-subtle text-foreground placeholder-muted focus:outline-none focus:border-accent"
+            />
+            <button
+              onClick={exportCsv}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg bg-white/5 border border-subtle text-foreground hover:bg-white/10 transition-colors"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+              </svg>
+              Export CSV
+            </button>
+          </div>
+        </div>
         <Card padded={false} className="overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -183,7 +248,7 @@ export default function AnalyticsView() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/[0.04]">
-                {rows.map((r) => {
+                {visibleRows.map((r) => {
                   const meets = r.uptime >= aggregate.slaTarget;
                   return (
                     <tr key={r.slug} className="hover:bg-white/[0.02] transition-colors">

--- a/src/components/OutageMapView.tsx
+++ b/src/components/OutageMapView.tsx
@@ -77,6 +77,7 @@ export default function OutageMapView() {
   const [selectedService, setSelectedService] = useState<string>('all');
   const [scope, setScope] = useState<Scope>('global');
   const [hoverRegion, setHoverRegion] = useState<string | null>(null);
+  const [hotspotPct, setHotspotPct] = useState(50);
 
   const filteredServices = useMemo(
     () =>
@@ -127,7 +128,7 @@ export default function OutageMapView() {
   const activeData = scope === 'global' ? worldData : naData;
   const maxReports = Math.max(1, ...activeData.map((r) => r.total));
   const totalReports = activeData.reduce((s, r) => s + r.total, 0);
-  const hotspotRegions = activeData.filter((r) => r.total > maxReports * 0.5).length;
+  const hotspotRegions = activeData.filter((r) => r.total > maxReports * (hotspotPct / 100)).length;
   const peak = activeData.length
     ? activeData.reduce((a, b) => (b.total > a.total ? b : a), activeData[0])
     : null;
@@ -152,7 +153,7 @@ export default function OutageMapView() {
           label="Hotspots"
           value={hotspotRegions}
           accent={hotspotRegions > 0 ? 'red' : 'green'}
-          hint=">50% of peak"
+          hint={`>${hotspotPct}% of peak`}
         />
         <StatTile
           label="Peak Region"
@@ -213,6 +214,21 @@ export default function OutageMapView() {
                 {s.name.split(' ')[0]}
               </button>
             ))}
+          </div>
+          <div className="flex items-center gap-4 flex-wrap px-1">
+            <div className="flex items-center gap-2">
+              <label className="text-xs text-muted whitespace-nowrap">Hotspot ≥</label>
+              <input
+                type="range"
+                min={10}
+                max={90}
+                step={5}
+                value={hotspotPct}
+                onChange={(e) => setHotspotPct(Number(e.target.value))}
+                className="w-24 accent-accent"
+              />
+              <span className="text-xs text-muted-strong w-8 tabular-nums">{hotspotPct}%</span>
+            </div>
           </div>
         </div>
 

--- a/src/components/ServiceDetailView.tsx
+++ b/src/components/ServiceDetailView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useServiceStatus, useIncidents, useHistory } from '@/hooks/useStatus';
 import { HistoryPoint } from '@/lib/types';
 import StatTile from './ui/StatTile';
@@ -31,9 +31,11 @@ function formatDateTime(ts: string | null): string {
 }
 
 export default function ServiceDetailView({ slug }: Props) {
+  const [rangeDays, setRangeDays] = useState<30 | 60 | 90>(30);
+
   const { data: statusData } = useServiceStatus();
-  const { data: incidentData } = useIncidents(30);
-  const { data: historyData } = useHistory(30);
+  const { data: incidentData } = useIncidents(rangeDays);
+  const { data: historyData } = useHistory(rangeDays);
 
   const service = statusData?.services?.find((s) => s.slug === slug);
   const history = useMemo(
@@ -151,7 +153,7 @@ export default function ServiceDetailView({ slug }: Props) {
 
       <section className="grid grid-cols-2 lg:grid-cols-4 gap-3 lg:gap-4">
         <StatTile
-          label="30-Day Uptime"
+          label={`${rangeDays}-Day Uptime`}
           value={`${metrics.uptime.toFixed(2)}%`}
           accent={metrics.uptime >= 99.9 ? 'green' : metrics.uptime >= 99 ? 'amber' : 'red'}
           hint={metrics.uptime >= 99.9 ? 'Meeting SLA' : 'Below SLA'}
@@ -160,13 +162,13 @@ export default function ServiceDetailView({ slug }: Props) {
           label="Outage Days"
           value={metrics.outageDays}
           accent={metrics.outageDays > 0 ? 'amber' : 'green'}
-          hint="of last 30"
+          hint={`of last ${rangeDays}`}
         />
         <StatTile
           label="Total Downtime"
           value={metrics.totalDowntime > 60 ? `${(metrics.totalDowntime / 60).toFixed(1)}h` : `${metrics.totalDowntime}m`}
           accent="cyan"
-          hint="30d cumulative"
+          hint={`${rangeDays}d cumulative`}
         />
         <StatTile
           label="DD Reports"
@@ -177,7 +179,22 @@ export default function ServiceDetailView({ slug }: Props) {
       </section>
 
       <section>
-        <h2 className="text-base font-semibold text-foreground mb-3">History</h2>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-base font-semibold text-foreground">History</h2>
+          <div className="inline-flex items-center gap-1 bg-white/5 rounded-full p-1">
+            {([30, 60, 90] as const).map((d) => (
+              <button
+                key={d}
+                onClick={() => setRangeDays(d)}
+                className={`px-3 py-1 text-xs rounded-full transition-colors ${
+                  rangeDays === d ? 'bg-accent text-white' : 'text-muted hover:text-foreground'
+                }`}
+              >
+                {d}d
+              </button>
+            ))}
+          </div>
+        </div>
         <OutageChart
           serviceName={service.name}
           serviceColor={service.color}
@@ -189,12 +206,12 @@ export default function ServiceDetailView({ slug }: Props) {
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-base font-semibold text-foreground">Recent incidents</h2>
           <span className="text-xs text-muted">
-            {incidents.length} in last 30 days · {metrics.critical} critical
+            {incidents.length} in last {rangeDays} days · {metrics.critical} critical
           </span>
         </div>
         {incidents.length === 0 ? (
           <Card className="text-center py-10 text-sm text-muted">
-            No incidents reported in the last 30 days.
+            No incidents reported in the last {rangeDays} days.
           </Card>
         ) : (
           <div className="space-y-2">

--- a/src/components/ServiceDetailView.tsx
+++ b/src/components/ServiceDetailView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useServiceStatus, useIncidents, useHistory } from '@/hooks/useStatus';
 import { HistoryPoint } from '@/lib/types';
 import StatTile from './ui/StatTile';
@@ -59,6 +59,27 @@ export default function ServiceDetailView({ slug }: Props) {
       ? [...result].sort((a, b) => (a.startedAt ?? '').localeCompare(b.startedAt ?? ''))
       : result;
   }, [incidents, incidentStatusFilter, incidentSeverity, incidentSort]);
+
+  const exportIncidentsCsv = useCallback(() => {
+    const headers = ['ID', 'Title', 'Severity', 'Status', 'Started', 'Resolved', 'Description'];
+    const csvRows = filteredIncidents.map((inc) => [
+      inc.id,
+      `"${(inc.title || '').replace(/"/g, '""')}"`,
+      inc.severity,
+      inc.status,
+      inc.startedAt ?? '',
+      inc.resolvedAt ?? '',
+      `"${(inc.description || '').replace(/"/g, '""')}"`,
+    ]);
+    const csv = [headers, ...csvRows].map((row) => row.join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${slug}-incidents-${rangeDays}d.csv`;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }, [filteredIncidents, slug, rangeDays]);
 
   const metrics = useMemo(() => {
     const uptime = uptimeForService(history);
@@ -218,9 +239,22 @@ export default function ServiceDetailView({ slug }: Props) {
       <section>
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-base font-semibold text-foreground">Recent incidents</h2>
-          <span className="text-xs text-muted">
-            {incidents.length} in last {rangeDays} days · {metrics.critical} critical
-          </span>
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-muted">
+              {incidents.length} in last {rangeDays} days · {metrics.critical} critical
+            </span>
+            {filteredIncidents.length > 0 && (
+              <button
+                onClick={exportIncidentsCsv}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-lg bg-white/5 border border-subtle text-muted hover:text-foreground hover:bg-white/10 transition-colors"
+              >
+                <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                </svg>
+                CSV
+              </button>
+            )}
+          </div>
         </div>
         <div className="flex items-center gap-2 flex-wrap mb-3">
           <div className="inline-flex items-center gap-0.5 bg-white/5 rounded-full p-0.5">

--- a/src/components/ServiceDetailView.tsx
+++ b/src/components/ServiceDetailView.tsx
@@ -32,6 +32,9 @@ function formatDateTime(ts: string | null): string {
 
 export default function ServiceDetailView({ slug }: Props) {
   const [rangeDays, setRangeDays] = useState<30 | 60 | 90>(30);
+  const [incidentStatusFilter, setIncidentStatusFilter] = useState<'all' | 'active' | 'resolved'>('all');
+  const [incidentSeverity, setIncidentSeverity] = useState<string[]>([]);
+  const [incidentSort, setIncidentSort] = useState<'newest' | 'oldest'>('newest');
 
   const { data: statusData } = useServiceStatus();
   const { data: incidentData } = useIncidents(rangeDays);
@@ -46,6 +49,16 @@ export default function ServiceDetailView({ slug }: Props) {
     () => (incidentData?.incidents || []).filter((i) => i.service === slug),
     [incidentData, slug],
   );
+
+  const filteredIncidents = useMemo(() => {
+    let result = incidents;
+    if (incidentStatusFilter === 'active') result = result.filter((i) => i.status !== 'resolved');
+    if (incidentStatusFilter === 'resolved') result = result.filter((i) => i.status === 'resolved');
+    if (incidentSeverity.length) result = result.filter((i) => incidentSeverity.includes(i.severity));
+    return incidentSort === 'oldest'
+      ? [...result].sort((a, b) => (a.startedAt ?? '').localeCompare(b.startedAt ?? ''))
+      : result;
+  }, [incidents, incidentStatusFilter, incidentSeverity, incidentSort]);
 
   const metrics = useMemo(() => {
     const uptime = uptimeForService(history);
@@ -209,13 +222,51 @@ export default function ServiceDetailView({ slug }: Props) {
             {incidents.length} in last {rangeDays} days · {metrics.critical} critical
           </span>
         </div>
-        {incidents.length === 0 ? (
+        <div className="flex items-center gap-2 flex-wrap mb-3">
+          <div className="inline-flex items-center gap-0.5 bg-white/5 rounded-full p-0.5">
+            {(['all', 'active', 'resolved'] as const).map((f) => (
+              <button
+                key={f}
+                onClick={() => setIncidentStatusFilter(f)}
+                className={`px-2.5 py-1 text-xs rounded-full capitalize transition-colors ${
+                  incidentStatusFilter === f ? 'bg-accent text-white' : 'text-muted hover:text-foreground'
+                }`}
+              >
+                {f}
+              </button>
+            ))}
+          </div>
+          {(['critical', 'major', 'minor'] as const).map((s) => (
+            <button
+              key={s}
+              onClick={() => setIncidentSeverity((prev) =>
+                prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]
+              )}
+              className={`px-2.5 py-1 text-xs rounded-full border capitalize transition-colors ${
+                incidentSeverity.includes(s)
+                  ? 'border-accent bg-accent/10 text-foreground'
+                  : 'border-subtle text-muted hover:border-strong'
+              }`}
+            >
+              {s}
+            </button>
+          ))}
+          <button
+            onClick={() => setIncidentSort((s) => s === 'newest' ? 'oldest' : 'newest')}
+            className="ml-auto px-2.5 py-1 text-xs rounded-full border border-subtle text-muted hover:text-foreground transition-colors"
+          >
+            {incidentSort === 'newest' ? '↓ Newest' : '↑ Oldest'}
+          </button>
+        </div>
+        {filteredIncidents.length === 0 ? (
           <Card className="text-center py-10 text-sm text-muted">
-            No incidents reported in the last {rangeDays} days.
+            {incidents.length === 0
+              ? `No incidents reported in the last ${rangeDays} days.`
+              : 'No incidents match the current filters.'}
           </Card>
         ) : (
           <div className="space-y-2">
-            {incidents.map((inc) => (
+            {filteredIncidents.map((inc) => (
               <Card key={inc.id} className="flex items-start gap-4 flex-wrap">
                 <span
                   className={`mt-1 w-2 h-2 rounded-full ${

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -219,6 +219,28 @@ export default function SettingsView() {
               />
             </button>
           </div>
+
+          <div className="flex items-center justify-between py-2 border-t border-subtle">
+            <div>
+              <p className="text-sm text-foreground">SLA target</p>
+              <p className="text-[11px] text-muted">Uptime % threshold for compliance badges in Analytics</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                min={90}
+                max={100}
+                step={0.01}
+                value={prefs.slaTarget ?? 99.9}
+                onChange={(e) => {
+                  const v = parseFloat(e.target.value);
+                  if (!isNaN(v) && v >= 90 && v <= 100) update('slaTarget', v);
+                }}
+                className="w-20 px-2 py-1.5 rounded-md bg-white/5 border border-subtle text-sm text-foreground text-right focus:outline-none focus:border-accent"
+              />
+              <span className="text-xs text-muted">%</span>
+            </div>
+          </div>
         </div>
       </Card>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useServiceStatus } from '@/hooks/useStatus';
+import { useServiceStatus, useSummary } from '@/hooks/useStatus';
 import { useSidebar } from './SidebarContext';
 
 interface NavItem {
@@ -88,9 +88,13 @@ export default function Sidebar() {
   const pathname = usePathname();
   const { collapsed, setCollapsed } = useSidebar();
   const { data } = useServiceStatus();
+  const { data: summary } = useSummary(60000);
   const services = data?.services || [];
   const health = getOverallHealth(services.map((s) => s.overallStatus));
-  const operational = services.filter((s) => s.overallStatus === 'operational').length;
+  const operational = summary?.operational ?? services.filter((s) => s.overallStatus === 'operational').length;
+  const total = summary?.totalServices ?? services.length;
+  const activeIncidents = summary?.activeIncidents ?? 0;
+  const uptimePct = summary?.uptimePct;
 
   const isActive = (href: string) =>
     href === '/' ? pathname === '/' : pathname?.startsWith(href);
@@ -170,15 +174,23 @@ export default function Sidebar() {
             <span className={`text-xs font-medium ${health.tone}`}>{health.label}</span>
           </div>
           <div className="text-[11px] text-muted">
-            {operational}/{services.length || '—'} services operational
+            {operational}/{total || '—'} services operational
           </div>
+          {activeIncidents > 0 && (
+            <div className="text-[11px] text-amber-400 mt-1">
+              {activeIncidents} active incident{activeIncidents !== 1 ? 's' : ''}
+            </div>
+          )}
+          {uptimePct !== undefined && (
+            <div className="text-[11px] text-muted mt-1">
+              {uptimePct.toFixed(1)}% uptime
+            </div>
+          )}
           <div className="mt-2 w-full h-1 rounded-full bg-white/5 overflow-hidden">
             <div
               className="h-full bg-gradient-to-r from-emerald-400 to-cyan-400 transition-all"
               style={{
-                width: services.length
-                  ? `${(operational / services.length) * 100}%`
-                  : '0%',
+                width: total ? `${(operational / total) * 100}%` : '0%',
               }}
             />
           </div>

--- a/src/components/SourcesView.tsx
+++ b/src/components/SourcesView.tsx
@@ -96,6 +96,8 @@ export default function SourcesView() {
   const [contributing, setContributing] = useState(false);
   const [contributeMessage, setContributeMessage] = useState<{ ok: boolean; text: string; url?: string } | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<{ name: string; color: string; refreshSeconds: number } | null>(null);
 
   const openContribute = () => {
     setContributeMessage(null);
@@ -158,6 +160,41 @@ export default function SourcesView() {
         setError(body.error || `Request failed (HTTP ${res.status})`);
         return;
       }
+      mutate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error');
+    }
+  };
+
+  const startEdit = (src: ImportedSource) => {
+    const row = sourceRows.find((r) => r.id === src.id);
+    setEditingId(src.id);
+    setEditDraft({
+      name: src.name,
+      color: src.color,
+      refreshSeconds: row?.refreshSeconds ?? src.refresh,
+    });
+  };
+
+  const handleEditSave = async (id: string) => {
+    if (!editDraft) return;
+    try {
+      const res = await fetch(`${SOURCES_API}/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: editDraft.name,
+          color: editDraft.color,
+          refreshSeconds: editDraft.refreshSeconds,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body.error || `Update failed (HTTP ${res.status})`);
+        return;
+      }
+      setEditingId(null);
+      setEditDraft(null);
       mutate();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Network error');
@@ -290,17 +327,14 @@ export default function SourcesView() {
               : h.lastLatencyMs < 2000 ? '#b58900'
               : '#dc322f';
             return (
+            <div key={src.id} style={{ borderRadius: 12, overflow: 'hidden', border: '1px solid var(--border-subtle)' }}>
             <div
-              key={src.id}
               style={{
                 display: 'flex',
                 alignItems: 'center',
                 gap: 14,
                 padding: '14px 16px',
                 background: 'var(--surface)',
-                border: '1px solid var(--border-subtle)',
-                borderRadius: 12,
-                transition: 'border-color 140ms ease',
               }}
             >
               {/* Logo */}
@@ -369,6 +403,21 @@ export default function SourcesView() {
                 )}
               </div>
 
+              {/* Edit */}
+              <button
+                onClick={() => editingId === src.id ? (setEditingId(null), setEditDraft(null)) : startEdit(src)}
+                style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  width: 30, height: 30, background: 'transparent', border: 0,
+                  color: editingId === src.id ? 'var(--accent)' : 'var(--muted-strong)',
+                  borderRadius: 8, cursor: 'pointer', flexShrink: 0,
+                }}
+                title="Edit source"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
+                </svg>
+              </button>
               {/* Remove */}
               <button
                 onClick={() => handleRemove(src.id)}
@@ -391,6 +440,50 @@ export default function SourcesView() {
                   <path d="M18 6L6 18M6 6l12 12" />
                 </svg>
               </button>
+            </div>
+            {editingId === src.id && editDraft && (
+              <div style={{
+                padding: '12px 16px',
+                borderTop: '1px solid var(--border-subtle)',
+                background: 'var(--surface-elevated)',
+                display: 'flex',
+                gap: 10,
+                alignItems: 'flex-end',
+                flexWrap: 'wrap',
+              }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <label style={{ fontSize: 10, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: 0.4 }}>Name</label>
+                  <input
+                    style={{ padding: '5px 8px', borderRadius: 7, background: 'var(--surface)', border: '1px solid var(--border-subtle)', color: 'var(--foreground)', fontSize: 13, fontFamily: 'inherit', width: 160 }}
+                    value={editDraft.name}
+                    onChange={(e) => setEditDraft({ ...editDraft, name: e.target.value })}
+                  />
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <label style={{ fontSize: 10, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: 0.4 }}>Color</label>
+                  <input
+                    type="color"
+                    style={{ width: 40, height: 30, borderRadius: 7, border: '1px solid var(--border-subtle)', cursor: 'pointer', padding: 2 }}
+                    value={editDraft.color}
+                    onChange={(e) => setEditDraft({ ...editDraft, color: e.target.value })}
+                  />
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <label style={{ fontSize: 10, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: 0.4 }}>Refresh (s)</label>
+                  <input
+                    type="number"
+                    min={10}
+                    style={{ padding: '5px 8px', borderRadius: 7, background: 'var(--surface)', border: '1px solid var(--border-subtle)', color: 'var(--foreground)', fontSize: 13, fontFamily: 'inherit', width: 80 }}
+                    value={editDraft.refreshSeconds}
+                    onChange={(e) => setEditDraft({ ...editDraft, refreshSeconds: Math.max(10, parseInt(e.target.value) || 60) })}
+                  />
+                </div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <button className="board-btn" onClick={() => { setEditingId(null); setEditDraft(null); }}>Cancel</button>
+                  <button className="board-btn board-btn-primary" onClick={() => handleEditSave(src.id)}>Save</button>
+                </div>
+              </div>
+            )}
             </div>
             );
           })}

--- a/src/components/SourcesView.tsx
+++ b/src/components/SourcesView.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import useSWR from 'swr';
+import { useFetcherHealth, type FetcherHealthEntry } from '@/hooks/useStatus';
 import PageHeader from './ui/PageHeader';
 import ImportSlideOver from './ImportSlideOver';
 
@@ -84,6 +85,10 @@ export default function SourcesView() {
   });
   const sourceRows = data?.sources ?? [];
   const sources = sourceRows.map(rowToView);
+  const { data: healthData } = useFetcherHealth();
+  const healthBySlug: Record<string, FetcherHealthEntry> = Object.fromEntries(
+    (healthData?.fetchers ?? []).map((f) => [f.service, f])
+  );
   const [importOpen, setImportOpen] = useState(false);
   const [search, setSearch] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -277,7 +282,14 @@ export default function SourcesView() {
         </div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {filtered.map((src) => (
+          {filtered.map((src) => {
+            const row = sourceRows.find((r) => r.id === src.id);
+            const h = row ? healthBySlug[row.slug] : undefined;
+            const latencyColor = !h || h.lastLatencyMs === null ? 'var(--muted-strong)'
+              : h.lastLatencyMs < 500 ? '#2aa198'
+              : h.lastLatencyMs < 2000 ? '#b58900'
+              : '#dc322f';
+            return (
             <div
               key={src.id}
               style={{
@@ -338,6 +350,23 @@ export default function SourcesView() {
               <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3, flexShrink: 0, fontSize: 11, color: 'var(--muted-strong)' }}>
                 <span>Refresh every {src.refresh < 60 ? `${src.refresh}s` : `${src.refresh / 60}m`}</span>
                 <span>Added {relTime(src.addedAt)}</span>
+                {h && (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    {h.lastLatencyMs !== null && (
+                      <span style={{ color: latencyColor }}>{h.lastLatencyMs}ms</span>
+                    )}
+                    {h.consecutiveFailures > 0 ? (
+                      <span
+                        title={h.lastError ?? undefined}
+                        style={{ padding: '1px 5px', borderRadius: 999, background: 'rgba(220,50,47,0.15)', color: '#dc322f' }}
+                      >
+                        {h.consecutiveFailures} fail
+                      </span>
+                    ) : h.lastSuccessAt ? (
+                      <span style={{ color: '#2aa198' }}>✓ {relTime(h.lastSuccessAt)}</span>
+                    ) : null}
+                  </div>
+                )}
               </div>
 
               {/* Remove */}
@@ -363,7 +392,8 @@ export default function SourcesView() {
                 </svg>
               </button>
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
 

--- a/src/components/TileGrid.tsx
+++ b/src/components/TileGrid.tsx
@@ -11,6 +11,9 @@ import RssFeedTile from './tiles/RssFeedTile';
 import UptimeChartTile from './tiles/UptimeChartTile';
 import StatusMapTile from './tiles/StatusMapTile';
 import StatusPageTile from './tiles/StatusPageTile';
+import IncidentMetricsTile from './tiles/IncidentMetricsTile';
+import FetcherHealthTile from './tiles/FetcherHealthTile';
+import AlertAuditTile from './tiles/AlertAuditTile';
 
 const ROW_HEIGHT = 88;            // matches .tile-grid grid-auto-rows in globals.css
 const ROW_HEIGHT_COMPACT = 72;    // ".compact" density override
@@ -65,14 +68,17 @@ function TileComponent({ tile, editing, live, onUpdate, onRemove, onResize, onTo
   };
 
   switch (tile.type) {
-    case 'service-watch':  return <ServiceWatchTile  {...common} config={tile.config as { service?: string }} />;
-    case 'service-grid':   return <ServiceGridTile   {...common} />;
-    case 'incident-feed':  return <IncidentFeedTile  {...common} />;
-    case 'stat':           return <BoardStatTile      {...common} />;
-    case 'rss':            return <RssFeedTile        {...common} />;
-    case 'uptime-chart':   return <UptimeChartTile    {...common} />;
-    case 'status-map':     return <StatusMapTile      {...common} />;
-    case 'statuspage':     return <StatusPageTile     {...common} />;
+    case 'service-watch':     return <ServiceWatchTile     {...common} config={tile.config as { service?: string }} />;
+    case 'service-grid':      return <ServiceGridTile      {...common} />;
+    case 'incident-feed':     return <IncidentFeedTile     {...common} />;
+    case 'stat':              return <BoardStatTile         {...common} />;
+    case 'rss':               return <RssFeedTile           {...common} />;
+    case 'uptime-chart':      return <UptimeChartTile       {...common} />;
+    case 'status-map':        return <StatusMapTile         {...common} />;
+    case 'statuspage':        return <StatusPageTile        {...common} />;
+    case 'incident-metrics':  return <IncidentMetricsTile   {...common} />;
+    case 'fetcher-health':    return <FetcherHealthTile     {...common} />;
+    case 'alert-audit':       return <AlertAuditTile        {...common} />;
     default:               return null;
   }
 }

--- a/src/components/tiles/AlertAuditTile.tsx
+++ b/src/components/tiles/AlertAuditTile.tsx
@@ -1,0 +1,86 @@
+import TileChrome from './TileChrome';
+import type { TileProps } from './types';
+import { useAlertLog } from '@/hooks/useStatus';
+
+function relTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diffMs / 60000);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+const TYPE_COLOR: Record<string, string> = {
+  email:   '#268bd2',
+  webhook: '#6c71c4',
+  desktop: '#2aa198',
+};
+
+export default function AlertAuditTile({
+  config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure,
+}: TileProps) {
+  const { data, isLoading } = useAlertLog(true, 60000);
+  const entries = data?.log ?? [];
+
+  return (
+    <TileChrome
+      title="Alert History"
+      icon={
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
+        </svg>
+      }
+      badge={<span className="count-pill">{entries.length}</span>}
+      label={typeof config.label === 'string' ? config.label : null}
+      iconText={typeof config.icon === 'string' ? config.icon : null}
+      tag={typeof config.tag === 'string' ? config.tag : null}
+      editing={editing}
+      onResize={onResize}
+      onRemove={onRemove}
+      onDuplicate={onDuplicate}
+      onRename={onRename}
+      onConfigure={onConfigure}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', overflowY: 'auto', flex: 1 }}>
+        {isLoading && entries.length === 0 ? (
+          <div style={{ fontSize: 11, color: 'var(--muted)' }}>Loading…</div>
+        ) : entries.length === 0 ? (
+          <div style={{ fontSize: 11, color: 'var(--muted)' }}>No alerts have been sent yet.</div>
+        ) : (
+          entries.map((entry) => (
+            <div
+              key={entry.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                padding: '5px 0',
+                borderBottom: '1px solid var(--border-subtle)',
+              }}
+            >
+              <span
+                style={{
+                  width: 6,
+                  height: 6,
+                  borderRadius: '50%',
+                  background: TYPE_COLOR[entry.alert_type] ?? 'var(--muted)',
+                  flexShrink: 0,
+                }}
+              />
+              <span style={{ fontSize: 11, color: 'var(--foreground)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {entry.service_slug}
+              </span>
+              <span style={{ fontSize: 10, color: 'var(--muted)', flexShrink: 0 }}>
+                {entry.alert_type}
+              </span>
+              <span style={{ fontSize: 10, color: 'var(--muted-strong)', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+                {relTime(entry.sent_at)}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+    </TileChrome>
+  );
+}

--- a/src/components/tiles/BoardStatTile.tsx
+++ b/src/components/tiles/BoardStatTile.tsx
@@ -2,8 +2,9 @@ import { useMemo } from 'react';
 import TileChrome from './TileChrome';
 import type { TileProps } from './types';
 import type { HistoryPoint } from '@/lib/types';
+import { usePreferences } from '@/hooks/usePreferences';
 
-type MetricKey = 'uptime' | 'incidents' | 'dd' | 'mttr';
+type MetricKey = 'uptime' | 'incidents' | 'dd' | 'mttr' | 'sla';
 
 function mttrForService(points: HistoryPoint[]): number {
   const affected = points.filter((p) => p.outageMinutes > 0);
@@ -14,6 +15,8 @@ function mttrForService(points: HistoryPoint[]): number {
 export default function BoardStatTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure, live }: TileProps) {
   const metric = (config.metric as MetricKey) || 'uptime';
   const { services, incidents } = live;
+  const prefs = usePreferences();
+  const slaTarget = prefs.slaTarget ?? 99.9;
 
   const operational = services.filter((s) => s.overallStatus === 'operational').length;
   const total = services.length;
@@ -28,11 +31,28 @@ export default function BoardStatTile({ config, editing, onResize, onRemove, onD
     return avg < 60 ? `${avg}m` : `${Math.round(avg / 60)}h`;
   }, [live.history]);
 
+  const slaCompliance = useMemo(() => {
+    const pts = Object.values(live.history);
+    if (!pts.length) return { meeting: 0, total: 0 };
+    const slugs = Object.keys(live.history);
+    let meeting = 0;
+    for (const slug of slugs) {
+      const points = live.history[slug] || [];
+      if (!points.length) { meeting++; continue; }
+      const totalMin = points.length * 24 * 60;
+      const downMin = points.reduce((s, p) => s + (p.outageMinutes || 0), 0);
+      const uptime = ((totalMin - downMin) / totalMin) * 100;
+      if (uptime >= slaTarget) meeting++;
+    }
+    return { meeting, total: slugs.length };
+  }, [live.history, slaTarget]);
+
   const metrics: Record<MetricKey, { label: string; value: string | number; sub: string; accent: string }> = {
-    uptime:    { label: 'Fleet Uptime',     value: `${uptimePct}%`,           sub: `${operational}/${total} services healthy`, accent: '#7CB342' },
-    incidents: { label: 'Active Incidents', value: activeIncidents,           sub: `${incidents.length} total in view`,         accent: '#FFD54F' },
-    dd:        { label: 'DD Reports',       value: totalDD.toLocaleString(),  sub: 'Aggregated across services',                 accent: '#2aa198' },
-    mttr:      { label: 'MTTR (30d)',       value: mttrDisplay,               sub: mttrDisplay === '—' ? 'No outage data' : 'Mean time to recovery', accent: '#268bd2' },
+    uptime:    { label: 'Fleet Uptime',     value: `${uptimePct}%`,                sub: `${operational}/${total} services healthy`,          accent: '#7CB342' },
+    incidents: { label: 'Active Incidents', value: activeIncidents,                sub: `${incidents.length} total in view`,                  accent: '#FFD54F' },
+    dd:        { label: 'DD Reports',       value: totalDD.toLocaleString(),       sub: 'Aggregated across services',                         accent: '#2aa198' },
+    mttr:      { label: 'MTTR (30d)',       value: mttrDisplay,                   sub: mttrDisplay === '—' ? 'No outage data' : 'Mean time to recovery', accent: '#268bd2' },
+    sla:       { label: 'SLA Compliance',   value: `${slaCompliance.meeting}/${slaCompliance.total}`, sub: `≥${slaTarget}% uptime target`, accent: slaCompliance.meeting === slaCompliance.total ? '#7CB342' : '#FFD54F' },
   };
 
   const m = metrics[metric] ?? metrics.uptime;

--- a/src/components/tiles/BoardStatTile.tsx
+++ b/src/components/tiles/BoardStatTile.tsx
@@ -1,7 +1,15 @@
+import { useMemo } from 'react';
 import TileChrome from './TileChrome';
 import type { TileProps } from './types';
+import type { HistoryPoint } from '@/lib/types';
 
 type MetricKey = 'uptime' | 'incidents' | 'dd' | 'mttr';
+
+function mttrForService(points: HistoryPoint[]): number {
+  const affected = points.filter((p) => p.outageMinutes > 0);
+  if (!affected.length) return 0;
+  return affected.reduce((s, p) => s + p.outageMinutes, 0) / affected.length;
+}
 
 export default function BoardStatTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure, live }: TileProps) {
   const metric = (config.metric as MetricKey) || 'uptime';
@@ -13,11 +21,18 @@ export default function BoardStatTile({ config, editing, onResize, onRemove, onD
   const totalDD = services.reduce((sum, s) => sum + (s.downdetectorReports || 0), 0);
   const uptimePct = total > 0 ? ((operational / total) * 100).toFixed(1) : '0.0';
 
+  const mttrDisplay = useMemo(() => {
+    const slugMttrs = Object.values(live.history).map(mttrForService).filter((m) => m > 0);
+    if (!slugMttrs.length) return '—';
+    const avg = Math.round(slugMttrs.reduce((s, m) => s + m, 0) / slugMttrs.length);
+    return avg < 60 ? `${avg}m` : `${Math.round(avg / 60)}h`;
+  }, [live.history]);
+
   const metrics: Record<MetricKey, { label: string; value: string | number; sub: string; accent: string }> = {
     uptime:    { label: 'Fleet Uptime',     value: `${uptimePct}%`,           sub: `${operational}/${total} services healthy`, accent: '#7CB342' },
     incidents: { label: 'Active Incidents', value: activeIncidents,           sub: `${incidents.length} total in view`,         accent: '#FFD54F' },
     dd:        { label: 'DD Reports',       value: totalDD.toLocaleString(),  sub: 'Aggregated across services',                 accent: '#2aa198' },
-    mttr:      { label: 'MTTR (30d)',       value: '38m',                     sub: 'Mean time to recovery',                     accent: '#268bd2' },
+    mttr:      { label: 'MTTR (30d)',       value: mttrDisplay,               sub: mttrDisplay === '—' ? 'No outage data' : 'Mean time to recovery', accent: '#268bd2' },
   };
 
   const m = metrics[metric] ?? metrics.uptime;

--- a/src/components/tiles/FetcherHealthTile.tsx
+++ b/src/components/tiles/FetcherHealthTile.tsx
@@ -1,0 +1,113 @@
+import TileChrome from './TileChrome';
+import type { TileProps } from './types';
+import { useFetcherHealth } from '@/hooks/useStatus';
+
+function latencyColor(ms: number | null): string {
+  if (ms === null) return 'var(--muted)';
+  if (ms < 500)  return '#7CB342';
+  if (ms < 2000) return '#FFD54F';
+  return '#EF5350';
+}
+
+function relTime(iso: string | null): string {
+  if (!iso) return '—';
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diffMs / 60000);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+export default function FetcherHealthTile({
+  config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure,
+}: TileProps) {
+  const { data, isLoading } = useFetcherHealth(30000);
+  const fetchers = data?.fetchers ?? [];
+  const failing = fetchers.filter((f) => f.consecutiveFailures > 0).length;
+
+  return (
+    <TileChrome
+      title="Fetcher Health"
+      icon={
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+        </svg>
+      }
+      badge={
+        failing > 0 ? (
+          <span className="count-pill" style={{ background: 'rgba(239,83,80,0.18)', color: '#EF5350' }}>
+            {failing} failing
+          </span>
+        ) : (
+          <span className="count-pill" style={{ background: 'rgba(124,179,66,0.18)', color: '#7CB342' }}>
+            all ok
+          </span>
+        )
+      }
+      label={typeof config.label === 'string' ? config.label : null}
+      iconText={typeof config.icon === 'string' ? config.icon : null}
+      tag={typeof config.tag === 'string' ? config.tag : null}
+      editing={editing}
+      onResize={onResize}
+      onRemove={onRemove}
+      onDuplicate={onDuplicate}
+      onRename={onRename}
+      onConfigure={onConfigure}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', overflowY: 'auto', flex: 1, gap: 0 }}>
+        {isLoading && fetchers.length === 0 ? (
+          <div style={{ fontSize: 11, color: 'var(--muted)' }}>Loading…</div>
+        ) : fetchers.length === 0 ? (
+          <div style={{ fontSize: 11, color: 'var(--muted)' }}>No fetchers tracked yet.</div>
+        ) : (
+          fetchers.map((f) => {
+            const ok = f.consecutiveFailures === 0;
+            return (
+              <div
+                key={`${f.service}-${f.source}`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '5px 0',
+                  borderBottom: '1px solid var(--border-subtle)',
+                }}
+              >
+                <span
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: '50%',
+                    background: ok ? '#7CB342' : '#EF5350',
+                    flexShrink: 0,
+                  }}
+                />
+                <span style={{ fontSize: 11, color: 'var(--foreground)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {f.service}
+                </span>
+                {f.consecutiveFailures > 0 ? (
+                  <span
+                    title={f.lastError ?? undefined}
+                    style={{ fontSize: 10, color: '#EF5350', flexShrink: 0 }}
+                  >
+                    {f.consecutiveFailures}× fail
+                  </span>
+                ) : (
+                  <span style={{ fontSize: 10, color: 'var(--muted)', flexShrink: 0 }}>
+                    ✓ {relTime(f.lastSuccessAt)}
+                  </span>
+                )}
+                {f.lastLatencyMs !== null && (
+                  <span style={{ fontSize: 10, color: latencyColor(f.lastLatencyMs), width: 36, textAlign: 'right', flexShrink: 0 }}>
+                    {f.lastLatencyMs}ms
+                  </span>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </TileChrome>
+  );
+}

--- a/src/components/tiles/IncidentFeedTile.tsx
+++ b/src/components/tiles/IncidentFeedTile.tsx
@@ -13,15 +13,16 @@ const SEV_COLOR: Record<string, string> = {
 
 export default function IncidentFeedTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure, live }: TileProps) {
   const refreshMs = typeof config.refreshMs === 'number' ? config.refreshMs : undefined;
-  const override = useIncidents(7, refreshMs);
-  const allIncidents = refreshMs && override.data ? override.data.incidents : live.incidents;
-  const services = live.services;
-
   const filters = (config.filters ?? {}) as {
     severity?: string[];
     statuses?: string[];
     services?: string[];
+    days?: number;
   };
+  const days = typeof filters.days === 'number' ? filters.days : 7;
+  const override = useIncidents(days, refreshMs);
+  const allIncidents = override.data ? override.data.incidents : live.incidents;
+  const services = live.services;
   const incidents = allIncidents.filter((i) => {
     if (filters.severity && filters.severity.length && !filters.severity.includes(i.severity)) return false;
     if (filters.statuses && filters.statuses.length && !filters.statuses.includes(i.status)) return false;

--- a/src/components/tiles/IncidentFeedTile.tsx
+++ b/src/components/tiles/IncidentFeedTile.tsx
@@ -1,7 +1,20 @@
+import { useMemo } from 'react';
 import TileChrome from './TileChrome';
 import { relTime } from '@/lib/boardColors';
 import { useIncidents } from '@/hooks/useStatus';
 import type { TileProps } from './types';
+
+function dayLabel(iso: string | null): string {
+  if (!iso) return 'Unknown date';
+  const d = new Date(iso);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today.getTime() - 86400000);
+  const day = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  if (day.getTime() === today.getTime()) return 'Today';
+  if (day.getTime() === yesterday.getTime()) return 'Yesterday';
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
 
 const SEV_COLOR: Record<string, string> = {
   critical: '#EF5350',
@@ -30,6 +43,20 @@ export default function IncidentFeedTile({ config, editing, onResize, onRemove, 
     return true;
   });
   const activeCount = incidents.filter((i) => i.status !== 'resolved').length;
+
+  const grouped = useMemo(() => {
+    const groups: { day: string; items: typeof incidents }[] = [];
+    for (const inc of incidents) {
+      const label = dayLabel(inc.startedAt);
+      const last = groups[groups.length - 1];
+      if (last && last.day === label) {
+        last.items.push(inc);
+      } else {
+        groups.push({ day: label, items: [inc] });
+      }
+    }
+    return groups;
+  }, [incidents]);
 
   return (
     <TileChrome
@@ -61,29 +88,45 @@ export default function IncidentFeedTile({ config, editing, onResize, onRemove, 
         {incidents.length === 0 ? (
           <div style={{ fontSize: 12, color: 'var(--muted)', padding: '8px 0' }}>No incidents.</div>
         ) : (
-          incidents.map((inc) => {
-            const svc = services.find((s) => s.slug === inc.service);
-            const sevKey = inc.severity === 'critical' ? 'critical' : inc.severity;
-            const color = SEV_COLOR[inc.status === 'resolved' ? 'resolved' : sevKey] ?? '#FFD54F';
-            return (
-              <div key={inc.id} className="incident-row">
-                <div style={{ width: 3, alignSelf: 'stretch', background: color, borderRadius: 2 }} />
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-                    <span style={{ fontSize: 10, fontWeight: 700, color, textTransform: 'uppercase', letterSpacing: 0.5 }}>
-                      {inc.severity}
-                    </span>
-                    <span style={{ fontSize: 11, color: 'var(--muted-strong)' }}>·</span>
-                    <span style={{ fontSize: 11, color: 'var(--muted)' }}>{svc?.name ?? inc.service}</span>
-                    <span style={{ fontSize: 11, color: 'var(--muted-strong)', marginLeft: 'auto' }}>
-                      {relTime(inc.startedAt)}
-                    </span>
-                  </div>
-                  <div style={{ fontSize: 12, color: 'var(--foreground)', lineHeight: 1.4 }}>{inc.title}</div>
-                </div>
+          grouped.map(({ day, items }) => (
+            <div key={day}>
+              <div style={{
+                fontSize: 10,
+                fontWeight: 600,
+                color: 'var(--muted)',
+                textTransform: 'uppercase',
+                letterSpacing: 0.7,
+                padding: '6px 0 3px',
+                borderBottom: '1px solid var(--border-subtle)',
+                marginBottom: 2,
+              }}>
+                {day}
               </div>
-            );
-          })
+              {items.map((inc) => {
+                const svc = services.find((s) => s.slug === inc.service);
+                const sevKey = inc.severity === 'critical' ? 'critical' : inc.severity;
+                const color = SEV_COLOR[inc.status === 'resolved' ? 'resolved' : sevKey] ?? '#FFD54F';
+                return (
+                  <div key={inc.id} className="incident-row">
+                    <div style={{ width: 3, alignSelf: 'stretch', background: color, borderRadius: 2 }} />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+                        <span style={{ fontSize: 10, fontWeight: 700, color, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                          {inc.severity}
+                        </span>
+                        <span style={{ fontSize: 11, color: 'var(--muted-strong)' }}>·</span>
+                        <span style={{ fontSize: 11, color: 'var(--muted)' }}>{svc?.name ?? inc.service}</span>
+                        <span style={{ fontSize: 11, color: 'var(--muted-strong)', marginLeft: 'auto' }}>
+                          {relTime(inc.startedAt)}
+                        </span>
+                      </div>
+                      <div style={{ fontSize: 12, color: 'var(--foreground)', lineHeight: 1.4 }}>{inc.title}</div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ))
         )}
       </div>
     </TileChrome>

--- a/src/components/tiles/IncidentMetricsTile.tsx
+++ b/src/components/tiles/IncidentMetricsTile.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import TileChrome from './TileChrome';
+import type { TileProps } from './types';
+import { useIncidentMetrics } from '@/hooks/useStatus';
+
+function mttrLabel(minutes: number | undefined): string {
+  if (minutes === undefined) return '—';
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.round(minutes / 60)}h ${minutes % 60}m`;
+}
+
+export default function IncidentMetricsTile({
+  config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure,
+}: TileProps) {
+  const days = typeof config.days === 'number' ? config.days : 30;
+  const { data, isLoading } = useIncidentMetrics(days);
+
+  const [rangeDays, setRangeDays] = useState(days);
+  const { data: rangeData } = useIncidentMetrics(rangeDays);
+  const metrics = rangeData ?? data;
+
+  const critical = metrics?.mttrBySeverity?.critical;
+  const major = metrics?.mttrBySeverity?.major;
+  const minor = metrics?.mttrBySeverity?.minor;
+  const resRate = metrics?.resolutionRate ?? 0;
+  const maxMttr = Math.max(critical ?? 0, major ?? 0, minor ?? 0, 1);
+
+  return (
+    <TileChrome
+      title="Incident Metrics"
+      icon={
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+        </svg>
+      }
+      badge={
+        <span className="count-pill">{metrics?.totalIncidents ?? 0} total</span>
+      }
+      label={typeof config.label === 'string' ? config.label : null}
+      iconText={typeof config.icon === 'string' ? config.icon : null}
+      tag={typeof config.tag === 'string' ? config.tag : null}
+      editing={editing}
+      onResize={onResize}
+      onRemove={onRemove}
+      onDuplicate={onDuplicate}
+      onRename={onRename}
+      onConfigure={onConfigure}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, flex: 1 }}>
+        <div style={{ display: 'flex', gap: 4 }}>
+          {([7, 30, 90] as const).map((d) => (
+            <button
+              key={d}
+              onClick={() => setRangeDays(d)}
+              style={{
+                padding: '2px 8px',
+                borderRadius: 999,
+                fontSize: 10,
+                border: 'none',
+                cursor: 'pointer',
+                background: rangeDays === d ? 'var(--accent)' : 'var(--surface)',
+                color: rangeDays === d ? '#fff' : 'var(--muted)',
+              }}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+
+        {isLoading && !metrics ? (
+          <div style={{ fontSize: 11, color: 'var(--muted)' }}>Loading…</div>
+        ) : (
+          <>
+            <div style={{ fontSize: 10, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: 0.5, marginTop: 2 }}>
+              MTTR by severity
+            </div>
+            {[
+              { label: 'Critical', value: critical, color: '#EF5350' },
+              { label: 'Major',    value: major,    color: '#FF8A65' },
+              { label: 'Minor',    value: minor,    color: '#FFD54F' },
+            ].map(({ label, value, color }) => (
+              <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ fontSize: 10, color: 'var(--muted)', width: 40, flexShrink: 0 }}>{label}</span>
+                <div style={{ flex: 1, height: 6, borderRadius: 3, background: 'var(--surface)', overflow: 'hidden' }}>
+                  <div
+                    style={{
+                      height: '100%',
+                      borderRadius: 3,
+                      background: color,
+                      width: value !== undefined ? `${(value / maxMttr) * 100}%` : '0%',
+                      transition: 'width 400ms ease',
+                    }}
+                  />
+                </div>
+                <span style={{ fontSize: 10, color: 'var(--muted-strong)', width: 36, textAlign: 'right', flexShrink: 0 }}>
+                  {mttrLabel(value)}
+                </span>
+              </div>
+            ))}
+
+            <div style={{ marginTop: 4, paddingTop: 6, borderTop: '1px solid var(--border-subtle)' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <span style={{ fontSize: 10, color: 'var(--muted)' }}>Resolution rate</span>
+                <span style={{ fontSize: 13, fontWeight: 700, color: resRate >= 90 ? '#7CB342' : resRate >= 70 ? '#FFD54F' : '#EF5350' }}>
+                  {resRate.toFixed(0)}%
+                </span>
+              </div>
+              <div style={{ marginTop: 4, height: 4, borderRadius: 2, background: 'var(--surface)', overflow: 'hidden' }}>
+                <div
+                  style={{
+                    height: '100%',
+                    borderRadius: 2,
+                    background: resRate >= 90 ? '#7CB342' : resRate >= 70 ? '#FFD54F' : '#EF5350',
+                    width: `${resRate}%`,
+                    transition: 'width 400ms ease',
+                  }}
+                />
+              </div>
+              <div style={{ fontSize: 10, color: 'var(--muted)', marginTop: 3 }}>
+                {metrics?.resolvedIncidents ?? 0}/{metrics?.totalIncidents ?? 0} resolved in {rangeDays}d
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </TileChrome>
+  );
+}

--- a/src/components/tiles/RssFeedTile.tsx
+++ b/src/components/tiles/RssFeedTile.tsx
@@ -1,33 +1,35 @@
 import TileChrome from './TileChrome';
 import type { TileProps } from './types';
+import { useRssFeed } from '@/hooks/useStatus';
 
-const FEEDS = [
-  {
-    id: 'aws-blog',
-    name: "AWS What's New",
-    items: [
-      { title: 'Amazon RDS announces Multi-AZ deployments with two readable standbys', time: '2h ago' },
-      { title: 'AWS Lambda now supports SnapStart for Python and .NET functions', time: '4h ago' },
-      { title: 'Amazon EKS now supports Kubernetes version 1.30', time: '7h ago' },
-    ],
-  },
-  {
-    id: 'gh-blog',
-    name: 'GitHub Engineering',
-    items: [
-      { title: 'Inside the migration to Kubernetes for GitHub.com', time: '1d ago' },
-      { title: 'How we reduced p99 latency on the issues API by 60%', time: '2d ago' },
-    ],
-  },
-];
+const FEED_NAMES: Record<string, string> = {
+  'aws-blog': "AWS What's New",
+  'gh-blog': 'GitHub Engineering',
+};
+
+function formatDate(pubDate: string | null): string {
+  if (!pubDate) return '';
+  const d = new Date(pubDate);
+  if (isNaN(d.getTime())) return '';
+  const diffMs = Date.now() - d.getTime();
+  const diffH = Math.floor(diffMs / 3600000);
+  if (diffH < 1) return 'just now';
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.floor(diffH / 24);
+  return `${diffD}d ago`;
+}
 
 export default function RssFeedTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure }: TileProps) {
   const feedId = (config.feed as string) || 'aws-blog';
-  const feed = FEEDS.find((f) => f.id === feedId) ?? FEEDS[0];
+  const feedName = FEED_NAMES[feedId] || feedId;
+
+  const { data, isLoading, error } = useRssFeed(feedId);
+
+  const displayName = data?.title || feedName;
 
   return (
     <TileChrome
-      title={feed.name}
+      title={displayName}
       icon={
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <path d="M4 11a9 9 0 019 9M4 4a16 16 0 0116 16" />
@@ -46,10 +48,27 @@ export default function RssFeedTile({ config, editing, onResize, onRemove, onDup
       onConfigure={onConfigure}
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8, overflowY: 'auto', flex: 1 }}>
-        {feed.items.map((item, i) => (
-          <a key={i} className="rss-row" href="#" onClick={(e) => e.preventDefault()}>
+        {isLoading && (
+          <div style={{ color: 'var(--muted-strong)', fontSize: 12 }}>Loading feed…</div>
+        )}
+        {error && !isLoading && (
+          <div style={{ color: 'var(--muted-strong)', fontSize: 12 }}>Feed unavailable</div>
+        )}
+        {data?.items.map((item, i) => (
+          <a
+            key={i}
+            className="rss-row"
+            href={item.url || '#'}
+            target={item.url ? '_blank' : undefined}
+            rel="noopener noreferrer"
+            onClick={!item.url ? (e) => e.preventDefault() : undefined}
+          >
             <div style={{ fontSize: 12, color: 'var(--foreground)', lineHeight: 1.4 }}>{item.title}</div>
-            <div style={{ fontSize: 10, color: 'var(--muted-strong)', marginTop: 2 }}>{item.time}</div>
+            {item.publishedAt && (
+              <div style={{ fontSize: 10, color: 'var(--muted-strong)', marginTop: 2 }}>
+                {formatDate(item.publishedAt)}
+              </div>
+            )}
           </a>
         ))}
       </div>

--- a/src/components/tiles/RssFeedTile.tsx
+++ b/src/components/tiles/RssFeedTile.tsx
@@ -5,6 +5,7 @@ import { useRssFeed } from '@/hooks/useStatus';
 const FEED_NAMES: Record<string, string> = {
   'aws-blog': "AWS What's New",
   'gh-blog': 'GitHub Engineering',
+  'custom': 'Custom Feed',
 };
 
 function formatDate(pubDate: string | null): string {
@@ -21,9 +22,10 @@ function formatDate(pubDate: string | null): string {
 
 export default function RssFeedTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure }: TileProps) {
   const feedId = (config.feed as string) || 'aws-blog';
+  const customUrl = (config.customFeedUrl as string) || '';
   const feedName = FEED_NAMES[feedId] || feedId;
 
-  const { data, isLoading, error } = useRssFeed(feedId);
+  const { data, isLoading, error } = useRssFeed(feedId, customUrl);
 
   const displayName = data?.title || feedName;
 

--- a/src/components/tiles/ServiceGridTile.tsx
+++ b/src/components/tiles/ServiceGridTile.tsx
@@ -12,6 +12,30 @@ export default function ServiceGridTile({ config, editing, onResize, onRemove, o
     shown = shown.filter((s) => s.overallStatus !== 'operational');
   }
 
+  const counts = {
+    operational: shown.filter((s) => s.overallStatus === 'operational').length,
+    degraded:    shown.filter((s) => s.overallStatus === 'degraded').length,
+    outage:      shown.filter((s) => s.overallStatus === 'major_outage' || s.overallStatus === 'down').length,
+  };
+
+  const statusBadge = (
+    <div style={{ display: 'flex', gap: 4 }}>
+      {counts.outage > 0 && (
+        <span className="count-pill" style={{ background: 'rgba(239,83,80,0.18)', color: '#EF5350' }}>
+          {counts.outage} down
+        </span>
+      )}
+      {counts.degraded > 0 && (
+        <span className="count-pill" style={{ background: 'rgba(255,213,79,0.18)', color: '#FFD54F' }}>
+          {counts.degraded} degraded
+        </span>
+      )}
+      {counts.outage === 0 && counts.degraded === 0 && (
+        <span className="count-pill">{shown.length}</span>
+      )}
+    </div>
+  );
+
   return (
     <TileChrome
       title="Service Grid"
@@ -23,9 +47,7 @@ export default function ServiceGridTile({ config, editing, onResize, onRemove, o
           <rect x="14" y="14" width="7" height="7" />
         </svg>
       }
-      badge={
-        <span className="count-pill">{shown.length}</span>
-      }
+      badge={statusBadge}
       label={typeof config.label === 'string' ? config.label : null}
       iconText={typeof config.icon === 'string' ? config.icon : null}
       tag={typeof config.tag === 'string' ? config.tag : null}
@@ -36,6 +58,13 @@ export default function ServiceGridTile({ config, editing, onResize, onRemove, o
       onRename={onRename}
       onConfigure={onConfigure}
     >
+      {shown.length > 0 && (counts.degraded > 0 || counts.outage > 0) && (
+        <div style={{ fontSize: 11, color: 'var(--muted-strong)', marginBottom: 8, borderBottom: '1px solid var(--border-subtle)', paddingBottom: 6 }}>
+          {counts.operational} operational
+          {counts.degraded > 0 && <span style={{ color: '#FFD54F' }}> · {counts.degraded} degraded</span>}
+          {counts.outage > 0 && <span style={{ color: '#EF5350' }}> · {counts.outage} down</span>}
+        </div>
+      )}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))', gap: 8, overflowY: 'auto', flex: 1 }}>
         {shown.map((s) => {
           const c = getStatusColor(s.overallStatus);

--- a/src/components/tiles/ServiceWatchTile.tsx
+++ b/src/components/tiles/ServiceWatchTile.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import TileChrome from './TileChrome';
 import Sparkline from '../Sparkline';
 import { getStatusColor, historyToSparkline } from '@/lib/boardColors';
@@ -124,6 +125,23 @@ export default function ServiceWatchTile({
       ? ((hist.filter((p) => p.status === 'operational').length / hist.length) * 100).toFixed(2)
       : '—';
 
+  const stabilityText = useMemo(() => {
+    if (!hist.length) return null;
+    const reversed = [...hist].reverse();
+    const idx = reversed.findIndex((p) => p.status !== 'operational' || p.outageMinutes > 0);
+    if (idx === -1) return `Stable ${hist.length}d`;
+    if (idx === 0) return 'Issue today';
+    return `Last issue ${idx}d ago`;
+  }, [hist]);
+
+  const stabilityColor = useMemo(() => {
+    if (!hist.length) return 'var(--muted)';
+    const reversed = [...hist].reverse();
+    const idx = reversed.findIndex((p) => p.status !== 'operational' || p.outageMinutes > 0);
+    if (idx === -1 || idx > 3) return 'var(--muted)';
+    return idx === 0 ? '#EF5350' : '#FFD54F';
+  }, [hist]);
+
   return (
     <TileChrome
       title={svc.name}
@@ -160,8 +178,13 @@ export default function ServiceWatchTile({
         <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
           <div>
             <StatusBadge status={status} />
+            {stabilityText && (
+              <p style={{ margin: '4px 0 0', fontSize: 10, color: stabilityColor, letterSpacing: 0.3 }}>
+                {stabilityText}
+              </p>
+            )}
             {svc.details && (
-              <p style={{ margin: '8px 0 0', fontSize: 12, color: 'var(--muted)', lineHeight: 1.4 }}>
+              <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--muted)', lineHeight: 1.4 }}>
                 {svc.details}
               </p>
             )}

--- a/src/components/tiles/StatusMapTile.tsx
+++ b/src/components/tiles/StatusMapTile.tsx
@@ -1,30 +1,34 @@
 import TileChrome from './TileChrome';
 import type { TileProps } from './types';
 
-const REGIONS = [
-  { x: 18, y: 38, r: 14, hot: 0.9, label: 'us-west' },
-  { x: 38, y: 32, r: 10, hot: 0.3, label: 'us-central' },
-  { x: 72, y: 28, r: 16, hot: 0.7, label: 'us-east' },
-  { x: 88, y: 48, r: 8,  hot: 0.2, label: 'eu-west' },
-  { x: 50, y: 58, r: 9,  hot: 0.4, label: 'sa-east' },
+const REGION_SPECS = [
+  { x: 18, y: 38, r: 14, weight: 0.25, label: 'us-west' },
+  { x: 38, y: 32, r: 10, weight: 0.15, label: 'us-central' },
+  { x: 72, y: 28, r: 16, weight: 0.30, label: 'us-east' },
+  { x: 88, y: 48, r: 8,  weight: 0.20, label: 'eu-west' },
+  { x: 50, y: 58, r: 9,  weight: 0.10, label: 'sa-east' },
 ];
+
+const INCIDENT_WEIGHT = 40;
+const STATUS_FLOOR: Record<string, number> = {
+  operational: 0, unknown: 0, degraded: 30, major_outage: 90, down: 140,
+};
 
 function regionColor(hot: number): string {
   if (hot > 0.6) return '#EF5350';
-  if (hot > 0.4) return '#FFD54F';
+  if (hot > 0.2) return '#FFD54F';
   return '#7CB342';
 }
 
 export default function StatusMapTile({ config, editing, onResize, onRemove, onDuplicate, onRename, onConfigure, live }: TileProps) {
-  // Compute a rough "heat" per region based on active incidents
-  const activeIncidents = live.incidents.filter((i) => i.status !== 'resolved').length;
-  const totalServices = live.services.length || 1;
-  const issueServices = live.services.filter((s) => s.overallStatus !== 'operational').length;
-  const baseHeat = issueServices / totalServices;
+  const totalSignal = live.services.reduce((sum, s) => {
+    const floor = Math.max(STATUS_FLOOR[s.officialStatus] || 0, STATUS_FLOOR[s.overallStatus] || 0);
+    return sum + (s.downdetectorReports || 0) + (s.incidentCount || 0) * INCIDENT_WEIGHT + floor;
+  }, 0);
 
-  const regions = REGIONS.map((r) => ({
+  const regions = REGION_SPECS.map((r) => ({
     ...r,
-    hot: Math.min(1, r.hot * (1 + baseHeat) * (activeIncidents > 0 ? 1.2 : 1)),
+    hot: Math.min(1, (totalSignal * r.weight) / Math.max(1, 200)),
   }));
 
   return (

--- a/src/components/tiles/configs/index.tsx
+++ b/src/components/tiles/configs/index.tsx
@@ -53,6 +53,7 @@ const StatForm: ConfigForm = ({ tile, onUpdate }) => {
           <option value="incidents">Active incidents</option>
           <option value="dd">DD reports</option>
           <option value="mttr">MTTR (30d)</option>
+          <option value="sla">SLA compliance</option>
         </select>
       </div>
     </>
@@ -287,13 +288,38 @@ const RssForm: ConfigForm = ({ tile, onUpdate }) => {
 const StatusMapForm: ConfigForm = ({ tile, onUpdate }) => common(tile, onUpdate, { hideRefresh: true });
 const StatusPageForm: ConfigForm = ({ tile, onUpdate }) => common(tile, onUpdate, { hideRefresh: true });
 
+const IncidentMetricsForm: ConfigForm = ({ tile, onUpdate }) => {
+  const days = typeof tile.config.days === 'number' ? tile.config.days : 30;
+  return (
+    <>
+      {common(tile, onUpdate, { hideRefresh: true })}
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Default range</span></div>
+        <div className="twk-seg">
+          {[7, 30, 90].map((d) => (
+            <button key={d} data-on={days === d} onClick={() => update(tile, onUpdate, { days: d })}>
+              {d}d
+            </button>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+};
+
+const FetcherHealthForm: ConfigForm = ({ tile, onUpdate }) => common(tile, onUpdate, { hideRefresh: true });
+const AlertAuditForm: ConfigForm = ({ tile, onUpdate }) => common(tile, onUpdate, { hideRefresh: true });
+
 export const TILE_CONFIG_FORMS: Record<TileType, ConfigForm> = {
-  'stat':          StatForm,
-  'service-watch': ServiceWatchForm,
-  'service-grid':  ServiceGridForm,
-  'incident-feed': IncidentFeedForm,
-  'rss':           RssForm,
-  'uptime-chart':  UptimeChartForm,
-  'status-map':    StatusMapForm,
-  'statuspage':    StatusPageForm,
+  'stat':              StatForm,
+  'service-watch':     ServiceWatchForm,
+  'service-grid':      ServiceGridForm,
+  'incident-feed':     IncidentFeedForm,
+  'rss':               RssForm,
+  'uptime-chart':      UptimeChartForm,
+  'status-map':        StatusMapForm,
+  'statuspage':        StatusPageForm,
+  'incident-metrics':  IncidentMetricsForm,
+  'fetcher-health':    FetcherHealthForm,
+  'alert-audit':       AlertAuditForm,
 };

--- a/src/components/tiles/configs/index.tsx
+++ b/src/components/tiles/configs/index.tsx
@@ -168,8 +168,9 @@ const IncidentFeedForm: ConfigForm = ({ tile, onUpdate }) => {
   );
 };
 
-const ServiceGridForm: ConfigForm = ({ tile, onUpdate }) => {
+const ServiceGridForm: ConfigForm = ({ tile, live, onUpdate }) => {
   const filters = (tile.config.filters ?? {}) as { hideOperational?: boolean };
+  const selectedServices = (tile.config.services ?? []) as string[];
   return (
     <>
       {common(tile, onUpdate, { hideRefresh: true })}
@@ -185,6 +186,28 @@ const ServiceGridForm: ConfigForm = ({ tile, onUpdate }) => {
         >
           <i />
         </button>
+      </div>
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Services</span></div>
+        <div className="twk-chips" style={{ maxHeight: 120, overflowY: 'auto' }}>
+          {live.services.map((s) => {
+            const selected = selectedServices.includes(s.slug);
+            return (
+              <button
+                key={s.slug}
+                className={`chip ${selected ? 'chip-on' : ''}`}
+                onClick={() => {
+                  const next = selected
+                    ? selectedServices.filter((x) => x !== s.slug)
+                    : [...selectedServices, s.slug];
+                  update(tile, onUpdate, { services: next.length ? next : undefined });
+                }}
+              >
+                {s.name}
+              </button>
+            );
+          })}
+        </div>
       </div>
     </>
   );
@@ -229,6 +252,7 @@ const UptimeChartForm: ConfigForm = ({ tile, live, onUpdate }) => {
 
 const RssForm: ConfigForm = ({ tile, onUpdate }) => {
   const feed = (tile.config.feed as string) || 'aws-blog';
+  const customFeedUrl = (tile.config.customFeedUrl as string) || '';
   return (
     <>
       {common(tile, onUpdate, { hideRefresh: true })}
@@ -241,8 +265,21 @@ const RssForm: ConfigForm = ({ tile, onUpdate }) => {
         >
           <option value="aws-blog">AWS What&apos;s New</option>
           <option value="gh-blog">GitHub Engineering</option>
+          <option value="custom">Custom URL</option>
         </select>
       </div>
+      {feed === 'custom' && (
+        <div className="twk-row">
+          <div className="twk-lbl"><span>URL</span></div>
+          <input
+            type="url"
+            className="twk-field"
+            placeholder="https://example.com/feed.xml"
+            value={customFeedUrl}
+            onChange={(e) => update(tile, onUpdate, { customFeedUrl: e.target.value })}
+          />
+        </div>
+      )}
     </>
   );
 };

--- a/src/components/tiles/configs/index.tsx
+++ b/src/components/tiles/configs/index.tsx
@@ -112,7 +112,8 @@ const SEVERITIES = ['critical', 'major', 'minor'] as const;
 const STATUSES = ['investigating', 'identified', 'monitoring', 'resolved'] as const;
 
 const IncidentFeedForm: ConfigForm = ({ tile, onUpdate }) => {
-  const filters = (tile.config.filters ?? {}) as { severity?: string[]; statuses?: string[] };
+  const filters = (tile.config.filters ?? {}) as { severity?: string[]; statuses?: string[]; days?: number };
+  const days = filters.days ?? 7;
   const toggle = (key: 'severity' | 'statuses', value: string) => {
     const current = filters[key] ?? [];
     const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
@@ -121,6 +122,20 @@ const IncidentFeedForm: ConfigForm = ({ tile, onUpdate }) => {
   return (
     <>
       {common(tile, onUpdate)}
+      <div className="twk-row">
+        <div className="twk-lbl"><span>Window</span></div>
+        <div className="twk-seg">
+          {[7, 14, 30].map((d) => (
+            <button
+              key={d}
+              data-on={days === d}
+              onClick={() => update(tile, onUpdate, { filters: { ...filters, days: d } })}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+      </div>
       <div className="twk-row">
         <div className="twk-lbl"><span>Severity</span></div>
         <div className="twk-chips">

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -13,7 +13,10 @@ export type TileType =
   | 'rss'
   | 'uptime-chart'
   | 'status-map'
-  | 'statuspage';
+  | 'statuspage'
+  | 'incident-metrics'
+  | 'fetcher-health'
+  | 'alert-audit';
 
 export interface TileConfig {
   id: string;
@@ -276,34 +279,43 @@ export function useBoard({ bp = 'desktop', boardId, tiles, onCommit }: UseBoardP
 
   const addTile = useCallback((type: TileType, extraConfig: Record<string, unknown> = {}) => {
     const defaultConfigs: Record<TileType, Record<string, unknown>> = {
-      'stat':          { metric: 'uptime' },
-      'service-watch': { service: 'github' },
-      'service-grid':  {},
-      'incident-feed': {},
-      'rss':           { feed: 'aws-blog' },
-      'uptime-chart':  { service: 'github' },
-      'status-map':    {},
-      'statuspage':    { name: 'New Service', color: '#268bd2' },
+      'stat':              { metric: 'uptime' },
+      'service-watch':     { service: 'github' },
+      'service-grid':      {},
+      'incident-feed':     {},
+      'rss':               { feed: 'aws-blog' },
+      'uptime-chart':      { service: 'github' },
+      'status-map':        {},
+      'statuspage':        { name: 'New Service', color: '#268bd2' },
+      'incident-metrics':  { days: 30 },
+      'fetcher-health':    {},
+      'alert-audit':       {},
     };
     const defaultSizes: Record<TileType, { w: number; h: number }> = {
-      'stat':          { w: 1, h: 2 },
-      'service-watch': { w: 2, h: 2 },
-      'service-grid':  { w: 4, h: 2 },
-      'incident-feed': { w: 2, h: 3 },
-      'rss':           { w: 2, h: 2 },
-      'uptime-chart':  { w: 2, h: 2 },
-      'status-map':    { w: 2, h: 2 },
-      'statuspage':    { w: 2, h: 2 },
+      'stat':              { w: 1, h: 2 },
+      'service-watch':     { w: 2, h: 2 },
+      'service-grid':      { w: 4, h: 2 },
+      'incident-feed':     { w: 2, h: 3 },
+      'rss':               { w: 2, h: 2 },
+      'uptime-chart':      { w: 2, h: 2 },
+      'status-map':        { w: 2, h: 2 },
+      'statuspage':        { w: 2, h: 2 },
+      'incident-metrics':  { w: 2, h: 2 },
+      'fetcher-health':    { w: 2, h: 2 },
+      'alert-audit':       { w: 2, h: 2 },
     };
     const defaultDataPoints: Record<TileType, string[]> = {
-      'stat':          [],
-      'service-watch': ['sparkline', 'uptime', 'official', 'downdetector'],
-      'service-grid':  [],
-      'incident-feed': [],
-      'rss':           [],
-      'uptime-chart':  [],
-      'status-map':    [],
-      'statuspage':    [],
+      'stat':              [],
+      'service-watch':     ['sparkline', 'uptime', 'official', 'downdetector'],
+      'service-grid':      [],
+      'incident-feed':     [],
+      'rss':               [],
+      'uptime-chart':      [],
+      'status-map':        [],
+      'statuspage':        [],
+      'incident-metrics':  [],
+      'fetcher-health':    [],
+      'alert-audit':       [],
     };
     const id = 't' + Date.now();
     const size = defaultSizes[type];

--- a/src/hooks/usePreferences.ts
+++ b/src/hooks/usePreferences.ts
@@ -7,6 +7,7 @@ export interface Preferences {
   compactCards: boolean;
   showDowndetector: boolean;
   pinnedServices: string[];
+  slaTarget: number;
 }
 
 export const DEFAULT_PREFERENCES: Preferences = {
@@ -14,6 +15,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   compactCards: false,
   showDowndetector: true,
   pinnedServices: [],
+  slaTarget: 99.9,
 };
 
 export const PREFERENCES_STORAGE_KEY = 'outage-map-prefs';

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -1,7 +1,13 @@
 'use client';
 
 import useSWR from 'swr';
-import { ServiceStatusResponse, IncidentResponse, HistoryResponse } from '@/lib/types';
+import { ServiceStatusResponse, IncidentResponse, HistoryResponse, SummaryResponse } from '@/lib/types';
+
+interface RssFeedResponse {
+  feed: string;
+  title: string;
+  items: Array<{ title: string; url: string | null; publishedAt: string | null }>;
+}
 
 const fetcher = async (url: string) => {
   const res = await fetch(url);
@@ -39,6 +45,28 @@ export function useHistory(days: number = 30, refreshIntervalMs?: number) {
     {
       refreshInterval: refreshIntervalMs ?? 300000,
       revalidateOnFocus: true,
+    }
+  );
+}
+
+export function useSummary(refreshIntervalMs?: number) {
+  return useSWR<SummaryResponse>(
+    '/api/summary',
+    fetcher,
+    {
+      refreshInterval: refreshIntervalMs ?? 60000,
+      revalidateOnFocus: true,
+    }
+  );
+}
+
+export function useRssFeed(feedId: string, refreshIntervalMs?: number) {
+  return useSWR<RssFeedResponse>(
+    feedId ? `/api/rss?feed=${encodeURIComponent(feedId)}` : null,
+    fetcher,
+    {
+      refreshInterval: refreshIntervalMs ?? 300000,
+      revalidateOnFocus: false,
     }
   );
 }

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -60,13 +60,51 @@ export function useSummary(refreshIntervalMs?: number) {
   );
 }
 
-export function useRssFeed(feedId: string, refreshIntervalMs?: number) {
-  return useSWR<RssFeedResponse>(
-    feedId ? `/api/rss?feed=${encodeURIComponent(feedId)}` : null,
+export function useRssFeed(feedId: string, customUrl?: string, refreshIntervalMs?: number) {
+  const key = feedId === 'custom' && customUrl
+    ? `/api/rss?feed=custom&url=${encodeURIComponent(customUrl)}`
+    : feedId ? `/api/rss?feed=${encodeURIComponent(feedId)}` : null;
+  return useSWR<RssFeedResponse>(key, fetcher, {
+    refreshInterval: refreshIntervalMs ?? 300000,
+    revalidateOnFocus: false,
+  });
+}
+
+interface FetcherHealthEntry {
+  service: string;
+  source: string;
+  lastSuccessAt: string | null;
+  lastErrorAt: string | null;
+  lastError: string | null;
+  lastLatencyMs: number | null;
+  consecutiveFailures: number;
+}
+
+export function useFetcherHealth(refreshIntervalMs?: number) {
+  return useSWR<{ fetchers: FetcherHealthEntry[] }>(
+    '/api/health/fetchers',
     fetcher,
     {
-      refreshInterval: refreshIntervalMs ?? 300000,
-      revalidateOnFocus: false,
+      refreshInterval: refreshIntervalMs ?? 30000,
+      revalidateOnFocus: true,
     }
   );
 }
+
+interface AlertLogEntry {
+  id: number;
+  service_slug: string;
+  incident_id: string | null;
+  alert_type: string;
+  sent_at: string;
+}
+
+export function useAlertLog(enabled: boolean, refreshIntervalMs?: number) {
+  return useSWR<{ log: AlertLogEntry[] }>(
+    enabled ? '/api/alerts/log' : null,
+    fetcher,
+    { refreshInterval: refreshIntervalMs ?? 60000, revalidateOnFocus: false }
+  );
+}
+
+export type { FetcherHealthEntry, AlertLogEntry };

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -108,3 +108,21 @@ export function useAlertLog(enabled: boolean, refreshIntervalMs?: number) {
 }
 
 export type { FetcherHealthEntry, AlertLogEntry };
+
+export interface IncidentMetrics {
+  days: number;
+  mttrBySeverity: { critical?: number; major?: number; minor?: number };
+  resolutionRate: number;
+  totalIncidents: number;
+  resolvedIncidents: number;
+  countBySeverity: { critical?: number; major?: number; minor?: number };
+  topServices: { service_slug: string; count: number }[];
+}
+
+export function useIncidentMetrics(days = 30, refreshIntervalMs = 60000) {
+  return useSWR<IncidentMetrics>(
+    `/api/incidents/metrics?days=${days}`,
+    fetcher,
+    { refreshInterval: refreshIntervalMs, revalidateOnFocus: false }
+  );
+}

--- a/src/lib/alerts/rules.ts
+++ b/src/lib/alerts/rules.ts
@@ -24,24 +24,45 @@ export function rowToRule(row: AlertRuleRow): AlertRule {
     services: parseServices(row.services),
     minSeverity: asIncidentSeverity(row.min_severity),
     emailEnabled: row.email_enabled === 1,
+    webhookUrl: row.webhook_url ?? null,
+    webhookEnabled: row.webhook_enabled === 1,
     enabled: row.enabled === 1,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
 }
 
+function ruleMatchesIncident(rule: AlertRule, incident: IncidentResult): boolean {
+  if (SEVERITY_RANK[incident.severity] < SEVERITY_RANK[rule.minSeverity]) return false;
+  if (rule.services.length > 0 && !rule.services.includes(incident.serviceSlug)) return false;
+  return true;
+}
+
 /**
- * Returns the deduplicated list of email recipients whose enabled rules
- * match the given incident. Empty `services` on a rule means "all services".
+ * Returns deduplicated email recipients whose enabled rules match the incident.
+ * Empty `services` on a rule means "all services".
  */
 export function evaluateRulesForIncident(incident: IncidentResult): string[] {
   const rules = listEnabledAlertRules().map(rowToRule);
   const matched = new Set<string>();
   for (const rule of rules) {
     if (!rule.emailEnabled) continue;
-    if (SEVERITY_RANK[incident.severity] < SEVERITY_RANK[rule.minSeverity]) continue;
-    if (rule.services.length > 0 && !rule.services.includes(incident.serviceSlug)) continue;
+    if (!ruleMatchesIncident(rule, incident)) continue;
     if (rule.email) matched.add(rule.email);
+  }
+  return Array.from(matched);
+}
+
+/**
+ * Returns deduplicated webhook URLs whose enabled rules match the incident.
+ */
+export function evaluateRulesForWebhook(incident: IncidentResult): string[] {
+  const rules = listEnabledAlertRules().map(rowToRule);
+  const matched = new Set<string>();
+  for (const rule of rules) {
+    if (!rule.webhookEnabled || !rule.webhookUrl) continue;
+    if (!ruleMatchesIncident(rule, incident)) continue;
+    matched.add(rule.webhookUrl);
   }
   return Array.from(matched);
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -120,9 +120,18 @@ function initTables(db: Database.Database) {
   `);
 
   // Safe migration for pre-existing databases — add incident_count if missing.
-  const cols = db.prepare(`PRAGMA table_info(status_history)`).all() as Array<{ name: string }>;
-  if (!cols.some((c) => c.name === 'incident_count')) {
+  const historyCols = db.prepare(`PRAGMA table_info(status_history)`).all() as Array<{ name: string }>;
+  if (!historyCols.some((c) => c.name === 'incident_count')) {
     db.exec(`ALTER TABLE status_history ADD COLUMN incident_count INTEGER DEFAULT 0`);
+  }
+
+  // Safe migration — add webhook columns to alert_rules if missing.
+  const ruleCols = db.prepare(`PRAGMA table_info(alert_rules)`).all() as Array<{ name: string }>;
+  if (!ruleCols.some((c) => c.name === 'webhook_url')) {
+    db.exec(`ALTER TABLE alert_rules ADD COLUMN webhook_url TEXT`);
+  }
+  if (!ruleCols.some((c) => c.name === 'webhook_enabled')) {
+    db.exec(`ALTER TABLE alert_rules ADD COLUMN webhook_enabled INTEGER NOT NULL DEFAULT 0`);
   }
 }
 
@@ -218,26 +227,59 @@ export function getActiveIncidentCounts(): Record<string, number> {
   return out;
 }
 
+type IncidentRow = {
+  id: number;
+  service_slug: string;
+  incident_id: string;
+  title: string;
+  status: string;
+  severity: string;
+  started_at: string | null;
+  resolved_at: string | null;
+  description: string | null;
+  source_url: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
 export function getRecentIncidents(days: number = 7) {
   const db = getDb();
   return db.prepare(`
     SELECT * FROM incidents
     WHERE created_at >= datetime('now', '-' || ? || ' days')
     ORDER BY started_at DESC, created_at DESC
-  `).all(days) as Array<{
-    id: number;
-    service_slug: string;
-    incident_id: string;
-    title: string;
-    status: string;
-    severity: string;
-    started_at: string | null;
-    resolved_at: string | null;
-    description: string | null;
-    source_url: string | null;
-    created_at: string;
-    updated_at: string;
-  }>;
+  `).all(days) as IncidentRow[];
+}
+
+export function getPaginatedIncidents(opts: {
+  days?: number;
+  service?: string | null;
+  limit?: number;
+  offset?: number;
+  since?: string | null;
+}): { incidents: IncidentRow[]; total: number } {
+  const db = getDb();
+  const { days = 7, service = null, limit = 50, offset = 0, since = null } = opts;
+
+  const conditions: string[] = [`created_at >= datetime('now', '-' || ? || ' days')`];
+  const params: Array<string | number> = [days];
+
+  if (service) {
+    conditions.push('service_slug = ?');
+    params.push(service);
+  }
+  if (since) {
+    conditions.push('updated_at > ?');
+    params.push(since);
+  }
+
+  const where = `WHERE ${conditions.join(' AND ')}`;
+  const total = (db.prepare(`SELECT COUNT(*) as n FROM incidents ${where}`).get(...params) as { n: number }).n;
+  const incidents = db.prepare(
+    `SELECT * FROM incidents ${where} ORDER BY started_at DESC, created_at DESC LIMIT ? OFFSET ?`
+  ).all(...params, limit, offset) as IncidentRow[];
+
+  return { incidents, total };
 }
 
 export function getStatusHistory(serviceSlug: string | null, days: number = 30) {
@@ -318,26 +360,26 @@ export interface AlertRuleRow {
   services: string;
   min_severity: string;
   email_enabled: number;
+  webhook_url: string | null;
+  webhook_enabled: number;
   enabled: number;
   created_at: string;
   updated_at: string;
 }
 
+const RULE_COLS = 'id, email, services, min_severity, email_enabled, webhook_url, webhook_enabled, enabled, created_at, updated_at';
+
 export function listAlertRules(): AlertRuleRow[] {
   const db = getDb();
   return db.prepare(`
-    SELECT id, email, services, min_severity, email_enabled, enabled, created_at, updated_at
-    FROM alert_rules
-    ORDER BY created_at DESC
+    SELECT ${RULE_COLS} FROM alert_rules ORDER BY created_at DESC
   `).all() as AlertRuleRow[];
 }
 
 export function listEnabledAlertRules(): AlertRuleRow[] {
   const db = getDb();
   return db.prepare(`
-    SELECT id, email, services, min_severity, email_enabled, enabled, created_at, updated_at
-    FROM alert_rules
-    WHERE enabled = 1
+    SELECT ${RULE_COLS} FROM alert_rules WHERE enabled = 1
   `).all() as AlertRuleRow[];
 }
 
@@ -347,18 +389,22 @@ export function insertAlertRule(row: {
   services: string;
   minSeverity: string;
   emailEnabled: boolean;
+  webhookUrl?: string | null;
+  webhookEnabled?: boolean;
   enabled: boolean;
 }) {
   const db = getDb();
   db.prepare(`
-    INSERT INTO alert_rules (id, email, services, min_severity, email_enabled, enabled)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT INTO alert_rules (id, email, services, min_severity, email_enabled, webhook_url, webhook_enabled, enabled)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     row.id,
     row.email,
     row.services,
     row.minSeverity,
     row.emailEnabled ? 1 : 0,
+    row.webhookUrl ?? null,
+    row.webhookEnabled ? 1 : 0,
     row.enabled ? 1 : 0,
   );
 }
@@ -370,16 +416,20 @@ export function updateAlertRule(
     services: string;
     minSeverity: string;
     emailEnabled: boolean;
+    webhookUrl: string | null;
+    webhookEnabled: boolean;
     enabled: boolean;
   }>,
 ): boolean {
   const db = getDb();
   const fields: string[] = [];
-  const values: Array<string | number> = [];
+  const values: Array<string | number | null> = [];
   if (patch.email !== undefined) { fields.push('email = ?'); values.push(patch.email); }
   if (patch.services !== undefined) { fields.push('services = ?'); values.push(patch.services); }
   if (patch.minSeverity !== undefined) { fields.push('min_severity = ?'); values.push(patch.minSeverity); }
   if (patch.emailEnabled !== undefined) { fields.push('email_enabled = ?'); values.push(patch.emailEnabled ? 1 : 0); }
+  if (patch.webhookUrl !== undefined) { fields.push('webhook_url = ?'); values.push(patch.webhookUrl); }
+  if (patch.webhookEnabled !== undefined) { fields.push('webhook_enabled = ?'); values.push(patch.webhookEnabled ? 1 : 0); }
   if (patch.enabled !== undefined) { fields.push('enabled = ?'); values.push(patch.enabled ? 1 : 0); }
   if (fields.length === 0) return false;
   fields.push(`updated_at = datetime('now')`);

--- a/src/lib/fetchers/downdetector.ts
+++ b/src/lib/fetchers/downdetector.ts
@@ -13,18 +13,26 @@ function getRandomUA(): string {
   return USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)];
 }
 
-const THRESHOLD_DEGRADED = parseInt(process.env.DD_REPORT_THRESHOLD_DEGRADED || '100', 10);
-const THRESHOLD_MAJOR = parseInt(process.env.DD_REPORT_THRESHOLD_MAJOR || '500', 10);
+const ENV_THRESHOLD_DEGRADED = parseInt(process.env.DD_REPORT_THRESHOLD_DEGRADED || '100', 10);
+const ENV_THRESHOLD_MAJOR = parseInt(process.env.DD_REPORT_THRESHOLD_MAJOR || '500', 10);
 
-function reportCountToStatus(count: number): ServiceStatus {
-  if (count >= THRESHOLD_MAJOR) return 'major_outage';
-  if (count >= THRESHOLD_DEGRADED) return 'degraded';
+interface DdThresholds {
+  degraded?: number;
+  major?: number;
+}
+
+function reportCountToStatus(count: number, thresholds: DdThresholds): ServiceStatus {
+  const major = thresholds.major ?? ENV_THRESHOLD_MAJOR;
+  const degraded = thresholds.degraded ?? ENV_THRESHOLD_DEGRADED;
+  if (count >= major) return 'major_outage';
+  if (count >= degraded) return 'degraded';
   return 'operational';
 }
 
 export async function fetchDowndetectorStatus(
   slug: string | null,
-  serviceSlug: string
+  serviceSlug: string,
+  thresholds: DdThresholds = {},
 ): Promise<StatusResult> {
   const result: StatusResult = {
     serviceSlug,
@@ -96,22 +104,24 @@ export async function fetchDowndetectorStatus(
     // count up based on the word "problems" appearing somewhere in a class
     // matching [class*="status"] produced false positives in the past.
     const statusText = $('.entry-title, .main-title').first().text().toLowerCase();
+    const threshDegraded = thresholds.degraded ?? ENV_THRESHOLD_DEGRADED;
+    const threshMajor = thresholds.major ?? ENV_THRESHOLD_MAJOR;
     if (statusText.includes('no problems') || statusText.includes('no issues')) {
-      reportCount = Math.min(reportCount, THRESHOLD_DEGRADED - 1);
+      reportCount = Math.min(reportCount, threshDegraded - 1);
     }
 
     // Pattern 4: Check for warning/danger CSS classes
     const hasWarning = $('.text-warning, .warning, [class*="warning"]').length > 0;
     const hasDanger = $('.text-danger, .danger, [class*="danger"]').length > 0;
 
-    if (hasDanger && reportCount < THRESHOLD_MAJOR) {
-      reportCount = THRESHOLD_MAJOR;
-    } else if (hasWarning && reportCount < THRESHOLD_DEGRADED) {
-      reportCount = THRESHOLD_DEGRADED;
+    if (hasDanger && reportCount < threshMajor) {
+      reportCount = threshMajor;
+    } else if (hasWarning && reportCount < threshDegraded) {
+      reportCount = threshDegraded;
     }
 
     result.reportCount = reportCount;
-    result.status = reportCountToStatus(reportCount);
+    result.status = reportCountToStatus(reportCount, thresholds);
     result.details = `${reportCount} reports on Downdetector`;
   } catch (err) {
     console.error(`[downdetector] Failed to fetch ${slug}:`, err);

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -10,7 +10,8 @@ import {
   vacuumDb,
 } from './db';
 import { sendIncidentAlert, sendStatusChangeAlert } from './email';
-import { evaluateRulesForIncident } from './alerts/rules';
+import { evaluateRulesForIncident, evaluateRulesForWebhook } from './alerts/rules';
+import { sendWebhookAlerts } from './webhook';
 import { metrics } from './metrics';
 import { health, HealthSource } from './health';
 import { circuit } from './fetchers/circuit';
@@ -161,7 +162,10 @@ async function pollService(service: ServiceConfig): Promise<{ ddReports: number 
     timedFetch<StatusResult>(
       service.slug,
       'downdetector',
-      () => fetchDowndetectorStatus(service.downdetectorSlug, service.slug),
+      () => fetchDowndetectorStatus(service.downdetectorSlug, service.slug, {
+        degraded: service.ddThresholdDegraded,
+        major: service.ddThresholdMajor,
+      }),
       (r) => ({ status: r.status, details: r.details }),
       (reason) => unknownStatusResult(service.slug, reason),
     ),
@@ -201,7 +205,11 @@ async function pollService(service: ServiceConfig): Promise<{ ddReports: number 
       // env-only deployments keep working.
       if (isNew && (incident.severity === 'major' || incident.severity === 'critical')) {
         const ruleRecipients = evaluateRulesForIncident(incident);
-        await sendIncidentAlert(incident, ruleRecipients);
+        const webhookUrls = evaluateRulesForWebhook(incident);
+        await Promise.all([
+          sendIncidentAlert(incident, ruleRecipients),
+          sendWebhookAlerts(incident, webhookUrls),
+        ]);
       }
     }
 

--- a/src/lib/statusUtils.ts
+++ b/src/lib/statusUtils.ts
@@ -1,0 +1,16 @@
+import { ServiceStatus } from './types';
+
+export function deriveOverallStatus(
+  official: ServiceStatus,
+  downdetector: ServiceStatus,
+  officialIncidentCount: number,
+): ServiceStatus {
+  if (official === 'down' || official === 'major_outage') return official;
+  if ((downdetector === 'down' || downdetector === 'major_outage') && officialIncidentCount > 0) {
+    return 'major_outage';
+  }
+  if (official === 'degraded' || downdetector === 'degraded') return 'degraded';
+  if (official === 'operational') return 'operational';
+  if (official === 'unknown' && downdetector !== 'unknown') return downdetector;
+  return official;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,8 @@ export interface ServiceConfig {
   downdetectorSlug: string | null;
   fetcher: FetcherType;
   brandFont: string;
+  ddThresholdDegraded?: number;
+  ddThresholdMajor?: number;
 }
 
 export interface StatusResult {
@@ -87,9 +89,23 @@ export interface AlertRule {
   services: string[];
   minSeverity: IncidentSeverity;
   emailEnabled: boolean;
+  webhookUrl: string | null;
+  webhookEnabled: boolean;
   enabled: boolean;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface SummaryResponse {
+  totalServices: number;
+  operational: number;
+  degraded: number;
+  majorOutage: number;
+  down: number;
+  unknown: number;
+  activeIncidents: number;
+  uptimePct: number;
+  lastUpdated: string;
 }
 
 const INCIDENT_STATUSES: ReadonlyArray<IncidentStatus> = [

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -1,0 +1,101 @@
+import { httpFetch } from './fetchers/httpFetch';
+import { hasRecentAlert, logAlert } from './db';
+import { getServiceBySlug } from './services';
+import { IncidentResult } from './types';
+import { metrics } from './metrics';
+
+// Block SSRF attempts: reject URLs that resolve to RFC-1918 / loopback ranges.
+const PRIVATE_IP_RE = /^(https?:\/\/)(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/i;
+
+export function isValidWebhookUrl(url: string): boolean {
+  if (!/^https?:\/\//i.test(url)) return false;
+  if (PRIVATE_IP_RE.test(url)) return false;
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface WebhookPayload {
+  text: string;
+  attachments: Array<{
+    color: string;
+    title: string;
+    fields: Array<{ title: string; value: string; short: boolean }>;
+  }>;
+  incident: {
+    service: string;
+    title: string;
+    severity: string;
+    status: string;
+    startedAt: string | null;
+    sourceUrl: string | null;
+  };
+}
+
+function buildPayload(incident: IncidentResult, serviceName: string): WebhookPayload {
+  const color = incident.severity === 'critical' ? '#dc2626' : '#f59e0b';
+  return {
+    text: `[${incident.severity.toUpperCase()}] ${serviceName}: ${incident.title}`,
+    attachments: [
+      {
+        color,
+        title: `${serviceName} — ${incident.title}`,
+        fields: [
+          { title: 'Severity', value: incident.severity, short: true },
+          { title: 'Status', value: incident.status, short: true },
+          { title: 'Started', value: incident.startedAt || 'Unknown', short: true },
+          ...(incident.sourceUrl ? [{ title: 'Source', value: incident.sourceUrl, short: false }] : []),
+        ],
+      },
+    ],
+    incident: {
+      service: incident.serviceSlug,
+      title: incident.title,
+      severity: incident.severity,
+      status: incident.status,
+      startedAt: incident.startedAt,
+      sourceUrl: incident.sourceUrl,
+    },
+  };
+}
+
+export async function sendWebhookAlert(url: string, payload: WebhookPayload): Promise<boolean> {
+  try {
+    const res = await httpFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      timeoutMs: 10000,
+      maxRetries: 1,
+    });
+    return res.ok || res.status < 500;
+  } catch (err) {
+    console.error(`[webhook] POST to ${url} failed:`, err);
+    return false;
+  }
+}
+
+export async function sendWebhookAlerts(
+  incident: IncidentResult,
+  webhookUrls: string[],
+): Promise<void> {
+  if (webhookUrls.length === 0) return;
+  if (hasRecentAlert(incident.serviceSlug, incident.incidentId, 'webhook_incident')) return;
+
+  const service = getServiceBySlug(incident.serviceSlug);
+  const serviceName = service?.name || incident.serviceSlug;
+  const payload = buildPayload(incident, serviceName);
+
+  const results = await Promise.allSettled(
+    webhookUrls.map((url) => sendWebhookAlert(url, payload)),
+  );
+
+  const anyOk = results.some((r) => r.status === 'fulfilled' && r.value);
+  if (anyOk) {
+    logAlert(incident.serviceSlug, incident.incidentId, 'webhook_incident');
+    metrics.recordAlertSent('webhook', incident.severity);
+  }
+}


### PR DESCRIPTION
## Summary

Four phases of improvements building on the existing Outage-Map infrastructure — no architectural changes, only new surfaces for already-collected data.

### Phase 1 — Backend layer
- `GET /api/summary` aggregated fleet stats
- ETag caching on `GET /api/status`
- Incident pagination support
- Real RSS feed parsing
- Webhook notification backend
- Per-service Downdetector thresholds

### Phase 2 — Frontend wiring
- AlertsView webhook UI
- BoardStatTile real MTTR
- StatusMapTile live heat signal
- IncidentFeedTile configurable time window
- AnalyticsView date range + CSV export
- ServiceDetailView date range selector

### Phase 3 — 12 new features
- **Header**: live summary health bar via `useSummary()` (active incidents, uptime %)
- **SourcesView**: fetcher health column (latency ms, failure count, last-seen)
- **AlertsView**: inline rule editing (PATCH endpoint was implemented, UI was missing) + collapsible alert delivery log
- **ServiceGridForm**: service multi-select filter chips in tile config
- **RssFeedTile**: custom RSS URL support with SSRF validation
- **SettingsView**: SLA target % preference (persisted to localStorage)
- **AnalyticsView**: incident severity breakdown stacked bar chart (critical/major/minor)
- **ServiceDetailView**: incident status/severity filters + newest/oldest sort
- **OutageMapView**: hotspot threshold range slider (replaces hardcoded 50%)
- **ServiceWatchTile**: stability indicator ("Stable 30d" / "Issue 3d ago")
- **ServiceGridTile**: status count summary bar (N down · N degraded)
- **BoardStatTile**: SLA compliance metric option

### Phase 4 — 10 more enhancements
- **New tile: Incident Metrics** — MTTR by severity + resolution rate with 7/30/90d selector; backed by new `GET /api/incidents/metrics` endpoint
- **New tile: Fetcher Health** — per-source latency, consecutive failure count, last-success timestamp
- **New tile: Alert History** — last 50 alert delivery events with type-colored timeline
- **IncidentFeedTile**: incidents now grouped by day (Today / Yesterday / date)
- **BoardStatTile**: added SLA compliance as a selectable metric
- **AnalyticsView**: top-5 services by incident count ranking panel
- **ServiceDetailView**: CSV export button for the filtered incidents list
- **SourcesView**: inline source editing (name, color, refresh interval) via PATCH endpoint
- **`useRssFeed`**: extended to accept custom URL for custom feed tiles
- **`useIncidentMetrics`**: new SWR hook wired to the new metrics endpoint

## Test plan
- [ ] Header shows active incident count (amber) and uptime % when summary data loads
- [ ] SourcesView rows show latency badge and red failure pill for unhealthy fetchers
- [ ] AlertsView: click pencil on a rule → inline form; save PATCHes and collapses
- [ ] Alert history panel shows entries after sending a test alert
- [ ] ServiceGrid tile config: service chips filter the displayed services
- [ ] Custom RSS URL in tile config fetches and displays a real external feed
- [ ] SLA target in Settings updates Analytics compliance badges reactively
- [ ] Analytics incident severity chart appears when services have incidents
- [ ] ServiceDetailView: status/severity filters and sort work correctly; CSV download works
- [ ] OutageMapView hotspot slider updates the hotspot count stat tile
- [ ] ServiceWatchTile shows stability text from history data
- [ ] ServiceGridTile shows colored status count badge
- [ ] Add "Incident Metrics" tile → shows MTTR bars + resolution rate ring
- [ ] Add "Fetcher Health" tile → shows per-source rows with latency/failure data
- [ ] Add "Alert History" tile → shows colored timeline of sent alerts
- [ ] IncidentFeedTile renders day group headers (Today, Yesterday, etc.)

https://claude.ai/code/session_0154e7rVfttkzsix225RTKMM