### PR TITLE
Fix CI build: rules-of-hooks and cheerio type errors

### DIFF
--- a/src/app/api/rss/route.ts
+++ b/src/app/api/rss/route.ts
@@ -33,7 +33,7 @@ function parseRss(xml: string): { title: string; items: RssItem[] } {
 
   const items: RssItem[] = [];
   // Support both RSS <item> and Atom <entry>
-  $('item, entry').each((_: number, el: cheerio.AnyNode) => {
+  $('item, entry').each((_, el) => {
     const title = $(el).find('title').first().text().trim();
     const link =
       $(el).find('link').attr('href') ||

--- a/src/components/tiles/ServiceWatchTile.tsx
+++ b/src/components/tiles/ServiceWatchTile.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import TileChrome from './TileChrome';
 import Sparkline from '../Sparkline';
 import { getStatusColor, historyToSparkline } from '@/lib/boardColors';
@@ -125,22 +124,21 @@ export default function ServiceWatchTile({
       ? ((hist.filter((p) => p.status === 'operational').length / hist.length) * 100).toFixed(2)
       : '—';
 
-  const stabilityText = useMemo(() => {
-    if (!hist.length) return null;
-    const reversed = [...hist].reverse();
-    const idx = reversed.findIndex((p) => p.status !== 'operational' || p.outageMinutes > 0);
-    if (idx === -1) return `Stable ${hist.length}d`;
-    if (idx === 0) return 'Issue today';
-    return `Last issue ${idx}d ago`;
-  }, [hist]);
+  const lastIssueIdx = hist.length
+    ? [...hist].reverse().findIndex((p) => p.status !== 'operational' || p.outageMinutes > 0)
+    : -1;
 
-  const stabilityColor = useMemo(() => {
-    if (!hist.length) return 'var(--muted)';
-    const reversed = [...hist].reverse();
-    const idx = reversed.findIndex((p) => p.status !== 'operational' || p.outageMinutes > 0);
-    if (idx === -1 || idx > 3) return 'var(--muted)';
-    return idx === 0 ? '#EF5350' : '#FFD54F';
-  }, [hist]);
+  let stabilityText: string | null = null;
+  if (hist.length) {
+    if (lastIssueIdx === -1) stabilityText = `Stable ${hist.length}d`;
+    else if (lastIssueIdx === 0) stabilityText = 'Issue today';
+    else stabilityText = `Last issue ${lastIssueIdx}d ago`;
+  }
+
+  let stabilityColor = 'var(--muted)';
+  if (hist.length && lastIssueIdx !== -1 && lastIssueIdx <= 3) {
+    stabilityColor = lastIssueIdx === 0 ? '#EF5350' : '#FFD54F';
+  }
 
   return (
     <TileChrome


### PR DESCRIPTION
## Summary

The `Build and publish Docker image` workflow has been failing on `main` since #39 merged. `next build` fails at the lint/type-check phase with two unrelated errors:

- `src/components/tiles/ServiceWatchTile.tsx` calls `useMemo` after an early `return` when no service is found, violating the Rules of Hooks (build-blocking error).
- `src/app/api/rss/route.ts` annotates an `each()` callback parameter as `cheerio.AnyNode`, but cheerio re-exports `AnyNode` as a type from `domhandler` and does not expose it under the `cheerio` namespace.

## Changes

- **ServiceWatchTile**: drop `useMemo` for `stabilityText` / `stabilityColor` and compute inline. The values are single-pass array scans on a 30-day history, so memoization isn't worth the hook-ordering hazard. Also drops the related `react-hooks/exhaustive-deps` warnings about the `hist` logical expression.
- **rss route**: drop the explicit type annotations on the `.each` callback — cheerio's typings already infer them correctly.

## Test plan

- [x] `npm run build` completes locally with no errors
- [ ] Docker image build succeeds in CI on both `linux/amd64` and `linux/arm64`

https://claude.ai/code/session_01KCHCetvi3zhUqhVojanntF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCHCetvi3zhUqhVojanntF)_